### PR TITLE
Changes, New glyphs, etc.

### DIFF
--- a/Cozette/Cozette.sfd
+++ b/Cozette/Cozette.sfd
@@ -22,7 +22,7 @@ OS2Version: 1
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: -2082812035
-ModificationTime: 1668729664
+ModificationTime: 1670097305
 PfmFamily: 49
 TTFWeight: 500
 TTFWidth: 5
@@ -119,14 +119,14 @@ NameList: AGL with PUA
 DisplaySize: 13
 AntiAlias: 1
 FitToEm: 0
-WinInfo: 62400 32 17
+WinInfo: 62836 46 14
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 524288 262144 174762 0 -1048576 174762 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 1114112 2872
+BeginChars: 1114112 2920
 
-StartChar: .notdef
-Encoding: 0 -1 0
+StartChar: uni0000
+Encoding: 0 0 0
 AltUni2: 000000.ffffffff.0
 Width: 1024
 Flags: W
@@ -579,7 +579,7 @@ EndChar
 StartChar: two
 Encoding: 50 50 50
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
 Fore
 Validated: 1
@@ -1202,8 +1202,6 @@ Encoding: 119 119 119
 Width: 1024
 Flags: W
 LayerCount: 2
-Fore
-Validated: 1
 EndChar
 
 StartChar: x
@@ -1751,6 +1749,8 @@ Encoding: 212 212 180
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Otilde
@@ -1758,6 +1758,8 @@ Encoding: 213 213 181
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Odieresis
@@ -1765,6 +1767,8 @@ Encoding: 214 214 182
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: multiply
@@ -1772,6 +1776,8 @@ Encoding: 215 215 183
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Oslash
@@ -1779,6 +1785,8 @@ Encoding: 216 216 184
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ugrave
@@ -1786,6 +1794,8 @@ Encoding: 217 217 185
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Uacute
@@ -1793,6 +1803,8 @@ Encoding: 218 218 186
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ucircumflex
@@ -1800,6 +1812,8 @@ Encoding: 219 219 187
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Udieresis
@@ -1807,6 +1821,8 @@ Encoding: 220 220 188
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Yacute
@@ -1814,6 +1830,8 @@ Encoding: 221 221 189
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Thorn
@@ -1821,6 +1839,8 @@ Encoding: 222 222 190
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: germandbls
@@ -1828,6 +1848,8 @@ Encoding: 223 223 191
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: agrave
@@ -1835,6 +1857,8 @@ Encoding: 224 224 192
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: aacute
@@ -1842,6 +1866,8 @@ Encoding: 225 225 193
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: acircumflex
@@ -1849,6 +1875,8 @@ Encoding: 226 226 194
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: atilde
@@ -1856,6 +1884,8 @@ Encoding: 227 227 195
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: adieresis
@@ -1863,6 +1893,8 @@ Encoding: 228 228 196
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: aring
@@ -1870,6 +1902,8 @@ Encoding: 229 229 197
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ae
@@ -1877,6 +1911,8 @@ Encoding: 230 230 198
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ccedilla
@@ -1884,6 +1920,8 @@ Encoding: 231 231 199
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: egrave
@@ -1891,6 +1929,8 @@ Encoding: 232 232 200
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: eacute
@@ -1898,6 +1938,8 @@ Encoding: 233 233 201
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ecircumflex
@@ -1905,6 +1947,8 @@ Encoding: 234 234 202
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: edieresis
@@ -1912,6 +1956,8 @@ Encoding: 235 235 203
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: igrave
@@ -1919,6 +1965,8 @@ Encoding: 236 236 204
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: iacute
@@ -1926,6 +1974,8 @@ Encoding: 237 237 205
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: icircumflex
@@ -1933,6 +1983,8 @@ Encoding: 238 238 206
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: idieresis
@@ -1940,6 +1992,8 @@ Encoding: 239 239 207
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: eth
@@ -1947,6 +2001,8 @@ Encoding: 240 240 208
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ntilde
@@ -1954,6 +2010,8 @@ Encoding: 241 241 209
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ograve
@@ -1961,6 +2019,8 @@ Encoding: 242 242 210
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: oacute
@@ -1968,6 +2028,8 @@ Encoding: 243 243 211
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ocircumflex
@@ -1975,6 +2037,8 @@ Encoding: 244 244 212
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: otilde
@@ -1982,6 +2046,8 @@ Encoding: 245 245 213
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: odieresis
@@ -1989,6 +2055,8 @@ Encoding: 246 246 214
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: divide
@@ -1996,6 +2064,8 @@ Encoding: 247 247 215
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: oslash
@@ -2003,6 +2073,8 @@ Encoding: 248 248 216
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ugrave
@@ -2010,6 +2082,8 @@ Encoding: 249 249 217
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uacute
@@ -2017,6 +2091,8 @@ Encoding: 250 250 218
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ucircumflex
@@ -2024,6 +2100,8 @@ Encoding: 251 251 219
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: udieresis
@@ -2031,6 +2109,8 @@ Encoding: 252 252 220
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: yacute
@@ -2038,6 +2118,8 @@ Encoding: 253 253 221
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: thorn
@@ -2045,6 +2127,8 @@ Encoding: 254 254 222
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ydieresis
@@ -2052,6 +2136,8 @@ Encoding: 255 255 223
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Amacron
@@ -2059,6 +2145,8 @@ Encoding: 256 256 224
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: amacron
@@ -2066,6 +2154,8 @@ Encoding: 257 257 225
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Abreve
@@ -2073,6 +2163,8 @@ Encoding: 258 258 226
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: abreve
@@ -2080,6 +2172,8 @@ Encoding: 259 259 227
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Aogonek
@@ -2087,6 +2181,8 @@ Encoding: 260 260 228
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: aogonek
@@ -2094,6 +2190,8 @@ Encoding: 261 261 229
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Cacute
@@ -2101,6 +2199,8 @@ Encoding: 262 262 230
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: cacute
@@ -2108,6 +2208,8 @@ Encoding: 263 263 231
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ccircumflex
@@ -2115,6 +2217,8 @@ Encoding: 264 264 232
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ccircumflex
@@ -2122,6 +2226,8 @@ Encoding: 265 265 233
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Cdotaccent
@@ -2129,6 +2235,8 @@ Encoding: 266 266 234
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: cdotaccent
@@ -2136,6 +2244,8 @@ Encoding: 267 267 235
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ccaron
@@ -2143,6 +2253,8 @@ Encoding: 268 268 236
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ccaron
@@ -2150,6 +2262,8 @@ Encoding: 269 269 237
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Dcaron
@@ -2157,6 +2271,8 @@ Encoding: 270 270 238
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dcaron
@@ -2164,6 +2280,8 @@ Encoding: 271 271 239
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Dcroat
@@ -2171,6 +2289,8 @@ Encoding: 272 272 240
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dcroat
@@ -2178,6 +2298,8 @@ Encoding: 273 273 241
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Emacron
@@ -2185,6 +2307,8 @@ Encoding: 274 274 242
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: emacron
@@ -2192,6 +2316,8 @@ Encoding: 275 275 243
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ebreve
@@ -2199,6 +2325,8 @@ Encoding: 276 276 244
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ebreve
@@ -2206,6 +2334,8 @@ Encoding: 277 277 245
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Edotaccent
@@ -2213,6 +2343,8 @@ Encoding: 278 278 246
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: edotaccent
@@ -2220,6 +2352,8 @@ Encoding: 279 279 247
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Eogonek
@@ -2227,6 +2361,8 @@ Encoding: 280 280 248
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: eogonek
@@ -2234,6 +2370,8 @@ Encoding: 281 281 249
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ecaron
@@ -2241,6 +2379,8 @@ Encoding: 282 282 250
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ecaron
@@ -2248,6 +2388,8 @@ Encoding: 283 283 251
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Gcircumflex
@@ -2255,6 +2397,8 @@ Encoding: 284 284 252
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gcircumflex
@@ -2262,6 +2406,8 @@ Encoding: 285 285 253
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Gbreve
@@ -2269,6 +2415,8 @@ Encoding: 286 286 254
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gbreve
@@ -2276,6 +2424,8 @@ Encoding: 287 287 255
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Gdotaccent
@@ -2283,6 +2433,8 @@ Encoding: 288 288 256
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gdotaccent
@@ -2290,6 +2442,8 @@ Encoding: 289 289 257
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Gcommaaccent
@@ -2297,6 +2451,8 @@ Encoding: 290 290 258
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gcommaaccent
@@ -2304,6 +2460,8 @@ Encoding: 291 291 259
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Hcircumflex
@@ -2311,6 +2469,8 @@ Encoding: 292 292 260
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: hcircumflex
@@ -2318,6 +2478,8 @@ Encoding: 293 293 261
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Hbar
@@ -2325,6 +2487,8 @@ Encoding: 294 294 262
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: hbar
@@ -2332,6 +2496,8 @@ Encoding: 295 295 263
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Itilde
@@ -2339,6 +2505,8 @@ Encoding: 296 296 264
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: itilde
@@ -2346,6 +2514,8 @@ Encoding: 297 297 265
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Imacron
@@ -2353,6 +2523,8 @@ Encoding: 298 298 266
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: imacron
@@ -2360,6 +2532,8 @@ Encoding: 299 299 267
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ibreve
@@ -2367,6 +2541,8 @@ Encoding: 300 300 268
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ibreve
@@ -2374,6 +2550,8 @@ Encoding: 301 301 269
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Iogonek
@@ -2381,6 +2559,8 @@ Encoding: 302 302 270
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: iogonek
@@ -2388,6 +2568,8 @@ Encoding: 303 303 271
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Idotaccent
@@ -2395,6 +2577,8 @@ Encoding: 304 304 272
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dotlessi
@@ -2402,6 +2586,8 @@ Encoding: 305 305 273
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: IJ
@@ -2409,6 +2595,8 @@ Encoding: 306 306 274
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ij
@@ -2416,6 +2604,8 @@ Encoding: 307 307 275
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Jcircumflex
@@ -2423,6 +2613,8 @@ Encoding: 308 308 276
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: jcircumflex
@@ -2430,6 +2622,8 @@ Encoding: 309 309 277
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Kcommaaccent
@@ -2437,6 +2631,8 @@ Encoding: 310 310 278
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: kcommaaccent
@@ -2444,6 +2640,8 @@ Encoding: 311 311 279
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: kgreenlandic
@@ -2451,6 +2649,8 @@ Encoding: 312 312 280
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Lacute
@@ -2458,6 +2658,8 @@ Encoding: 313 313 281
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lacute
@@ -2465,6 +2667,8 @@ Encoding: 314 314 282
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Lcommaaccent
@@ -2472,6 +2676,8 @@ Encoding: 315 315 283
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lcommaaccent
@@ -2479,6 +2685,8 @@ Encoding: 316 316 284
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Lcaron
@@ -2486,6 +2694,8 @@ Encoding: 317 317 285
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lcaron
@@ -2493,6 +2703,8 @@ Encoding: 318 318 286
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ldot
@@ -2500,6 +2712,8 @@ Encoding: 319 319 287
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ldot
@@ -2507,6 +2721,8 @@ Encoding: 320 320 288
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Lslash
@@ -2514,6 +2730,8 @@ Encoding: 321 321 289
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lslash
@@ -2521,6 +2739,8 @@ Encoding: 322 322 290
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Nacute
@@ -2528,6 +2748,8 @@ Encoding: 323 323 291
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: nacute
@@ -2535,6 +2757,8 @@ Encoding: 324 324 292
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ncommaaccent
@@ -2542,6 +2766,8 @@ Encoding: 325 325 293
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ncommaaccent
@@ -2549,6 +2775,8 @@ Encoding: 326 326 294
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ncaron
@@ -2556,6 +2784,8 @@ Encoding: 327 327 295
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ncaron
@@ -2563,6 +2793,8 @@ Encoding: 328 328 296
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: napostrophe
@@ -2570,6 +2802,8 @@ Encoding: 329 329 297
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Eng
@@ -2577,6 +2811,8 @@ Encoding: 330 330 298
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: eng
@@ -2584,6 +2820,8 @@ Encoding: 331 331 299
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Omacron
@@ -2591,6 +2829,8 @@ Encoding: 332 332 300
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: omacron
@@ -2598,6 +2838,8 @@ Encoding: 333 333 301
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Obreve
@@ -2605,6 +2847,8 @@ Encoding: 334 334 302
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: obreve
@@ -2612,6 +2856,8 @@ Encoding: 335 335 303
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ohungarumlaut
@@ -2619,6 +2865,8 @@ Encoding: 336 336 304
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ohungarumlaut
@@ -2626,6 +2874,8 @@ Encoding: 337 337 305
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: OE
@@ -2633,6 +2883,8 @@ Encoding: 338 338 306
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: oe
@@ -2640,6 +2892,8 @@ Encoding: 339 339 307
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Racute
@@ -2647,6 +2901,8 @@ Encoding: 340 340 308
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: racute
@@ -2654,6 +2910,8 @@ Encoding: 341 341 309
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Rcommaaccent
@@ -2661,6 +2919,8 @@ Encoding: 342 342 310
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: rcommaaccent
@@ -2668,6 +2928,8 @@ Encoding: 343 343 311
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Rcaron
@@ -2675,6 +2937,8 @@ Encoding: 344 344 312
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: rcaron
@@ -2682,6 +2946,8 @@ Encoding: 345 345 313
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Sacute
@@ -2689,6 +2955,8 @@ Encoding: 346 346 314
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: sacute
@@ -2696,6 +2964,8 @@ Encoding: 347 347 315
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Scircumflex
@@ -2703,6 +2973,8 @@ Encoding: 348 348 316
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: scircumflex
@@ -2710,6 +2982,8 @@ Encoding: 349 349 317
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Scedilla
@@ -2717,6 +2991,8 @@ Encoding: 350 350 318
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: scedilla
@@ -2724,6 +3000,8 @@ Encoding: 351 351 319
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Scaron
@@ -2731,6 +3009,8 @@ Encoding: 352 352 320
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: scaron
@@ -2738,6 +3018,8 @@ Encoding: 353 353 321
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Tcommaaccent
@@ -2745,6 +3027,8 @@ Encoding: 354 354 322
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: tcommaaccent
@@ -2752,6 +3036,8 @@ Encoding: 355 355 323
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Tcaron
@@ -2759,6 +3045,8 @@ Encoding: 356 356 324
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: tcaron
@@ -2766,6 +3054,8 @@ Encoding: 357 357 325
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Utilde
@@ -2773,6 +3063,8 @@ Encoding: 360 360 326
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: utilde
@@ -2780,6 +3072,8 @@ Encoding: 361 361 327
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Umacron
@@ -2787,6 +3081,8 @@ Encoding: 362 362 328
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: umacron
@@ -2794,6 +3090,8 @@ Encoding: 363 363 329
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ubreve
@@ -2801,6 +3099,8 @@ Encoding: 364 364 330
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ubreve
@@ -2808,6 +3108,8 @@ Encoding: 365 365 331
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Uring
@@ -2815,6 +3117,8 @@ Encoding: 366 366 332
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uring
@@ -2822,6 +3126,8 @@ Encoding: 367 367 333
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Uhungarumlaut
@@ -2829,6 +3135,8 @@ Encoding: 368 368 334
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uhungarumlaut
@@ -2836,6 +3144,8 @@ Encoding: 369 369 335
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ydieresis
@@ -2843,6 +3153,8 @@ Encoding: 376 376 336
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Zacute
@@ -2850,6 +3162,8 @@ Encoding: 377 377 337
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: zacute
@@ -2857,6 +3171,8 @@ Encoding: 378 378 338
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Zdotaccent
@@ -2864,6 +3180,8 @@ Encoding: 379 379 339
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: zdotaccent
@@ -2871,6 +3189,8 @@ Encoding: 380 380 340
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Zcaron
@@ -2878,6 +3198,8 @@ Encoding: 381 381 341
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: zcaron
@@ -2885,6 +3207,8 @@ Encoding: 382 382 342
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: florin
@@ -2892,6 +3216,8 @@ Encoding: 402 402 343
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01C3
@@ -2899,6 +3225,8 @@ Encoding: 451 451 344
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0246
@@ -2906,6 +3234,8 @@ Encoding: 582 582 345
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0247
@@ -2913,6 +3243,8 @@ Encoding: 583 583 346
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: circumflex
@@ -2920,6 +3252,8 @@ Encoding: 710 710 347
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: tilde
@@ -2927,6 +3261,8 @@ Encoding: 732 732 348
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Alpha
@@ -2934,6 +3270,8 @@ Encoding: 913 913 349
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Beta
@@ -2941,6 +3279,8 @@ Encoding: 914 914 350
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Gamma
@@ -2948,6 +3288,8 @@ Encoding: 915 915 351
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0394
@@ -2955,6 +3297,8 @@ Encoding: 916 916 352
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Epsilon
@@ -2962,6 +3306,8 @@ Encoding: 917 917 353
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Zeta
@@ -2969,13 +3315,17 @@ Encoding: 918 918 354
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Eta
 Encoding: 919 919 355
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Theta
@@ -2983,6 +3333,8 @@ Encoding: 920 920 356
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Iota
@@ -2990,6 +3342,8 @@ Encoding: 921 921 357
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Kappa
@@ -2997,6 +3351,8 @@ Encoding: 922 922 358
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Lambda
@@ -3004,6 +3360,8 @@ Encoding: 923 923 359
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Mu
@@ -3011,6 +3369,8 @@ Encoding: 924 924 360
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Nu
@@ -3018,6 +3378,8 @@ Encoding: 925 925 361
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Xi
@@ -3025,6 +3387,8 @@ Encoding: 926 926 362
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Omicron
@@ -3032,6 +3396,8 @@ Encoding: 927 927 363
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Pi
@@ -3039,6 +3405,8 @@ Encoding: 928 928 364
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Rho
@@ -3046,6 +3414,8 @@ Encoding: 929 929 365
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Sigma
@@ -3053,6 +3423,8 @@ Encoding: 931 931 366
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Tau
@@ -3060,6 +3432,8 @@ Encoding: 932 932 367
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Upsilon
@@ -3067,6 +3441,8 @@ Encoding: 933 933 368
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Phi
@@ -3074,6 +3450,8 @@ Encoding: 934 934 369
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Chi
@@ -3081,6 +3459,8 @@ Encoding: 935 935 370
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Psi
@@ -3088,6 +3468,8 @@ Encoding: 936 936 371
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03A9
@@ -3095,6 +3477,8 @@ Encoding: 937 937 372
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Iotadieresis
@@ -3102,6 +3486,8 @@ Encoding: 938 938 373
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Upsilondieresis
@@ -3109,6 +3495,8 @@ Encoding: 939 939 374
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: alphatonos
@@ -3116,6 +3504,8 @@ Encoding: 940 940 375
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: alpha
@@ -3123,6 +3513,8 @@ Encoding: 945 945 376
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: beta
@@ -3130,6 +3522,8 @@ Encoding: 946 946 377
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gamma
@@ -3137,6 +3531,8 @@ Encoding: 947 947 378
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: delta
@@ -3144,6 +3540,8 @@ Encoding: 948 948 379
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: epsilon
@@ -3151,6 +3549,8 @@ Encoding: 949 949 380
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: zeta
@@ -3158,6 +3558,8 @@ Encoding: 950 950 381
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: eta
@@ -3165,6 +3567,8 @@ Encoding: 951 951 382
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: theta
@@ -3172,6 +3576,8 @@ Encoding: 952 952 383
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: iota
@@ -3179,6 +3585,8 @@ Encoding: 953 953 384
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: kappa
@@ -3186,6 +3594,8 @@ Encoding: 954 954 385
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lambda
@@ -3193,6 +3603,8 @@ Encoding: 955 955 386
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03BC
@@ -3200,6 +3612,8 @@ Encoding: 956 956 387
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: nu
@@ -3207,6 +3621,8 @@ Encoding: 957 957 388
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: xi
@@ -3214,6 +3630,8 @@ Encoding: 958 958 389
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: omicron
@@ -3221,6 +3639,8 @@ Encoding: 959 959 390
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: pi
@@ -3228,6 +3648,8 @@ Encoding: 960 960 391
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: rho
@@ -3235,6 +3657,8 @@ Encoding: 961 961 392
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: sigma1
@@ -3242,6 +3666,8 @@ Encoding: 962 962 393
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: sigma
@@ -3249,6 +3675,8 @@ Encoding: 963 963 394
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: tau
@@ -3256,6 +3684,8 @@ Encoding: 964 964 395
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: upsilon
@@ -3263,6 +3693,8 @@ Encoding: 965 965 396
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: phi
@@ -3270,6 +3702,8 @@ Encoding: 966 966 397
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: chi
@@ -3277,6 +3711,8 @@ Encoding: 967 967 398
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: psi
@@ -3284,6 +3720,8 @@ Encoding: 968 968 399
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: omega
@@ -3291,6 +3729,8 @@ Encoding: 969 969 400
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E9E
@@ -3298,6 +3738,8 @@ Encoding: 7838 7838 401
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2010
@@ -3305,6 +3747,8 @@ Encoding: 8208 8208 402
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2011
@@ -3312,6 +3756,8 @@ Encoding: 8209 8209 403
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: figuredash
@@ -3319,6 +3765,8 @@ Encoding: 8210 8210 404
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: endash
@@ -3326,6 +3774,8 @@ Encoding: 8211 8211 405
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: emdash
@@ -3333,6 +3783,8 @@ Encoding: 8212 8212 406
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii00208
@@ -3340,6 +3792,8 @@ Encoding: 8213 8213 407
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2016
@@ -3347,6 +3801,8 @@ Encoding: 8214 8214 408
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: underscoredbl
@@ -3354,6 +3810,8 @@ Encoding: 8215 8215 409
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quoteleft
@@ -3361,6 +3819,8 @@ Encoding: 8216 8216 410
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quoteright
@@ -3368,6 +3828,8 @@ Encoding: 8217 8217 411
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quotesinglbase
@@ -3375,6 +3837,8 @@ Encoding: 8218 8218 412
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quotereversed
@@ -3382,6 +3846,8 @@ Encoding: 8219 8219 413
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quotedblleft
@@ -3389,6 +3855,8 @@ Encoding: 8220 8220 414
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quotedblright
@@ -3396,6 +3864,8 @@ Encoding: 8221 8221 415
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: quotedblbase
@@ -3403,6 +3873,8 @@ Encoding: 8222 8222 416
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni201F
@@ -3410,6 +3882,8 @@ Encoding: 8223 8223 417
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dagger
@@ -3417,6 +3891,8 @@ Encoding: 8224 8224 418
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: daggerdbl
@@ -3424,6 +3900,8 @@ Encoding: 8225 8225 419
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: bullet
@@ -3431,6 +3909,8 @@ Encoding: 8226 8226 420
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2023
@@ -3438,6 +3918,8 @@ Encoding: 8227 8227 421
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: onedotenleader
@@ -3445,6 +3927,8 @@ Encoding: 8228 8228 422
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: twodotenleader
@@ -3452,6 +3936,8 @@ Encoding: 8229 8229 423
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ellipsis
@@ -3459,6 +3945,8 @@ Encoding: 8230 8230 424
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2027
@@ -3466,6 +3954,8 @@ Encoding: 8231 8231 425
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: perthousand
@@ -3473,6 +3963,8 @@ Encoding: 8240 8240 426
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: minute
@@ -3480,6 +3972,8 @@ Encoding: 8242 8242 427
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: second
@@ -3487,6 +3981,8 @@ Encoding: 8243 8243 428
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2034
@@ -3494,6 +3990,8 @@ Encoding: 8244 8244 429
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2035
@@ -3501,6 +3999,8 @@ Encoding: 8245 8245 430
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2036
@@ -3508,6 +4008,8 @@ Encoding: 8246 8246 431
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2037
@@ -3515,6 +4017,8 @@ Encoding: 8247 8247 432
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2038
@@ -3522,6 +4026,8 @@ Encoding: 8248 8248 433
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: guilsinglleft
@@ -3529,6 +4035,8 @@ Encoding: 8249 8249 434
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: guilsinglright
@@ -3536,6 +4044,8 @@ Encoding: 8250 8250 435
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Euro
@@ -3543,6 +4053,8 @@ Encoding: 8364 8364 436
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: trademark
@@ -3550,6 +4062,8 @@ Encoding: 8482 8482 437
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowleft
@@ -3557,6 +4071,8 @@ Encoding: 8592 8592 438
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowup
@@ -3564,6 +4080,8 @@ Encoding: 8593 8593 439
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowright
@@ -3571,6 +4089,8 @@ Encoding: 8594 8594 440
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowdown
@@ -3578,6 +4098,8 @@ Encoding: 8595 8595 441
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowboth
@@ -3585,6 +4107,8 @@ Encoding: 8596 8596 442
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowupdn
@@ -3592,6 +4116,8 @@ Encoding: 8597 8597 443
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2196
@@ -3599,6 +4125,8 @@ Encoding: 8598 8598 444
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2197
@@ -3606,6 +4134,8 @@ Encoding: 8599 8599 445
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2198
@@ -3613,6 +4143,8 @@ Encoding: 8600 8600 446
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2199
@@ -3620,6 +4152,8 @@ Encoding: 8601 8601 447
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni219A
@@ -3627,6 +4161,8 @@ Encoding: 8602 8602 448
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni219B
@@ -3634,6 +4170,8 @@ Encoding: 8603 8603 449
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowdblleft
@@ -3641,6 +4179,8 @@ Encoding: 8656 8656 450
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowdblup
@@ -3648,6 +4188,8 @@ Encoding: 8657 8657 451
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowdblright
@@ -3655,6 +4197,8 @@ Encoding: 8658 8658 452
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowdbldown
@@ -3662,6 +4206,8 @@ Encoding: 8659 8659 453
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: arrowdblboth
@@ -3669,6 +4215,8 @@ Encoding: 8660 8660 454
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21D5
@@ -3676,6 +4224,8 @@ Encoding: 8661 8661 455
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: universal
@@ -3683,6 +4233,8 @@ Encoding: 8704 8704 456
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: existential
@@ -3690,6 +4242,8 @@ Encoding: 8707 8707 457
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2204
@@ -3697,6 +4251,8 @@ Encoding: 8708 8708 458
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: emptyset
@@ -3704,6 +4260,8 @@ Encoding: 8709 8709 459
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Delta
@@ -3711,6 +4269,8 @@ Encoding: 8710 8710 460
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gradient
@@ -3718,6 +4278,8 @@ Encoding: 8711 8711 461
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: element
@@ -3725,6 +4287,8 @@ Encoding: 8712 8712 462
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: notelement
@@ -3732,6 +4296,8 @@ Encoding: 8713 8713 463
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni220A
@@ -3739,6 +4305,8 @@ Encoding: 8714 8714 464
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: suchthat
@@ -3746,6 +4314,8 @@ Encoding: 8715 8715 465
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni220C
@@ -3753,6 +4323,8 @@ Encoding: 8716 8716 466
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni220D
@@ -3760,6 +4332,8 @@ Encoding: 8717 8717 467
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni220E
@@ -3767,6 +4341,8 @@ Encoding: 8718 8718 468
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: product
@@ -3774,6 +4350,8 @@ Encoding: 8719 8719 469
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2210
@@ -3781,6 +4359,8 @@ Encoding: 8720 8720 470
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: asteriskmath
@@ -3788,6 +4368,8 @@ Encoding: 8727 8727 471
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2218
@@ -3795,6 +4377,8 @@ Encoding: 8728 8728 472
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2219
@@ -3802,6 +4386,8 @@ Encoding: 8729 8729 473
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: notequal
@@ -3809,6 +4395,8 @@ Encoding: 8800 8800 474
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lessequal
@@ -3816,6 +4404,8 @@ Encoding: 8804 8804 475
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: greaterequal
@@ -3823,6 +4413,8 @@ Encoding: 8805 8805 476
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni229E
@@ -3830,6 +4422,8 @@ Encoding: 8862 8862 477
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni229F
@@ -3837,6 +4431,8 @@ Encoding: 8863 8863 478
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F4
@@ -3844,6 +4440,8 @@ Encoding: 9204 9204 479
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F5
@@ -3851,6 +4449,8 @@ Encoding: 9205 9205 480
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F6
@@ -3858,6 +4458,8 @@ Encoding: 9206 9206 481
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F7
@@ -3865,6 +4467,8 @@ Encoding: 9207 9207 482
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F8
@@ -3872,6 +4476,8 @@ Encoding: 9208 9208 483
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F9
@@ -3879,6 +4485,8 @@ Encoding: 9209 9209 484
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23FA
@@ -3886,6 +4494,8 @@ Encoding: 9210 9210 485
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23FB
@@ -3893,6 +4503,8 @@ Encoding: 9211 9211 486
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23FC
@@ -3900,6 +4512,8 @@ Encoding: 9212 9212 487
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF100000
@@ -3907,6 +4521,8 @@ Encoding: 9472 9472 488
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2501
@@ -3914,6 +4530,8 @@ Encoding: 9473 9473 489
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF110000
@@ -3921,6 +4539,8 @@ Encoding: 9474 9474 490
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2503
@@ -3928,6 +4548,8 @@ Encoding: 9475 9475 491
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2504
@@ -3935,6 +4557,8 @@ Encoding: 9476 9476 492
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2505
@@ -3942,6 +4566,8 @@ Encoding: 9477 9477 493
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2506
@@ -3949,6 +4575,8 @@ Encoding: 9478 9478 494
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2507
@@ -3956,6 +4584,8 @@ Encoding: 9479 9479 495
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2508
@@ -3963,6 +4593,8 @@ Encoding: 9480 9480 496
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2509
@@ -3970,6 +4602,8 @@ Encoding: 9481 9481 497
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni250A
@@ -3977,6 +4611,8 @@ Encoding: 9482 9482 498
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni250B
@@ -3984,6 +4620,8 @@ Encoding: 9483 9483 499
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF010000
@@ -3991,6 +4629,8 @@ Encoding: 9484 9484 500
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni250D
@@ -3998,6 +4638,8 @@ Encoding: 9485 9485 501
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni250E
@@ -4005,6 +4647,8 @@ Encoding: 9486 9486 502
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni250F
@@ -4012,6 +4656,8 @@ Encoding: 9487 9487 503
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF030000
@@ -4019,6 +4665,8 @@ Encoding: 9488 9488 504
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2511
@@ -4026,6 +4674,8 @@ Encoding: 9489 9489 505
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2512
@@ -4033,6 +4683,8 @@ Encoding: 9490 9490 506
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2513
@@ -4040,6 +4692,8 @@ Encoding: 9491 9491 507
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF020000
@@ -4047,6 +4701,8 @@ Encoding: 9492 9492 508
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2515
@@ -4054,6 +4710,8 @@ Encoding: 9493 9493 509
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2516
@@ -4061,6 +4719,8 @@ Encoding: 9494 9494 510
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2517
@@ -4068,6 +4728,8 @@ Encoding: 9495 9495 511
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF040000
@@ -4075,6 +4737,8 @@ Encoding: 9496 9496 512
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2519
@@ -4082,6 +4746,8 @@ Encoding: 9497 9497 513
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni251A
@@ -4089,6 +4755,8 @@ Encoding: 9498 9498 514
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni251B
@@ -4096,6 +4764,8 @@ Encoding: 9499 9499 515
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF080000
@@ -4103,6 +4773,8 @@ Encoding: 9500 9500 516
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni251D
@@ -4110,6 +4782,8 @@ Encoding: 9501 9501 517
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni251E
@@ -4117,6 +4791,8 @@ Encoding: 9502 9502 518
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni251F
@@ -4124,6 +4800,8 @@ Encoding: 9503 9503 519
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2520
@@ -4131,6 +4809,8 @@ Encoding: 9504 9504 520
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2521
@@ -4138,6 +4818,8 @@ Encoding: 9505 9505 521
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2522
@@ -4145,6 +4827,8 @@ Encoding: 9506 9506 522
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2523
@@ -4152,6 +4836,8 @@ Encoding: 9507 9507 523
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF090000
@@ -4159,6 +4845,8 @@ Encoding: 9508 9508 524
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2525
@@ -4166,6 +4854,8 @@ Encoding: 9509 9509 525
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2526
@@ -4173,6 +4863,8 @@ Encoding: 9510 9510 526
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2527
@@ -4180,6 +4872,8 @@ Encoding: 9511 9511 527
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2528
@@ -4187,6 +4881,8 @@ Encoding: 9512 9512 528
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2529
@@ -4194,6 +4890,8 @@ Encoding: 9513 9513 529
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni252A
@@ -4201,6 +4899,8 @@ Encoding: 9514 9514 530
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni252B
@@ -4208,6 +4908,8 @@ Encoding: 9515 9515 531
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF060000
@@ -4215,6 +4917,8 @@ Encoding: 9516 9516 532
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni252D
@@ -4222,6 +4926,8 @@ Encoding: 9517 9517 533
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni252E
@@ -4229,6 +4935,8 @@ Encoding: 9518 9518 534
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni252F
@@ -4236,6 +4944,8 @@ Encoding: 9519 9519 535
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2530
@@ -4243,6 +4953,8 @@ Encoding: 9520 9520 536
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2531
@@ -4250,6 +4962,8 @@ Encoding: 9521 9521 537
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2532
@@ -4257,6 +4971,8 @@ Encoding: 9522 9522 538
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2533
@@ -4264,6 +4980,8 @@ Encoding: 9523 9523 539
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF070000
@@ -4271,6 +4989,8 @@ Encoding: 9524 9524 540
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2535
@@ -4278,6 +4998,8 @@ Encoding: 9525 9525 541
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2536
@@ -4285,6 +5007,8 @@ Encoding: 9526 9526 542
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2537
@@ -4292,6 +5016,8 @@ Encoding: 9527 9527 543
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2538
@@ -4299,6 +5025,8 @@ Encoding: 9528 9528 544
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2539
@@ -4306,6 +5034,8 @@ Encoding: 9529 9529 545
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni253A
@@ -4313,6 +5043,8 @@ Encoding: 9530 9530 546
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni253B
@@ -4320,6 +5052,8 @@ Encoding: 9531 9531 547
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF050000
@@ -4327,6 +5061,8 @@ Encoding: 9532 9532 548
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni253D
@@ -4334,6 +5070,8 @@ Encoding: 9533 9533 549
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni253E
@@ -4341,6 +5079,8 @@ Encoding: 9534 9534 550
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni253F
@@ -4348,6 +5088,8 @@ Encoding: 9535 9535 551
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2540
@@ -4355,6 +5097,8 @@ Encoding: 9536 9536 552
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2541
@@ -4362,6 +5106,8 @@ Encoding: 9537 9537 553
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2542
@@ -4369,6 +5115,8 @@ Encoding: 9538 9538 554
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2543
@@ -4376,6 +5124,8 @@ Encoding: 9539 9539 555
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2544
@@ -4383,6 +5133,8 @@ Encoding: 9540 9540 556
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2545
@@ -4390,6 +5142,8 @@ Encoding: 9541 9541 557
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2546
@@ -4397,6 +5151,8 @@ Encoding: 9542 9542 558
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2547
@@ -4404,6 +5160,8 @@ Encoding: 9543 9543 559
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2548
@@ -4411,6 +5169,8 @@ Encoding: 9544 9544 560
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2549
@@ -4418,6 +5178,8 @@ Encoding: 9545 9545 561
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni254A
@@ -4425,6 +5187,8 @@ Encoding: 9546 9546 562
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni254B
@@ -4432,6 +5196,8 @@ Encoding: 9547 9547 563
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni254C
@@ -4439,6 +5205,8 @@ Encoding: 9548 9548 564
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni254D
@@ -4446,6 +5214,8 @@ Encoding: 9549 9549 565
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni254E
@@ -4453,6 +5223,8 @@ Encoding: 9550 9550 566
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni254F
@@ -4460,6 +5232,8 @@ Encoding: 9551 9551 567
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF430000
@@ -4467,6 +5241,8 @@ Encoding: 9552 9552 568
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF240000
@@ -4474,6 +5250,8 @@ Encoding: 9553 9553 569
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF510000
@@ -4481,6 +5259,8 @@ Encoding: 9554 9554 570
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF520000
@@ -4488,6 +5268,8 @@ Encoding: 9555 9555 571
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF390000
@@ -4495,6 +5277,8 @@ Encoding: 9556 9556 572
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF220000
@@ -4502,6 +5286,8 @@ Encoding: 9557 9557 573
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF210000
@@ -4509,6 +5295,8 @@ Encoding: 9558 9558 574
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF250000
@@ -4516,6 +5304,8 @@ Encoding: 9559 9559 575
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF500000
@@ -4523,6 +5313,8 @@ Encoding: 9560 9560 576
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF490000
@@ -4530,6 +5322,8 @@ Encoding: 9561 9561 577
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF380000
@@ -4537,6 +5331,8 @@ Encoding: 9562 9562 578
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF280000
@@ -4544,6 +5340,8 @@ Encoding: 9563 9563 579
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF270000
@@ -4551,6 +5349,8 @@ Encoding: 9564 9564 580
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF260000
@@ -4558,6 +5358,8 @@ Encoding: 9565 9565 581
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF360000
@@ -4565,6 +5367,8 @@ Encoding: 9566 9566 582
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF370000
@@ -4572,6 +5376,8 @@ Encoding: 9567 9567 583
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF420000
@@ -4579,6 +5385,8 @@ Encoding: 9568 9568 584
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF190000
@@ -4586,6 +5394,8 @@ Encoding: 9569 9569 585
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF200000
@@ -4593,6 +5403,8 @@ Encoding: 9570 9570 586
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF230000
@@ -4600,6 +5412,8 @@ Encoding: 9571 9571 587
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF470000
@@ -4607,6 +5421,8 @@ Encoding: 9572 9572 588
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF480000
@@ -4614,6 +5430,8 @@ Encoding: 9573 9573 589
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF410000
@@ -4621,6 +5439,8 @@ Encoding: 9574 9574 590
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF450000
@@ -4628,6 +5448,8 @@ Encoding: 9575 9575 591
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF460000
@@ -4635,6 +5457,8 @@ Encoding: 9576 9576 592
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF400000
@@ -4642,6 +5466,8 @@ Encoding: 9577 9577 593
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF540000
@@ -4649,6 +5475,8 @@ Encoding: 9578 9578 594
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF530000
@@ -4656,6 +5484,8 @@ Encoding: 9579 9579 595
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: SF440000
@@ -4663,6 +5493,8 @@ Encoding: 9580 9580 596
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni256D
@@ -4670,6 +5502,8 @@ Encoding: 9581 9581 597
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni256E
@@ -4677,6 +5511,8 @@ Encoding: 9582 9582 598
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni256F
@@ -4684,6 +5520,8 @@ Encoding: 9583 9583 599
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2570
@@ -4691,6 +5529,8 @@ Encoding: 9584 9584 600
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2571
@@ -4698,6 +5538,8 @@ Encoding: 9585 9585 601
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2572
@@ -4705,6 +5547,8 @@ Encoding: 9586 9586 602
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2573
@@ -4712,6 +5556,8 @@ Encoding: 9587 9587 603
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2574
@@ -4719,6 +5565,8 @@ Encoding: 9588 9588 604
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2575
@@ -4726,6 +5574,8 @@ Encoding: 9589 9589 605
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2576
@@ -4733,6 +5583,8 @@ Encoding: 9590 9590 606
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2577
@@ -4740,6 +5592,8 @@ Encoding: 9591 9591 607
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2578
@@ -4747,6 +5601,8 @@ Encoding: 9592 9592 608
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2579
@@ -4754,6 +5610,8 @@ Encoding: 9593 9593 609
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni257A
@@ -4761,6 +5619,8 @@ Encoding: 9594 9594 610
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni257B
@@ -4768,6 +5628,8 @@ Encoding: 9595 9595 611
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni257C
@@ -4775,6 +5637,8 @@ Encoding: 9596 9596 612
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni257D
@@ -4782,6 +5646,8 @@ Encoding: 9597 9597 613
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni257E
@@ -4789,6 +5655,8 @@ Encoding: 9598 9598 614
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni257F
@@ -4796,6 +5664,8 @@ Encoding: 9599 9599 615
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: upblock
@@ -4803,6 +5673,8 @@ Encoding: 9600 9600 616
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2581
@@ -4810,6 +5682,8 @@ Encoding: 9601 9601 617
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2582
@@ -4817,6 +5691,8 @@ Encoding: 9602 9602 618
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2583
@@ -4824,6 +5700,8 @@ Encoding: 9603 9603 619
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dnblock
@@ -4831,6 +5709,8 @@ Encoding: 9604 9604 620
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2585
@@ -4838,6 +5718,8 @@ Encoding: 9605 9605 621
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2586
@@ -4845,6 +5727,8 @@ Encoding: 9606 9606 622
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2587
@@ -4852,6 +5736,8 @@ Encoding: 9607 9607 623
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: block
@@ -4859,6 +5745,8 @@ Encoding: 9608 9608 624
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2589
@@ -4866,6 +5754,8 @@ Encoding: 9609 9609 625
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni258A
@@ -4873,6 +5763,8 @@ Encoding: 9610 9610 626
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni258B
@@ -4880,6 +5772,8 @@ Encoding: 9611 9611 627
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lfblock
@@ -4887,6 +5781,8 @@ Encoding: 9612 9612 628
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni258D
@@ -4894,6 +5790,8 @@ Encoding: 9613 9613 629
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni258E
@@ -4901,6 +5799,8 @@ Encoding: 9614 9614 630
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni258F
@@ -4908,6 +5808,8 @@ Encoding: 9615 9615 631
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: rtblock
@@ -4915,6 +5817,8 @@ Encoding: 9616 9616 632
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ltshade
@@ -4922,6 +5826,8 @@ Encoding: 9617 9617 633
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: shade
@@ -4929,6 +5835,8 @@ Encoding: 9618 9618 634
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dkshade
@@ -4936,6 +5844,8 @@ Encoding: 9619 9619 635
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: H18533
@@ -4943,6 +5853,8 @@ Encoding: 9679 9679 636
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: spade
@@ -4950,6 +5862,8 @@ Encoding: 9824 9824 637
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2661
@@ -4957,6 +5871,8 @@ Encoding: 9825 9825 638
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2662
@@ -4964,6 +5880,8 @@ Encoding: 9826 9826 639
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: club
@@ -4971,6 +5889,8 @@ Encoding: 9827 9827 640
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2664
@@ -4978,6 +5898,8 @@ Encoding: 9828 9828 641
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: heart
@@ -4985,6 +5907,8 @@ Encoding: 9829 9829 642
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: diamond
@@ -4992,6 +5916,8 @@ Encoding: 9830 9830 643
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2667
@@ -4999,6 +5925,8 @@ Encoding: 9831 9831 644
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni26A1
@@ -5006,6 +5934,8 @@ Encoding: 9889 9889 645
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2713
@@ -5013,6 +5943,8 @@ Encoding: 10003 10003 646
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2714
@@ -5020,6 +5952,8 @@ Encoding: 10004 10004 647
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2715
@@ -5027,6 +5961,8 @@ Encoding: 10005 10005 648
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2716
@@ -5034,6 +5970,8 @@ Encoding: 10006 10006 649
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2717
@@ -5041,6 +5979,8 @@ Encoding: 10007 10007 650
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2718
@@ -5048,6 +5988,8 @@ Encoding: 10008 10008 651
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2719
@@ -5055,6 +5997,8 @@ Encoding: 10009 10009 652
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni271A
@@ -5062,6 +6006,8 @@ Encoding: 10010 10010 653
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni271B
@@ -5069,6 +6015,8 @@ Encoding: 10011 10011 654
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni271C
@@ -5076,6 +6024,8 @@ Encoding: 10012 10012 655
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni272E
@@ -5083,6 +6033,8 @@ Encoding: 10030 10030 656
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2801
@@ -5090,6 +6042,8 @@ Encoding: 10241 10241 657
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2802
@@ -5097,6 +6051,8 @@ Encoding: 10242 10242 658
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2803
@@ -5104,6 +6060,8 @@ Encoding: 10243 10243 659
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2804
@@ -5111,6 +6069,8 @@ Encoding: 10244 10244 660
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2805
@@ -5118,6 +6078,8 @@ Encoding: 10245 10245 661
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2806
@@ -5125,6 +6087,8 @@ Encoding: 10246 10246 662
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2807
@@ -5132,6 +6096,8 @@ Encoding: 10247 10247 663
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2808
@@ -5139,6 +6105,8 @@ Encoding: 10248 10248 664
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2809
@@ -5146,6 +6114,8 @@ Encoding: 10249 10249 665
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni280A
@@ -5153,6 +6123,8 @@ Encoding: 10250 10250 666
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni280B
@@ -5160,6 +6132,8 @@ Encoding: 10251 10251 667
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni280C
@@ -5167,6 +6141,8 @@ Encoding: 10252 10252 668
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni280D
@@ -5174,6 +6150,8 @@ Encoding: 10253 10253 669
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni280E
@@ -5181,6 +6159,8 @@ Encoding: 10254 10254 670
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni280F
@@ -5188,6 +6168,8 @@ Encoding: 10255 10255 671
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2810
@@ -5195,6 +6177,8 @@ Encoding: 10256 10256 672
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2811
@@ -5202,6 +6186,8 @@ Encoding: 10257 10257 673
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2812
@@ -5209,6 +6195,8 @@ Encoding: 10258 10258 674
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2813
@@ -5216,6 +6204,8 @@ Encoding: 10259 10259 675
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2814
@@ -5223,6 +6213,8 @@ Encoding: 10260 10260 676
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2815
@@ -5230,6 +6222,8 @@ Encoding: 10261 10261 677
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2816
@@ -5237,6 +6231,8 @@ Encoding: 10262 10262 678
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2817
@@ -5244,6 +6240,8 @@ Encoding: 10263 10263 679
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2818
@@ -5251,6 +6249,8 @@ Encoding: 10264 10264 680
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2819
@@ -5258,6 +6258,8 @@ Encoding: 10265 10265 681
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni281A
@@ -5265,6 +6267,8 @@ Encoding: 10266 10266 682
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni281B
@@ -5272,6 +6276,8 @@ Encoding: 10267 10267 683
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni281C
@@ -5279,6 +6285,8 @@ Encoding: 10268 10268 684
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni281D
@@ -5286,6 +6294,8 @@ Encoding: 10269 10269 685
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni281E
@@ -5293,6 +6303,8 @@ Encoding: 10270 10270 686
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni281F
@@ -5300,6 +6312,8 @@ Encoding: 10271 10271 687
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2820
@@ -5307,6 +6321,8 @@ Encoding: 10272 10272 688
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2821
@@ -5314,6 +6330,8 @@ Encoding: 10273 10273 689
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2822
@@ -5321,6 +6339,8 @@ Encoding: 10274 10274 690
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2823
@@ -5328,6 +6348,8 @@ Encoding: 10275 10275 691
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2824
@@ -5335,6 +6357,8 @@ Encoding: 10276 10276 692
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2825
@@ -5342,6 +6366,8 @@ Encoding: 10277 10277 693
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2826
@@ -5349,6 +6375,8 @@ Encoding: 10278 10278 694
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2827
@@ -5356,6 +6384,8 @@ Encoding: 10279 10279 695
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2828
@@ -5363,6 +6393,8 @@ Encoding: 10280 10280 696
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2829
@@ -5370,6 +6402,8 @@ Encoding: 10281 10281 697
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni282A
@@ -5377,6 +6411,8 @@ Encoding: 10282 10282 698
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni282B
@@ -5384,6 +6420,8 @@ Encoding: 10283 10283 699
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni282C
@@ -5391,6 +6429,8 @@ Encoding: 10284 10284 700
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni282D
@@ -5398,6 +6438,8 @@ Encoding: 10285 10285 701
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni282E
@@ -5405,6 +6447,8 @@ Encoding: 10286 10286 702
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni282F
@@ -5412,6 +6456,8 @@ Encoding: 10287 10287 703
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2830
@@ -5419,6 +6465,8 @@ Encoding: 10288 10288 704
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2831
@@ -5426,6 +6474,8 @@ Encoding: 10289 10289 705
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2832
@@ -5433,6 +6483,8 @@ Encoding: 10290 10290 706
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2833
@@ -5440,6 +6492,8 @@ Encoding: 10291 10291 707
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2834
@@ -5447,6 +6501,8 @@ Encoding: 10292 10292 708
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2835
@@ -5454,6 +6510,8 @@ Encoding: 10293 10293 709
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2836
@@ -5461,6 +6519,8 @@ Encoding: 10294 10294 710
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2837
@@ -5468,6 +6528,8 @@ Encoding: 10295 10295 711
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2838
@@ -5475,6 +6537,8 @@ Encoding: 10296 10296 712
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2839
@@ -5482,6 +6546,8 @@ Encoding: 10297 10297 713
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni283A
@@ -5489,6 +6555,8 @@ Encoding: 10298 10298 714
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni283B
@@ -5496,6 +6564,8 @@ Encoding: 10299 10299 715
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni283C
@@ -5503,6 +6573,8 @@ Encoding: 10300 10300 716
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni283D
@@ -5510,6 +6582,8 @@ Encoding: 10301 10301 717
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni283E
@@ -5517,6 +6591,8 @@ Encoding: 10302 10302 718
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni283F
@@ -5524,6 +6600,8 @@ Encoding: 10303 10303 719
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2840
@@ -5531,6 +6609,8 @@ Encoding: 10304 10304 720
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2841
@@ -5538,6 +6618,8 @@ Encoding: 10305 10305 721
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2842
@@ -5545,6 +6627,8 @@ Encoding: 10306 10306 722
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2843
@@ -5552,6 +6636,8 @@ Encoding: 10307 10307 723
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2844
@@ -5559,6 +6645,8 @@ Encoding: 10308 10308 724
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2845
@@ -5566,6 +6654,8 @@ Encoding: 10309 10309 725
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2846
@@ -5573,6 +6663,8 @@ Encoding: 10310 10310 726
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2847
@@ -5580,6 +6672,8 @@ Encoding: 10311 10311 727
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2848
@@ -5587,6 +6681,8 @@ Encoding: 10312 10312 728
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2849
@@ -5594,6 +6690,8 @@ Encoding: 10313 10313 729
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni284A
@@ -5601,6 +6699,8 @@ Encoding: 10314 10314 730
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni284B
@@ -5608,6 +6708,8 @@ Encoding: 10315 10315 731
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni284C
@@ -5615,6 +6717,8 @@ Encoding: 10316 10316 732
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni284D
@@ -5622,6 +6726,8 @@ Encoding: 10317 10317 733
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni284E
@@ -5629,6 +6735,8 @@ Encoding: 10318 10318 734
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni284F
@@ -5636,6 +6744,8 @@ Encoding: 10319 10319 735
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2850
@@ -5643,6 +6753,8 @@ Encoding: 10320 10320 736
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2851
@@ -5650,6 +6762,8 @@ Encoding: 10321 10321 737
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2852
@@ -5657,6 +6771,8 @@ Encoding: 10322 10322 738
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2853
@@ -5664,6 +6780,8 @@ Encoding: 10323 10323 739
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2854
@@ -5671,6 +6789,8 @@ Encoding: 10324 10324 740
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2855
@@ -5678,6 +6798,8 @@ Encoding: 10325 10325 741
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2856
@@ -5685,6 +6807,8 @@ Encoding: 10326 10326 742
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2857
@@ -5692,6 +6816,8 @@ Encoding: 10327 10327 743
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2858
@@ -5699,6 +6825,8 @@ Encoding: 10328 10328 744
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2859
@@ -5706,6 +6834,8 @@ Encoding: 10329 10329 745
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni285A
@@ -5713,6 +6843,8 @@ Encoding: 10330 10330 746
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni285B
@@ -5720,6 +6852,8 @@ Encoding: 10331 10331 747
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni285C
@@ -5727,6 +6861,8 @@ Encoding: 10332 10332 748
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni285D
@@ -5734,6 +6870,8 @@ Encoding: 10333 10333 749
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni285E
@@ -5741,6 +6879,8 @@ Encoding: 10334 10334 750
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni285F
@@ -5748,6 +6888,8 @@ Encoding: 10335 10335 751
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2860
@@ -5755,6 +6897,8 @@ Encoding: 10336 10336 752
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2861
@@ -5762,6 +6906,8 @@ Encoding: 10337 10337 753
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2862
@@ -5769,6 +6915,8 @@ Encoding: 10338 10338 754
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2863
@@ -5776,6 +6924,8 @@ Encoding: 10339 10339 755
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2864
@@ -5783,6 +6933,8 @@ Encoding: 10340 10340 756
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2865
@@ -5790,6 +6942,8 @@ Encoding: 10341 10341 757
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2866
@@ -5797,6 +6951,8 @@ Encoding: 10342 10342 758
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2867
@@ -5804,6 +6960,8 @@ Encoding: 10343 10343 759
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2868
@@ -5811,6 +6969,8 @@ Encoding: 10344 10344 760
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2869
@@ -5818,6 +6978,8 @@ Encoding: 10345 10345 761
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni286A
@@ -5825,6 +6987,8 @@ Encoding: 10346 10346 762
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni286B
@@ -5832,6 +6996,8 @@ Encoding: 10347 10347 763
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni286C
@@ -5839,6 +7005,8 @@ Encoding: 10348 10348 764
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni286D
@@ -5846,6 +7014,8 @@ Encoding: 10349 10349 765
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni286E
@@ -5853,6 +7023,8 @@ Encoding: 10350 10350 766
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni286F
@@ -5860,6 +7032,8 @@ Encoding: 10351 10351 767
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2870
@@ -5867,6 +7041,8 @@ Encoding: 10352 10352 768
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2871
@@ -5874,6 +7050,8 @@ Encoding: 10353 10353 769
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2872
@@ -5881,6 +7059,8 @@ Encoding: 10354 10354 770
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2873
@@ -5888,6 +7068,8 @@ Encoding: 10355 10355 771
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2874
@@ -5895,6 +7077,8 @@ Encoding: 10356 10356 772
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2875
@@ -5902,6 +7086,8 @@ Encoding: 10357 10357 773
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2876
@@ -5909,6 +7095,8 @@ Encoding: 10358 10358 774
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2877
@@ -5916,6 +7104,8 @@ Encoding: 10359 10359 775
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2878
@@ -5923,6 +7113,8 @@ Encoding: 10360 10360 776
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2879
@@ -5930,6 +7122,8 @@ Encoding: 10361 10361 777
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni287A
@@ -5937,6 +7131,8 @@ Encoding: 10362 10362 778
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni287B
@@ -5944,6 +7140,8 @@ Encoding: 10363 10363 779
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni287C
@@ -5951,6 +7149,8 @@ Encoding: 10364 10364 780
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni287D
@@ -5958,6 +7158,8 @@ Encoding: 10365 10365 781
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni287E
@@ -5965,6 +7167,8 @@ Encoding: 10366 10366 782
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni287F
@@ -5972,6 +7176,8 @@ Encoding: 10367 10367 783
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2880
@@ -5979,6 +7185,8 @@ Encoding: 10368 10368 784
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2881
@@ -5986,6 +7194,8 @@ Encoding: 10369 10369 785
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2882
@@ -5993,6 +7203,8 @@ Encoding: 10370 10370 786
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2883
@@ -6000,6 +7212,8 @@ Encoding: 10371 10371 787
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2884
@@ -6007,6 +7221,8 @@ Encoding: 10372 10372 788
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2885
@@ -6014,6 +7230,8 @@ Encoding: 10373 10373 789
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2886
@@ -6021,6 +7239,8 @@ Encoding: 10374 10374 790
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2887
@@ -6028,6 +7248,8 @@ Encoding: 10375 10375 791
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2888
@@ -6035,6 +7257,8 @@ Encoding: 10376 10376 792
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2889
@@ -6042,6 +7266,8 @@ Encoding: 10377 10377 793
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni288A
@@ -6049,6 +7275,8 @@ Encoding: 10378 10378 794
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni288B
@@ -6056,6 +7284,8 @@ Encoding: 10379 10379 795
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni288C
@@ -6063,6 +7293,8 @@ Encoding: 10380 10380 796
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni288D
@@ -6070,6 +7302,8 @@ Encoding: 10381 10381 797
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni288E
@@ -6077,6 +7311,8 @@ Encoding: 10382 10382 798
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni288F
@@ -6084,6 +7320,8 @@ Encoding: 10383 10383 799
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2890
@@ -6091,6 +7329,8 @@ Encoding: 10384 10384 800
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2891
@@ -6098,6 +7338,8 @@ Encoding: 10385 10385 801
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2892
@@ -6105,6 +7347,8 @@ Encoding: 10386 10386 802
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2893
@@ -6112,6 +7356,8 @@ Encoding: 10387 10387 803
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2894
@@ -6119,6 +7365,8 @@ Encoding: 10388 10388 804
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2895
@@ -6126,6 +7374,8 @@ Encoding: 10389 10389 805
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2896
@@ -6133,6 +7383,8 @@ Encoding: 10390 10390 806
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2897
@@ -6140,6 +7392,8 @@ Encoding: 10391 10391 807
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2898
@@ -6147,6 +7401,8 @@ Encoding: 10392 10392 808
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2899
@@ -6154,6 +7410,8 @@ Encoding: 10393 10393 809
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni289A
@@ -6161,6 +7419,8 @@ Encoding: 10394 10394 810
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni289B
@@ -6168,6 +7428,8 @@ Encoding: 10395 10395 811
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni289C
@@ -6175,6 +7437,8 @@ Encoding: 10396 10396 812
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni289D
@@ -6182,6 +7446,8 @@ Encoding: 10397 10397 813
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni289E
@@ -6189,6 +7455,8 @@ Encoding: 10398 10398 814
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni289F
@@ -6196,6 +7464,8 @@ Encoding: 10399 10399 815
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A0
@@ -6203,6 +7473,8 @@ Encoding: 10400 10400 816
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A1
@@ -6210,6 +7482,8 @@ Encoding: 10401 10401 817
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A2
@@ -6217,6 +7491,8 @@ Encoding: 10402 10402 818
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A3
@@ -6224,6 +7500,8 @@ Encoding: 10403 10403 819
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A4
@@ -6231,6 +7509,8 @@ Encoding: 10404 10404 820
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A5
@@ -6238,6 +7518,8 @@ Encoding: 10405 10405 821
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A6
@@ -6245,6 +7527,8 @@ Encoding: 10406 10406 822
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A7
@@ -6252,6 +7536,8 @@ Encoding: 10407 10407 823
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A8
@@ -6259,6 +7545,8 @@ Encoding: 10408 10408 824
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28A9
@@ -6266,6 +7554,8 @@ Encoding: 10409 10409 825
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28AA
@@ -6273,6 +7563,8 @@ Encoding: 10410 10410 826
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28AB
@@ -6280,6 +7572,8 @@ Encoding: 10411 10411 827
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28AC
@@ -6287,6 +7581,8 @@ Encoding: 10412 10412 828
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28AD
@@ -6294,6 +7590,8 @@ Encoding: 10413 10413 829
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28AE
@@ -6301,6 +7599,8 @@ Encoding: 10414 10414 830
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28AF
@@ -6308,6 +7608,8 @@ Encoding: 10415 10415 831
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B0
@@ -6315,6 +7617,8 @@ Encoding: 10416 10416 832
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B1
@@ -6322,6 +7626,8 @@ Encoding: 10417 10417 833
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B2
@@ -6329,6 +7635,8 @@ Encoding: 10418 10418 834
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B3
@@ -6336,6 +7644,8 @@ Encoding: 10419 10419 835
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B4
@@ -6343,6 +7653,8 @@ Encoding: 10420 10420 836
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B5
@@ -6350,6 +7662,8 @@ Encoding: 10421 10421 837
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B6
@@ -6357,6 +7671,8 @@ Encoding: 10422 10422 838
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B7
@@ -6364,6 +7680,8 @@ Encoding: 10423 10423 839
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B8
@@ -6371,6 +7689,8 @@ Encoding: 10424 10424 840
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28B9
@@ -6378,6 +7698,8 @@ Encoding: 10425 10425 841
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28BA
@@ -6385,6 +7707,8 @@ Encoding: 10426 10426 842
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28BB
@@ -6392,6 +7716,8 @@ Encoding: 10427 10427 843
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28BC
@@ -6399,6 +7725,8 @@ Encoding: 10428 10428 844
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28BD
@@ -6406,6 +7734,8 @@ Encoding: 10429 10429 845
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28BE
@@ -6413,6 +7743,8 @@ Encoding: 10430 10430 846
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28BF
@@ -6420,6 +7752,8 @@ Encoding: 10431 10431 847
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C0
@@ -6427,6 +7761,8 @@ Encoding: 10432 10432 848
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C1
@@ -6434,6 +7770,8 @@ Encoding: 10433 10433 849
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C2
@@ -6441,6 +7779,8 @@ Encoding: 10434 10434 850
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C3
@@ -6448,6 +7788,8 @@ Encoding: 10435 10435 851
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C4
@@ -6455,6 +7797,8 @@ Encoding: 10436 10436 852
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C5
@@ -6462,6 +7806,8 @@ Encoding: 10437 10437 853
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C6
@@ -6469,6 +7815,8 @@ Encoding: 10438 10438 854
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C7
@@ -6476,6 +7824,8 @@ Encoding: 10439 10439 855
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C8
@@ -6483,6 +7833,8 @@ Encoding: 10440 10440 856
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28C9
@@ -6490,6 +7842,8 @@ Encoding: 10441 10441 857
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28CA
@@ -6497,6 +7851,8 @@ Encoding: 10442 10442 858
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28CB
@@ -6504,6 +7860,8 @@ Encoding: 10443 10443 859
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28CC
@@ -6511,6 +7869,8 @@ Encoding: 10444 10444 860
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28CD
@@ -6518,6 +7878,8 @@ Encoding: 10445 10445 861
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28CE
@@ -6525,6 +7887,8 @@ Encoding: 10446 10446 862
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28CF
@@ -6532,6 +7896,8 @@ Encoding: 10447 10447 863
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D0
@@ -6539,6 +7905,8 @@ Encoding: 10448 10448 864
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D1
@@ -6546,6 +7914,8 @@ Encoding: 10449 10449 865
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D2
@@ -6553,6 +7923,8 @@ Encoding: 10450 10450 866
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D3
@@ -6560,6 +7932,8 @@ Encoding: 10451 10451 867
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D4
@@ -6567,6 +7941,8 @@ Encoding: 10452 10452 868
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D5
@@ -6574,6 +7950,8 @@ Encoding: 10453 10453 869
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D6
@@ -6581,6 +7959,8 @@ Encoding: 10454 10454 870
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D7
@@ -6588,6 +7968,8 @@ Encoding: 10455 10455 871
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D8
@@ -6595,6 +7977,8 @@ Encoding: 10456 10456 872
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28D9
@@ -6602,6 +7986,8 @@ Encoding: 10457 10457 873
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28DA
@@ -6609,6 +7995,8 @@ Encoding: 10458 10458 874
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28DB
@@ -6616,6 +8004,8 @@ Encoding: 10459 10459 875
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28DC
@@ -6623,6 +8013,8 @@ Encoding: 10460 10460 876
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28DD
@@ -6630,6 +8022,8 @@ Encoding: 10461 10461 877
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28DE
@@ -6637,6 +8031,8 @@ Encoding: 10462 10462 878
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28DF
@@ -6644,6 +8040,8 @@ Encoding: 10463 10463 879
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E0
@@ -6651,6 +8049,8 @@ Encoding: 10464 10464 880
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E1
@@ -6658,6 +8058,8 @@ Encoding: 10465 10465 881
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E2
@@ -6665,6 +8067,8 @@ Encoding: 10466 10466 882
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E3
@@ -6672,6 +8076,8 @@ Encoding: 10467 10467 883
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E4
@@ -6679,6 +8085,8 @@ Encoding: 10468 10468 884
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E5
@@ -6686,6 +8094,8 @@ Encoding: 10469 10469 885
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E6
@@ -6693,6 +8103,8 @@ Encoding: 10470 10470 886
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E7
@@ -6700,6 +8112,8 @@ Encoding: 10471 10471 887
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E8
@@ -6707,6 +8121,8 @@ Encoding: 10472 10472 888
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28E9
@@ -6714,6 +8130,8 @@ Encoding: 10473 10473 889
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28EA
@@ -6721,6 +8139,8 @@ Encoding: 10474 10474 890
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28EB
@@ -6728,6 +8148,8 @@ Encoding: 10475 10475 891
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28EC
@@ -6735,6 +8157,8 @@ Encoding: 10476 10476 892
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28ED
@@ -6742,6 +8166,8 @@ Encoding: 10477 10477 893
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28EE
@@ -6749,6 +8175,8 @@ Encoding: 10478 10478 894
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28EF
@@ -6756,6 +8184,8 @@ Encoding: 10479 10479 895
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F0
@@ -6763,6 +8193,8 @@ Encoding: 10480 10480 896
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F1
@@ -6770,6 +8202,8 @@ Encoding: 10481 10481 897
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F2
@@ -6777,6 +8211,8 @@ Encoding: 10482 10482 898
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F3
@@ -6784,6 +8220,8 @@ Encoding: 10483 10483 899
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F4
@@ -6791,6 +8229,8 @@ Encoding: 10484 10484 900
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F5
@@ -6798,6 +8238,8 @@ Encoding: 10485 10485 901
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F6
@@ -6805,6 +8247,8 @@ Encoding: 10486 10486 902
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F7
@@ -6812,6 +8256,8 @@ Encoding: 10487 10487 903
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F8
@@ -6819,6 +8265,8 @@ Encoding: 10488 10488 904
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28F9
@@ -6826,6 +8274,8 @@ Encoding: 10489 10489 905
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28FA
@@ -6833,6 +8283,8 @@ Encoding: 10490 10490 906
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28FB
@@ -6840,6 +8292,8 @@ Encoding: 10491 10491 907
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28FC
@@ -6847,6 +8301,8 @@ Encoding: 10492 10492 908
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28FD
@@ -6854,6 +8310,8 @@ Encoding: 10493 10493 909
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28FE
@@ -6861,6 +8319,8 @@ Encoding: 10494 10494 910
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni28FF
@@ -6868,6 +8328,8 @@ Encoding: 10495 10495 911
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0A0
@@ -6875,6 +8337,8 @@ Encoding: 57504 57504 912
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0A1
@@ -6882,6 +8346,8 @@ Encoding: 57505 57505 913
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0A2
@@ -6889,6 +8355,8 @@ Encoding: 57506 57506 914
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0A3
@@ -6896,6 +8364,8 @@ Encoding: 57507 57507 915
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B0
@@ -6903,6 +8373,8 @@ Encoding: 57520 57520 916
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B1
@@ -6910,6 +8382,8 @@ Encoding: 57521 57521 917
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B2
@@ -6917,6 +8391,8 @@ Encoding: 57522 57522 918
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B3
@@ -6924,6 +8400,8 @@ Encoding: 57523 57523 919
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B4
@@ -6931,6 +8409,8 @@ Encoding: 57524 57524 920
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B5
@@ -6938,6 +8418,8 @@ Encoding: 57525 57525 921
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE5FF
@@ -6945,6 +8427,8 @@ Encoding: 58879 58879 922
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE600
@@ -6952,6 +8436,8 @@ Encoding: 58880 58880 923
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE601
@@ -6959,6 +8445,8 @@ Encoding: 58881 58881 924
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE602
@@ -6966,6 +8454,8 @@ Encoding: 58882 58882 925
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE603
@@ -6973,6 +8463,8 @@ Encoding: 58883 58883 926
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE604
@@ -6980,6 +8472,8 @@ Encoding: 58884 58884 927
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE605
@@ -6987,6 +8481,8 @@ Encoding: 58885 58885 928
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE606
@@ -6994,6 +8490,8 @@ Encoding: 58886 58886 929
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE607
@@ -7001,6 +8499,8 @@ Encoding: 58887 58887 930
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE608
@@ -7008,6 +8508,8 @@ Encoding: 58888 58888 931
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE609
@@ -7015,6 +8517,8 @@ Encoding: 58889 58889 932
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE60A
@@ -7022,6 +8526,8 @@ Encoding: 58890 58890 933
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE60B
@@ -7029,6 +8535,8 @@ Encoding: 58891 58891 934
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE60C
@@ -7036,6 +8544,8 @@ Encoding: 58892 58892 935
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE60D
@@ -7043,6 +8553,8 @@ Encoding: 58893 58893 936
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE60E
@@ -7050,6 +8562,8 @@ Encoding: 58894 58894 937
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE60F
@@ -7057,6 +8571,8 @@ Encoding: 58895 58895 938
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE610
@@ -7064,6 +8580,8 @@ Encoding: 58896 58896 939
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE611
@@ -7071,6 +8589,8 @@ Encoding: 58897 58897 940
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE612
@@ -7078,6 +8598,8 @@ Encoding: 58898 58898 941
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE613
@@ -7085,6 +8607,8 @@ Encoding: 58899 58899 942
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE614
@@ -7092,6 +8616,8 @@ Encoding: 58900 58900 943
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE615
@@ -7099,6 +8625,8 @@ Encoding: 58901 58901 944
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE616
@@ -7106,6 +8634,8 @@ Encoding: 58902 58902 945
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE617
@@ -7113,6 +8643,8 @@ Encoding: 58903 58903 946
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE618
@@ -7120,6 +8652,8 @@ Encoding: 58904 58904 947
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE619
@@ -7127,6 +8661,8 @@ Encoding: 58905 58905 948
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE61A
@@ -7134,6 +8670,8 @@ Encoding: 58906 58906 949
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE61B
@@ -7141,6 +8679,8 @@ Encoding: 58907 58907 950
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE61C
@@ -7148,6 +8688,8 @@ Encoding: 58908 58908 951
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE61F
@@ -7155,6 +8697,8 @@ Encoding: 58911 58911 952
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE620
@@ -7162,6 +8706,8 @@ Encoding: 58912 58912 953
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE622
@@ -7169,6 +8715,8 @@ Encoding: 58914 58914 954
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE623
@@ -7176,6 +8724,8 @@ Encoding: 58915 58915 955
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE624
@@ -7183,6 +8733,8 @@ Encoding: 58916 58916 956
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE625
@@ -7190,6 +8742,8 @@ Encoding: 58917 58917 957
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE627
@@ -7197,6 +8751,8 @@ Encoding: 58919 58919 958
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE628
@@ -7204,6 +8760,8 @@ Encoding: 58920 58920 959
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE711
@@ -7211,6 +8769,8 @@ Encoding: 59153 59153 960
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE712
@@ -7218,6 +8778,8 @@ Encoding: 59154 59154 961
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE795
@@ -7225,6 +8787,8 @@ Encoding: 59285 59285 962
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE77B
@@ -7232,6 +8796,8 @@ Encoding: 59259 59259 963
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7A2
@@ -7239,6 +8805,8 @@ Encoding: 59298 59298 964
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE61D
@@ -7246,6 +8814,8 @@ Encoding: 58909 58909 965
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE61E
@@ -7253,6 +8823,8 @@ Encoding: 58910 58910 966
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE621
@@ -7260,6 +8832,8 @@ Encoding: 58913 58913 967
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF120
@@ -7267,6 +8841,8 @@ Encoding: 61728 61728 968
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE5FE
@@ -7274,6 +8850,8 @@ Encoding: 58878 58878 969
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE62B
@@ -7281,6 +8859,8 @@ Encoding: 58923 58923 970
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0FD
@@ -7288,6 +8868,8 @@ Encoding: 61693 61693 971
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE70C
@@ -7295,6 +8877,8 @@ Encoding: 59148 59148 972
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7AF
@@ -7302,6 +8886,8 @@ Encoding: 59311 59311 973
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7B1
@@ -7309,6 +8895,8 @@ Encoding: 59313 59313 974
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE739
@@ -7316,6 +8904,8 @@ Encoding: 59193 59193 975
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE73C
@@ -7323,6 +8913,8 @@ Encoding: 59196 59196 976
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE73B
@@ -7330,6 +8922,8 @@ Encoding: 59195 59195 977
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE73D
@@ -7337,6 +8931,8 @@ Encoding: 59197 59197 978
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE73E
@@ -7344,6 +8940,8 @@ Encoding: 59198 59198 979
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE73A
@@ -7351,6 +8949,8 @@ Encoding: 59194 59194 980
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF303
@@ -7358,6 +8958,8 @@ Encoding: 62211 62211 981
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23CE
@@ -7365,6 +8967,8 @@ Encoding: 9166 9166 982
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: infinity
@@ -7372,6 +8976,8 @@ Encoding: 8734 8734 983
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10037
@@ -7379,6 +8985,8 @@ Encoding: 1059 1059 984
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10065
@@ -7386,6 +8994,8 @@ Encoding: 1072 1072 985
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10066
@@ -7393,6 +9003,8 @@ Encoding: 1073 1073 986
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10089
@@ -7400,6 +9012,8 @@ Encoding: 1095 1095 987
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10071
@@ -7407,6 +9021,8 @@ Encoding: 1105 1105 988
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A0
@@ -7414,6 +9030,8 @@ Encoding: 5792 5792 989
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2070
@@ -7421,6 +9039,8 @@ Encoding: 8304 8304 990
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2074
@@ -7428,6 +9048,8 @@ Encoding: 8308 8308 991
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2075
@@ -7435,6 +9057,8 @@ Encoding: 8309 8309 992
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2076
@@ -7442,6 +9066,8 @@ Encoding: 8310 8310 993
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2077
@@ -7449,6 +9075,8 @@ Encoding: 8311 8311 994
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2078
@@ -7456,6 +9084,8 @@ Encoding: 8312 8312 995
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2079
@@ -7463,6 +9093,8 @@ Encoding: 8313 8313 996
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2081
@@ -7470,6 +9102,8 @@ Encoding: 8321 8321 997
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2225
@@ -7477,6 +9111,8 @@ Encoding: 8741 8741 998
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2226
@@ -7484,6 +9120,8 @@ Encoding: 8742 8742 999
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni229D
@@ -7491,6 +9129,8 @@ Encoding: 8861 8861 1000
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2387
@@ -7498,6 +9138,8 @@ Encoding: 9095 9095 1001
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni240A
@@ -7505,6 +9147,8 @@ Encoding: 9226 9226 1002
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2424
@@ -7512,6 +9156,8 @@ Encoding: 9252 9252 1003
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25B6
@@ -7519,6 +9165,8 @@ Encoding: 9654 9654 1004
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25C0
@@ -7526,6 +9174,8 @@ Encoding: 9664 9664 1005
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2630
@@ -7533,6 +9183,8 @@ Encoding: 9776 9776 1006
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2631
@@ -7540,6 +9192,8 @@ Encoding: 9777 9777 1007
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2632
@@ -7547,6 +9201,8 @@ Encoding: 9778 9778 1008
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2633
@@ -7554,6 +9210,8 @@ Encoding: 9779 9779 1009
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2634
@@ -7561,6 +9219,8 @@ Encoding: 9780 9780 1010
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2635
@@ -7568,6 +9228,8 @@ Encoding: 9781 9781 1011
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2636
@@ -7575,6 +9237,8 @@ Encoding: 9782 9782 1012
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2637
@@ -7582,6 +9246,8 @@ Encoding: 9783 9783 1013
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B60
@@ -7589,6 +9255,8 @@ Encoding: 11104 11104 1014
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B61
@@ -7596,6 +9264,8 @@ Encoding: 11105 11105 1015
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B62
@@ -7603,6 +9273,8 @@ Encoding: 11106 11106 1016
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B63
@@ -7610,6 +9282,8 @@ Encoding: 11107 11107 1017
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B64
@@ -7617,6 +9291,8 @@ Encoding: 11108 11108 1018
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B65
@@ -7624,6 +9300,8 @@ Encoding: 11109 11109 1019
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B66
@@ -7631,6 +9309,8 @@ Encoding: 11110 11110 1020
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B67
@@ -7638,6 +9318,8 @@ Encoding: 11111 11111 1021
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B68
@@ -7645,6 +9327,8 @@ Encoding: 11112 11112 1022
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B69
@@ -7652,6 +9336,8 @@ Encoding: 11113 11113 1023
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B80
@@ -7659,6 +9345,8 @@ Encoding: 11136 11136 1024
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B81
@@ -7666,6 +9354,8 @@ Encoding: 11137 11137 1025
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B82
@@ -7673,6 +9363,8 @@ Encoding: 11138 11138 1026
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B83
@@ -7680,6 +9372,8 @@ Encoding: 11139 11139 1027
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni33D1
@@ -7687,6 +9381,8 @@ Encoding: 13265 13265 1028
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniA7A8
@@ -7694,13 +9390,17 @@ Encoding: 42920 42920 1029
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F512
 Encoding: 128274 128274 1030
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFC5D
@@ -7708,6 +9408,8 @@ Encoding: 64605 64605 1031
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF026
@@ -7715,6 +9417,8 @@ Encoding: 61478 61478 1032
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF027
@@ -7722,6 +9426,8 @@ Encoding: 61479 61479 1033
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF028
@@ -7729,6 +9435,8 @@ Encoding: 61480 61480 1034
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFA7E
@@ -7736,6 +9444,8 @@ Encoding: 64126 64126 1035
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFA7F
@@ -7743,6 +9453,8 @@ Encoding: 64127 64127 1036
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFA80
@@ -7750,6 +9462,8 @@ Encoding: 64128 64128 1037
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFC5C
@@ -7757,6 +9471,8 @@ Encoding: 64604 64604 1038
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFC5B
@@ -7764,6 +9480,8 @@ Encoding: 64603 64603 1039
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF244
@@ -7771,6 +9489,8 @@ Encoding: 62020 62020 1040
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF243
@@ -7778,6 +9498,8 @@ Encoding: 62019 62019 1041
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF242
@@ -7785,6 +9507,8 @@ Encoding: 62018 62018 1042
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF241
@@ -7792,6 +9516,8 @@ Encoding: 62017 62017 1043
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF240
@@ -7799,6 +9525,8 @@ Encoding: 62016 62016 1044
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF578
@@ -7806,6 +9534,8 @@ Encoding: 62840 62840 1045
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF579
@@ -7813,6 +9543,8 @@ Encoding: 62841 62841 1046
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF57A
@@ -7820,6 +9552,8 @@ Encoding: 62842 62842 1047
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF57B
@@ -7827,6 +9561,8 @@ Encoding: 62843 62843 1048
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF57C
@@ -7834,6 +9570,8 @@ Encoding: 62844 62844 1049
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF57D
@@ -7841,6 +9579,8 @@ Encoding: 62845 62845 1050
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF57E
@@ -7848,6 +9588,8 @@ Encoding: 62846 62846 1051
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF57F
@@ -7855,6 +9597,8 @@ Encoding: 62847 62847 1052
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF580
@@ -7862,6 +9606,8 @@ Encoding: 62848 62848 1053
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF581
@@ -7869,6 +9615,8 @@ Encoding: 62849 62849 1054
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF582
@@ -7876,6 +9624,8 @@ Encoding: 62850 62850 1055
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF583
@@ -7883,6 +9633,8 @@ Encoding: 62851 62851 1056
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF584
@@ -7890,6 +9642,8 @@ Encoding: 62852 62852 1057
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF585
@@ -7897,6 +9651,8 @@ Encoding: 62853 62853 1058
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF586
@@ -7904,6 +9660,8 @@ Encoding: 62854 62854 1059
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF587
@@ -7911,6 +9669,8 @@ Encoding: 62855 62855 1060
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF588
@@ -7918,6 +9678,8 @@ Encoding: 62856 62856 1061
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF589
@@ -7925,6 +9687,8 @@ Encoding: 62857 62857 1062
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF58A
@@ -7932,6 +9696,8 @@ Encoding: 62858 62858 1063
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF58B
@@ -7939,6 +9705,8 @@ Encoding: 62859 62859 1064
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF58C
@@ -7946,6 +9714,8 @@ Encoding: 62860 62860 1065
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF58D
@@ -7953,6 +9723,8 @@ Encoding: 62861 62861 1066
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF58E
@@ -7960,6 +9732,8 @@ Encoding: 62862 62862 1067
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF58F
@@ -7967,6 +9741,8 @@ Encoding: 62863 62863 1068
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF590
@@ -7974,6 +9750,8 @@ Encoding: 62864 62864 1069
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD05
@@ -7981,6 +9759,8 @@ Encoding: 64773 64773 1070
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD06
@@ -7988,6 +9768,8 @@ Encoding: 64774 64774 1071
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD07
@@ -7995,6 +9777,8 @@ Encoding: 64775 64775 1072
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD08
@@ -8002,6 +9786,8 @@ Encoding: 64776 64776 1073
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD09
@@ -8009,6 +9795,8 @@ Encoding: 64777 64777 1074
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD0A
@@ -8016,6 +9804,8 @@ Encoding: 64778 64778 1075
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD0B
@@ -8023,6 +9813,8 @@ Encoding: 64779 64779 1076
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD0C
@@ -8030,6 +9822,8 @@ Encoding: 64780 64780 1077
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD0D
@@ -8037,6 +9831,8 @@ Encoding: 64781 64781 1078
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD0E
@@ -8044,6 +9840,8 @@ Encoding: 64782 64782 1079
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD0F
@@ -8051,6 +9849,8 @@ Encoding: 64783 64783 1080
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD10
@@ -8058,6 +9858,8 @@ Encoding: 64784 64784 1081
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF2C7
@@ -8065,6 +9867,8 @@ Encoding: 62151 62151 1082
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF2C8
@@ -8072,6 +9876,8 @@ Encoding: 62152 62152 1083
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF2C9
@@ -8079,6 +9885,8 @@ Encoding: 62153 62153 1084
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF2CA
@@ -8086,6 +9894,8 @@ Encoding: 62154 62154 1085
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF2CB
@@ -8093,6 +9903,8 @@ Encoding: 62155 62155 1086
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE20C
@@ -8100,6 +9912,8 @@ Encoding: 57868 57868 1087
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE20A
@@ -8107,6 +9921,8 @@ Encoding: 57866 57866 1088
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE20B
@@ -8114,6 +9930,8 @@ Encoding: 57867 57867 1089
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0AC
@@ -8121,6 +9939,8 @@ Encoding: 61612 61612 1090
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1EB
@@ -8128,6 +9948,8 @@ Encoding: 61931 61931 1091
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: zcaron.sc
@@ -8135,6 +9957,8 @@ Encoding: 63231 63231 1092
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFAA8
@@ -8142,6 +9966,8 @@ Encoding: 64168 64168 1093
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFAA9
@@ -8149,6 +9975,8 @@ Encoding: 64169 64169 1094
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1FE
@@ -8156,6 +9984,8 @@ Encoding: 61950 61950 1095
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF201
@@ -8163,6 +9993,8 @@ Encoding: 61953 61953 1096
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF200
@@ -8170,6 +10002,8 @@ Encoding: 61952 61952 1097
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF17C
@@ -8177,6 +10011,8 @@ Encoding: 61820 61820 1098
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF179
@@ -8184,6 +10020,8 @@ Encoding: 61817 61817 1099
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF198
@@ -8191,6 +10029,8 @@ Encoding: 61848 61848 1100
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1B7
@@ -8198,6 +10038,8 @@ Encoding: 61879 61879 1101
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1B6
@@ -8205,6 +10047,8 @@ Encoding: 61878 61878 1102
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF26A
@@ -8213,6 +10057,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF269
@@ -8221,6 +10067,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF268
@@ -8229,6 +10077,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE745
@@ -8237,6 +10087,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE746
@@ -8245,6 +10097,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE743
@@ -8253,6 +10107,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF080
@@ -8260,6 +10116,8 @@ Encoding: 61568 61568 1109
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF81F
@@ -8267,6 +10125,8 @@ Encoding: 63519 63519 1110
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF820
@@ -8275,6 +10135,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF2DB
@@ -8282,6 +10144,8 @@ Encoding: 62171 62171 1112
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF025
@@ -8289,6 +10153,8 @@ Encoding: 61477 61477 1113
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF7CA
@@ -8296,6 +10162,8 @@ Encoding: 63434 63434 1114
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF7CD
@@ -8304,6 +10172,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF7CC
@@ -8311,6 +10181,8 @@ Encoding: 63436 63436 1116
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF7CB
@@ -8318,6 +10190,8 @@ Encoding: 63435 63435 1117
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF7CF
@@ -8326,6 +10200,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFCCC
@@ -8333,6 +10209,8 @@ Encoding: 64716 64716 1119
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF130
@@ -8340,6 +10218,8 @@ Encoding: 61744 61744 1120
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF131
@@ -8347,6 +10227,8 @@ Encoding: 61745 61745 1121
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF04B
@@ -8354,6 +10236,8 @@ Encoding: 61515 61515 1122
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF04C
@@ -8361,6 +10245,8 @@ Encoding: 61516 61516 1123
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF04D
@@ -8368,6 +10254,8 @@ Encoding: 61517 61517 1124
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF04E
@@ -8375,6 +10263,8 @@ Encoding: 61518 61518 1125
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF050
@@ -8382,6 +10272,8 @@ Encoding: 61520 61520 1126
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF051
@@ -8389,6 +10281,8 @@ Encoding: 61521 61521 1127
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF052
@@ -8396,6 +10290,8 @@ Encoding: 61522 61522 1128
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF049
@@ -8403,6 +10299,8 @@ Encoding: 61513 61513 1129
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF04A
@@ -8410,6 +10308,8 @@ Encoding: 61514 61514 1130
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF048
@@ -8417,6 +10317,8 @@ Encoding: 61512 61512 1131
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0F3
@@ -8424,6 +10326,8 @@ Encoding: 61683 61683 1132
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0A2
@@ -8431,6 +10335,8 @@ Encoding: 61602 61602 1133
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1F6
@@ -8438,6 +10344,8 @@ Encoding: 61942 61942 1134
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1F7
@@ -8445,6 +10353,8 @@ Encoding: 61943 61943 1135
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF133
@@ -8452,6 +10362,8 @@ Encoding: 61747 61747 1136
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF017
@@ -8459,6 +10371,8 @@ Encoding: 61463 61463 1137
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF084
@@ -8466,6 +10380,8 @@ Encoding: 61572 61572 1138
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF80A
@@ -8473,6 +10389,8 @@ Encoding: 63498 63498 1139
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0400
@@ -8480,6 +10398,8 @@ Encoding: 1024 1024 1140
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10023
@@ -8487,6 +10407,8 @@ Encoding: 1025 1025 1141
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10051
@@ -8494,6 +10416,8 @@ Encoding: 1026 1026 1142
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10052
@@ -8501,6 +10425,8 @@ Encoding: 1027 1027 1143
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10053
@@ -8508,6 +10434,8 @@ Encoding: 1028 1028 1144
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10054
@@ -8515,6 +10443,8 @@ Encoding: 1029 1029 1145
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10055
@@ -8522,6 +10452,8 @@ Encoding: 1030 1030 1146
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10056
@@ -8529,6 +10461,8 @@ Encoding: 1031 1031 1147
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10057
@@ -8536,6 +10470,8 @@ Encoding: 1032 1032 1148
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10058
@@ -8543,6 +10479,8 @@ Encoding: 1033 1033 1149
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10059
@@ -8550,6 +10488,8 @@ Encoding: 1034 1034 1150
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10060
@@ -8557,6 +10497,8 @@ Encoding: 1035 1035 1151
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10061
@@ -8564,6 +10506,8 @@ Encoding: 1036 1036 1152
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni040D
@@ -8571,6 +10515,8 @@ Encoding: 1037 1037 1153
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10062
@@ -8578,6 +10524,8 @@ Encoding: 1038 1038 1154
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10145
@@ -8585,6 +10533,8 @@ Encoding: 1039 1039 1155
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10017
@@ -8592,6 +10542,8 @@ Encoding: 1040 1040 1156
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10018
@@ -8599,6 +10551,8 @@ Encoding: 1041 1041 1157
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10019
@@ -8606,6 +10560,8 @@ Encoding: 1042 1042 1158
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10020
@@ -8613,6 +10569,8 @@ Encoding: 1043 1043 1159
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10021
@@ -8620,6 +10578,8 @@ Encoding: 1044 1044 1160
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10022
@@ -8627,6 +10587,8 @@ Encoding: 1045 1045 1161
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10024
@@ -8634,6 +10596,8 @@ Encoding: 1046 1046 1162
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10025
@@ -8641,6 +10605,8 @@ Encoding: 1047 1047 1163
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10026
@@ -8648,6 +10614,8 @@ Encoding: 1048 1048 1164
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10027
@@ -8655,6 +10623,8 @@ Encoding: 1049 1049 1165
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10028
@@ -8662,6 +10632,8 @@ Encoding: 1050 1050 1166
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10029
@@ -8669,6 +10641,8 @@ Encoding: 1051 1051 1167
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10030
@@ -8676,6 +10650,8 @@ Encoding: 1052 1052 1168
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10031
@@ -8683,6 +10659,8 @@ Encoding: 1053 1053 1169
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10032
@@ -8690,6 +10668,8 @@ Encoding: 1054 1054 1170
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10033
@@ -8697,6 +10677,8 @@ Encoding: 1055 1055 1171
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10034
@@ -8704,6 +10686,8 @@ Encoding: 1056 1056 1172
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10035
@@ -8711,6 +10695,8 @@ Encoding: 1057 1057 1173
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10036
@@ -8718,6 +10704,8 @@ Encoding: 1058 1058 1174
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10038
@@ -8725,6 +10713,8 @@ Encoding: 1060 1060 1175
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10039
@@ -8732,6 +10722,8 @@ Encoding: 1061 1061 1176
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10040
@@ -8739,6 +10731,8 @@ Encoding: 1062 1062 1177
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10041
@@ -8746,6 +10740,8 @@ Encoding: 1063 1063 1178
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10042
@@ -8753,6 +10749,8 @@ Encoding: 1064 1064 1179
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10043
@@ -8760,6 +10758,8 @@ Encoding: 1065 1065 1180
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10044
@@ -8767,6 +10767,8 @@ Encoding: 1066 1066 1181
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10045
@@ -8774,6 +10776,8 @@ Encoding: 1067 1067 1182
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10046
@@ -8781,6 +10785,8 @@ Encoding: 1068 1068 1183
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10047
@@ -8788,6 +10794,8 @@ Encoding: 1069 1069 1184
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10048
@@ -8795,6 +10803,8 @@ Encoding: 1070 1070 1185
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10049
@@ -8802,6 +10812,8 @@ Encoding: 1071 1071 1186
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10067
@@ -8809,6 +10821,8 @@ Encoding: 1074 1074 1187
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10068
@@ -8816,6 +10830,8 @@ Encoding: 1075 1075 1188
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10069
@@ -8823,6 +10839,8 @@ Encoding: 1076 1076 1189
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10070
@@ -8830,6 +10848,8 @@ Encoding: 1077 1077 1190
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10072
@@ -8837,6 +10857,8 @@ Encoding: 1078 1078 1191
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10073
@@ -8844,6 +10866,8 @@ Encoding: 1079 1079 1192
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10074
@@ -8851,6 +10875,8 @@ Encoding: 1080 1080 1193
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10075
@@ -8858,6 +10884,8 @@ Encoding: 1081 1081 1194
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10076
@@ -8865,6 +10893,8 @@ Encoding: 1082 1082 1195
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10077
@@ -8872,6 +10902,8 @@ Encoding: 1083 1083 1196
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10078
@@ -8879,6 +10911,8 @@ Encoding: 1084 1084 1197
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10079
@@ -8886,6 +10920,8 @@ Encoding: 1085 1085 1198
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10080
@@ -8893,6 +10929,8 @@ Encoding: 1086 1086 1199
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10081
@@ -8900,6 +10938,8 @@ Encoding: 1087 1087 1200
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10082
@@ -8907,6 +10947,8 @@ Encoding: 1088 1088 1201
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10083
@@ -8914,6 +10956,8 @@ Encoding: 1089 1089 1202
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10084
@@ -8921,6 +10965,8 @@ Encoding: 1090 1090 1203
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10085
@@ -8928,6 +10974,8 @@ Encoding: 1091 1091 1204
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10086
@@ -8935,6 +10983,8 @@ Encoding: 1092 1092 1205
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10087
@@ -8942,6 +10992,8 @@ Encoding: 1093 1093 1206
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10088
@@ -8949,6 +11001,8 @@ Encoding: 1094 1094 1207
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10090
@@ -8956,6 +11010,8 @@ Encoding: 1096 1096 1208
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10091
@@ -8963,6 +11019,8 @@ Encoding: 1097 1097 1209
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10092
@@ -8970,6 +11028,8 @@ Encoding: 1098 1098 1210
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10093
@@ -8977,6 +11037,8 @@ Encoding: 1099 1099 1211
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10094
@@ -8984,6 +11046,8 @@ Encoding: 1100 1100 1212
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10095
@@ -8991,6 +11055,8 @@ Encoding: 1101 1101 1213
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10096
@@ -8998,6 +11064,8 @@ Encoding: 1102 1102 1214
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10097
@@ -9005,6 +11073,8 @@ Encoding: 1103 1103 1215
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0450
@@ -9012,6 +11082,8 @@ Encoding: 1104 1104 1216
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10099
@@ -9019,6 +11091,8 @@ Encoding: 1106 1106 1217
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10100
@@ -9026,6 +11100,8 @@ Encoding: 1107 1107 1218
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10101
@@ -9033,6 +11109,8 @@ Encoding: 1108 1108 1219
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10102
@@ -9040,6 +11118,8 @@ Encoding: 1109 1109 1220
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10103
@@ -9047,6 +11127,8 @@ Encoding: 1110 1110 1221
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10104
@@ -9054,6 +11136,8 @@ Encoding: 1111 1111 1222
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10105
@@ -9061,6 +11145,8 @@ Encoding: 1112 1112 1223
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10106
@@ -9068,6 +11154,8 @@ Encoding: 1113 1113 1224
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10107
@@ -9075,6 +11163,8 @@ Encoding: 1114 1114 1225
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10108
@@ -9082,6 +11172,8 @@ Encoding: 1115 1115 1226
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10109
@@ -9089,6 +11181,8 @@ Encoding: 1116 1116 1227
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni045D
@@ -9096,6 +11190,8 @@ Encoding: 1117 1117 1228
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10110
@@ -9103,6 +11199,8 @@ Encoding: 1118 1118 1229
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10193
@@ -9110,6 +11208,8 @@ Encoding: 1119 1119 1230
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0460
@@ -9117,6 +11217,8 @@ Encoding: 1120 1120 1231
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0461
@@ -9124,6 +11226,8 @@ Encoding: 1121 1121 1232
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10146
@@ -9131,6 +11235,8 @@ Encoding: 1122 1122 1233
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10194
@@ -9138,6 +11244,8 @@ Encoding: 1123 1123 1234
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0464
@@ -9145,6 +11253,8 @@ Encoding: 1124 1124 1235
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0465
@@ -9152,6 +11262,8 @@ Encoding: 1125 1125 1236
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0466
@@ -9159,6 +11271,8 @@ Encoding: 1126 1126 1237
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0467
@@ -9166,6 +11280,8 @@ Encoding: 1127 1127 1238
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0468
@@ -9173,6 +11289,8 @@ Encoding: 1128 1128 1239
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0469
@@ -9180,6 +11298,8 @@ Encoding: 1129 1129 1240
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni046A
@@ -9187,6 +11307,8 @@ Encoding: 1130 1130 1241
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni046B
@@ -9194,6 +11316,8 @@ Encoding: 1131 1131 1242
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni046C
@@ -9201,6 +11325,8 @@ Encoding: 1132 1132 1243
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni046D
@@ -9208,6 +11334,8 @@ Encoding: 1133 1133 1244
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni046E
@@ -9215,6 +11343,8 @@ Encoding: 1134 1134 1245
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni046F
@@ -9222,6 +11352,8 @@ Encoding: 1135 1135 1246
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0470
@@ -9229,6 +11361,8 @@ Encoding: 1136 1136 1247
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0471
@@ -9236,6 +11370,8 @@ Encoding: 1137 1137 1248
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10147
@@ -9243,6 +11379,8 @@ Encoding: 1138 1138 1249
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10195
@@ -9250,6 +11388,8 @@ Encoding: 1139 1139 1250
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10148
@@ -9257,6 +11397,8 @@ Encoding: 1140 1140 1251
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10196
@@ -9264,6 +11406,8 @@ Encoding: 1141 1141 1252
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0476
@@ -9271,6 +11415,8 @@ Encoding: 1142 1142 1253
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0477
@@ -9278,6 +11424,8 @@ Encoding: 1143 1143 1254
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0478
@@ -9285,6 +11433,8 @@ Encoding: 1144 1144 1255
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0479
@@ -9292,6 +11442,8 @@ Encoding: 1145 1145 1256
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni047A
@@ -9299,6 +11451,8 @@ Encoding: 1146 1146 1257
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni047B
@@ -9306,6 +11460,8 @@ Encoding: 1147 1147 1258
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni047C
@@ -9313,6 +11469,8 @@ Encoding: 1148 1148 1259
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni047D
@@ -9320,6 +11478,8 @@ Encoding: 1149 1149 1260
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni047E
@@ -9327,6 +11487,8 @@ Encoding: 1150 1150 1261
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni047F
@@ -9334,6 +11496,8 @@ Encoding: 1151 1151 1262
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0480
@@ -9341,6 +11505,8 @@ Encoding: 1152 1152 1263
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0481
@@ -9348,6 +11514,8 @@ Encoding: 1153 1153 1264
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0482
@@ -9355,6 +11523,8 @@ Encoding: 1154 1154 1265
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni048A
@@ -9362,6 +11532,8 @@ Encoding: 1162 1162 1266
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni048B
@@ -9369,6 +11541,8 @@ Encoding: 1163 1163 1267
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni048C
@@ -9376,6 +11550,8 @@ Encoding: 1164 1164 1268
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni048D
@@ -9383,6 +11559,8 @@ Encoding: 1165 1165 1269
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni048E
@@ -9390,6 +11568,8 @@ Encoding: 1166 1166 1270
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni048F
@@ -9397,6 +11577,8 @@ Encoding: 1167 1167 1271
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10050
@@ -9404,6 +11586,8 @@ Encoding: 1168 1168 1272
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10098
@@ -9411,6 +11595,8 @@ Encoding: 1169 1169 1273
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0492
@@ -9418,6 +11604,8 @@ Encoding: 1170 1170 1274
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0493
@@ -9425,6 +11613,8 @@ Encoding: 1171 1171 1275
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0494
@@ -9432,6 +11622,8 @@ Encoding: 1172 1172 1276
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0495
@@ -9439,6 +11631,8 @@ Encoding: 1173 1173 1277
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0496
@@ -9446,6 +11640,8 @@ Encoding: 1174 1174 1278
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0497
@@ -9453,6 +11649,8 @@ Encoding: 1175 1175 1279
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0498
@@ -9460,6 +11658,8 @@ Encoding: 1176 1176 1280
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0499
@@ -9467,6 +11667,8 @@ Encoding: 1177 1177 1281
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni049A
@@ -9474,6 +11676,8 @@ Encoding: 1178 1178 1282
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni049B
@@ -9481,6 +11685,8 @@ Encoding: 1179 1179 1283
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni049C
@@ -9488,6 +11694,8 @@ Encoding: 1180 1180 1284
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni049D
@@ -9495,6 +11703,8 @@ Encoding: 1181 1181 1285
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni049E
@@ -9502,6 +11712,8 @@ Encoding: 1182 1182 1286
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni049F
@@ -9509,6 +11721,8 @@ Encoding: 1183 1183 1287
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A0
@@ -9516,6 +11730,8 @@ Encoding: 1184 1184 1288
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A1
@@ -9523,6 +11739,8 @@ Encoding: 1185 1185 1289
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A2
@@ -9530,6 +11748,8 @@ Encoding: 1186 1186 1290
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A3
@@ -9537,6 +11757,8 @@ Encoding: 1187 1187 1291
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A4
@@ -9544,6 +11766,8 @@ Encoding: 1188 1188 1292
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A5
@@ -9551,6 +11775,8 @@ Encoding: 1189 1189 1293
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A6
@@ -9558,6 +11784,8 @@ Encoding: 1190 1190 1294
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A7
@@ -9565,6 +11793,8 @@ Encoding: 1191 1191 1295
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A8
@@ -9572,6 +11802,8 @@ Encoding: 1192 1192 1296
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04A9
@@ -9579,6 +11811,8 @@ Encoding: 1193 1193 1297
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04AA
@@ -9586,6 +11820,8 @@ Encoding: 1194 1194 1298
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04AB
@@ -9593,6 +11829,8 @@ Encoding: 1195 1195 1299
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04AC
@@ -9600,6 +11838,8 @@ Encoding: 1196 1196 1300
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04AD
@@ -9607,6 +11847,8 @@ Encoding: 1197 1197 1301
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04AE
@@ -9614,6 +11856,8 @@ Encoding: 1198 1198 1302
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04AF
@@ -9621,6 +11865,8 @@ Encoding: 1199 1199 1303
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B0
@@ -9628,6 +11874,8 @@ Encoding: 1200 1200 1304
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B1
@@ -9635,6 +11883,8 @@ Encoding: 1201 1201 1305
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B2
@@ -9642,6 +11892,8 @@ Encoding: 1202 1202 1306
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B3
@@ -9649,6 +11901,8 @@ Encoding: 1203 1203 1307
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B4
@@ -9656,6 +11910,8 @@ Encoding: 1204 1204 1308
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B5
@@ -9663,6 +11919,8 @@ Encoding: 1205 1205 1309
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B6
@@ -9670,6 +11928,8 @@ Encoding: 1206 1206 1310
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B7
@@ -9677,6 +11937,8 @@ Encoding: 1207 1207 1311
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B8
@@ -9684,6 +11946,8 @@ Encoding: 1208 1208 1312
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04B9
@@ -9691,6 +11955,8 @@ Encoding: 1209 1209 1313
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04BA
@@ -9698,6 +11964,8 @@ Encoding: 1210 1210 1314
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04BB
@@ -9705,6 +11973,8 @@ Encoding: 1211 1211 1315
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04BC
@@ -9712,6 +11982,8 @@ Encoding: 1212 1212 1316
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04BD
@@ -9719,6 +11991,8 @@ Encoding: 1213 1213 1317
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04BE
@@ -9726,6 +12000,8 @@ Encoding: 1214 1214 1318
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04BF
@@ -9733,6 +12009,8 @@ Encoding: 1215 1215 1319
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C0
@@ -9740,6 +12018,8 @@ Encoding: 1216 1216 1320
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C1
@@ -9747,6 +12027,8 @@ Encoding: 1217 1217 1321
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C2
@@ -9754,6 +12036,8 @@ Encoding: 1218 1218 1322
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C3
@@ -9761,6 +12045,8 @@ Encoding: 1219 1219 1323
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C4
@@ -9768,6 +12054,8 @@ Encoding: 1220 1220 1324
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C5
@@ -9775,6 +12063,8 @@ Encoding: 1221 1221 1325
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C6
@@ -9782,6 +12072,8 @@ Encoding: 1222 1222 1326
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C7
@@ -9789,6 +12081,8 @@ Encoding: 1223 1223 1327
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C8
@@ -9796,6 +12090,8 @@ Encoding: 1224 1224 1328
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04C9
@@ -9803,6 +12099,8 @@ Encoding: 1225 1225 1329
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04CA
@@ -9810,6 +12108,8 @@ Encoding: 1226 1226 1330
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04CB
@@ -9817,6 +12117,8 @@ Encoding: 1227 1227 1331
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04CC
@@ -9824,6 +12126,8 @@ Encoding: 1228 1228 1332
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04CD
@@ -9831,6 +12135,8 @@ Encoding: 1229 1229 1333
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04CE
@@ -9838,6 +12144,8 @@ Encoding: 1230 1230 1334
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04CF
@@ -9845,6 +12153,8 @@ Encoding: 1231 1231 1335
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D0
@@ -9852,6 +12162,8 @@ Encoding: 1232 1232 1336
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D1
@@ -9859,6 +12171,8 @@ Encoding: 1233 1233 1337
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D2
@@ -9866,6 +12180,8 @@ Encoding: 1234 1234 1338
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D3
@@ -9873,6 +12189,8 @@ Encoding: 1235 1235 1339
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D4
@@ -9880,6 +12198,8 @@ Encoding: 1236 1236 1340
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D5
@@ -9887,6 +12207,8 @@ Encoding: 1237 1237 1341
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D6
@@ -9894,6 +12216,8 @@ Encoding: 1238 1238 1342
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D7
@@ -9901,6 +12225,8 @@ Encoding: 1239 1239 1343
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04D8
@@ -9908,6 +12234,8 @@ Encoding: 1240 1240 1344
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii10846
@@ -9915,6 +12243,8 @@ Encoding: 1241 1241 1345
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04DA
@@ -9922,6 +12252,8 @@ Encoding: 1242 1242 1346
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04DB
@@ -9929,6 +12261,8 @@ Encoding: 1243 1243 1347
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04DC
@@ -9936,6 +12270,8 @@ Encoding: 1244 1244 1348
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04DD
@@ -9943,6 +12279,8 @@ Encoding: 1245 1245 1349
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04DE
@@ -9950,6 +12288,8 @@ Encoding: 1246 1246 1350
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04DF
@@ -9957,6 +12297,8 @@ Encoding: 1247 1247 1351
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E0
@@ -9964,6 +12306,8 @@ Encoding: 1248 1248 1352
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E1
@@ -9971,6 +12315,8 @@ Encoding: 1249 1249 1353
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E2
@@ -9978,6 +12324,8 @@ Encoding: 1250 1250 1354
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E3
@@ -9985,6 +12333,8 @@ Encoding: 1251 1251 1355
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E4
@@ -9992,6 +12342,8 @@ Encoding: 1252 1252 1356
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E5
@@ -9999,6 +12351,8 @@ Encoding: 1253 1253 1357
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E6
@@ -10006,6 +12360,8 @@ Encoding: 1254 1254 1358
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E7
@@ -10013,6 +12369,8 @@ Encoding: 1255 1255 1359
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E8
@@ -10020,6 +12378,8 @@ Encoding: 1256 1256 1360
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04E9
@@ -10027,6 +12387,8 @@ Encoding: 1257 1257 1361
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04EA
@@ -10034,6 +12396,8 @@ Encoding: 1258 1258 1362
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04EB
@@ -10041,6 +12405,8 @@ Encoding: 1259 1259 1363
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04EC
@@ -10048,6 +12414,8 @@ Encoding: 1260 1260 1364
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04ED
@@ -10055,6 +12423,8 @@ Encoding: 1261 1261 1365
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04EE
@@ -10062,6 +12432,8 @@ Encoding: 1262 1262 1366
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04EF
@@ -10069,6 +12441,8 @@ Encoding: 1263 1263 1367
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F0
@@ -10076,6 +12450,8 @@ Encoding: 1264 1264 1368
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F1
@@ -10083,6 +12459,8 @@ Encoding: 1265 1265 1369
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F2
@@ -10090,6 +12468,8 @@ Encoding: 1266 1266 1370
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F3
@@ -10097,6 +12477,8 @@ Encoding: 1267 1267 1371
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F4
@@ -10104,6 +12486,8 @@ Encoding: 1268 1268 1372
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F5
@@ -10111,6 +12495,8 @@ Encoding: 1269 1269 1373
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F6
@@ -10118,6 +12504,8 @@ Encoding: 1270 1270 1374
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F7
@@ -10125,6 +12513,8 @@ Encoding: 1271 1271 1375
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F8
@@ -10132,6 +12522,8 @@ Encoding: 1272 1272 1376
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04F9
@@ -10139,6 +12531,8 @@ Encoding: 1273 1273 1377
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04FA
@@ -10146,6 +12540,8 @@ Encoding: 1274 1274 1378
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04FB
@@ -10153,6 +12549,8 @@ Encoding: 1275 1275 1379
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04FC
@@ -10160,6 +12558,8 @@ Encoding: 1276 1276 1380
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04FD
@@ -10167,6 +12567,8 @@ Encoding: 1277 1277 1381
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04FE
@@ -10174,6 +12576,8 @@ Encoding: 1278 1278 1382
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni04FF
@@ -10181,6 +12585,8 @@ Encoding: 1279 1279 1383
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0500
@@ -10188,6 +12594,8 @@ Encoding: 1280 1280 1384
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0501
@@ -10195,6 +12603,8 @@ Encoding: 1281 1281 1385
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0502
@@ -10202,6 +12612,8 @@ Encoding: 1282 1282 1386
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0503
@@ -10209,6 +12621,8 @@ Encoding: 1283 1283 1387
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0504
@@ -10216,6 +12630,8 @@ Encoding: 1284 1284 1388
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0505
@@ -10223,6 +12639,8 @@ Encoding: 1285 1285 1389
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0506
@@ -10230,6 +12648,8 @@ Encoding: 1286 1286 1390
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0507
@@ -10237,6 +12657,8 @@ Encoding: 1287 1287 1391
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0508
@@ -10244,6 +12666,8 @@ Encoding: 1288 1288 1392
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0509
@@ -10251,6 +12675,8 @@ Encoding: 1289 1289 1393
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni050A
@@ -10258,6 +12684,8 @@ Encoding: 1290 1290 1394
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni050B
@@ -10265,6 +12693,8 @@ Encoding: 1291 1291 1395
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni050C
@@ -10272,6 +12702,8 @@ Encoding: 1292 1292 1396
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni050D
@@ -10279,6 +12711,8 @@ Encoding: 1293 1293 1397
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni050E
@@ -10286,6 +12720,8 @@ Encoding: 1294 1294 1398
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni050F
@@ -10293,6 +12729,8 @@ Encoding: 1295 1295 1399
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0510
@@ -10300,6 +12738,8 @@ Encoding: 1296 1296 1400
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0511
@@ -10307,6 +12747,8 @@ Encoding: 1297 1297 1401
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0512
@@ -10314,6 +12756,8 @@ Encoding: 1298 1298 1402
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0513
@@ -10321,6 +12765,8 @@ Encoding: 1299 1299 1403
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0514
@@ -10328,6 +12774,8 @@ Encoding: 1300 1300 1404
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0515
@@ -10335,6 +12783,8 @@ Encoding: 1301 1301 1405
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0516
@@ -10342,6 +12792,8 @@ Encoding: 1302 1302 1406
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0517
@@ -10349,6 +12801,8 @@ Encoding: 1303 1303 1407
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0518
@@ -10356,6 +12810,8 @@ Encoding: 1304 1304 1408
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0519
@@ -10363,6 +12819,8 @@ Encoding: 1305 1305 1409
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni051A
@@ -10370,6 +12828,8 @@ Encoding: 1306 1306 1410
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni051B
@@ -10377,6 +12837,8 @@ Encoding: 1307 1307 1411
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni051C
@@ -10384,6 +12846,8 @@ Encoding: 1308 1308 1412
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni051D
@@ -10391,6 +12855,8 @@ Encoding: 1309 1309 1413
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni051E
@@ -10398,6 +12864,8 @@ Encoding: 1310 1310 1414
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni051F
@@ -10405,6 +12873,8 @@ Encoding: 1311 1311 1415
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0520
@@ -10412,6 +12882,8 @@ Encoding: 1312 1312 1416
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0521
@@ -10419,6 +12891,8 @@ Encoding: 1313 1313 1417
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0522
@@ -10426,6 +12900,8 @@ Encoding: 1314 1314 1418
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0523
@@ -10433,6 +12909,8 @@ Encoding: 1315 1315 1419
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0524
@@ -10440,6 +12918,8 @@ Encoding: 1316 1316 1420
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0525
@@ -10447,6 +12927,8 @@ Encoding: 1317 1317 1421
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0526
@@ -10454,6 +12936,8 @@ Encoding: 1318 1318 1422
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0527
@@ -10461,6 +12945,8 @@ Encoding: 1319 1319 1423
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0528
@@ -10468,6 +12954,8 @@ Encoding: 1320 1320 1424
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0529
@@ -10475,6 +12963,8 @@ Encoding: 1321 1321 1425
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni052A
@@ -10482,6 +12972,8 @@ Encoding: 1322 1322 1426
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni052B
@@ -10489,6 +12981,8 @@ Encoding: 1323 1323 1427
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni052C
@@ -10496,6 +12990,8 @@ Encoding: 1324 1324 1428
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni052D
@@ -10503,6 +12999,8 @@ Encoding: 1325 1325 1429
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni052E
@@ -10510,6 +13008,8 @@ Encoding: 1326 1326 1430
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni052F
@@ -10517,6 +13017,8 @@ Encoding: 1327 1327 1431
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2603
@@ -10524,6 +13026,8 @@ Encoding: 9731 9731 1432
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni26B8
@@ -10531,6 +13035,8 @@ Encoding: 9912 9912 1433
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE737
@@ -10538,6 +13044,8 @@ Encoding: 59191 59191 1434
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE738
@@ -10545,6 +13053,8 @@ Encoding: 59192 59192 1435
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE768
@@ -10552,6 +13062,8 @@ Encoding: 59240 59240 1436
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE769
@@ -10559,6 +13071,8 @@ Encoding: 59241 59241 1437
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE76A
@@ -10566,6 +13080,8 @@ Encoding: 59242 59242 1438
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE791
@@ -10573,6 +13089,8 @@ Encoding: 59281 59281 1439
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE798
@@ -10580,6 +13098,8 @@ Encoding: 59288 59288 1440
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7A7
@@ -10587,6 +13107,8 @@ Encoding: 59303 59303 1441
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE5FB
@@ -10594,6 +13116,8 @@ Encoding: 58875 58875 1442
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE62C
@@ -10601,6 +13125,8 @@ Encoding: 58924 58924 1443
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE62D
@@ -10608,6 +13134,8 @@ Encoding: 58925 58925 1444
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE706
@@ -10615,6 +13143,8 @@ Encoding: 59142 59142 1445
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE707
@@ -10622,6 +13152,8 @@ Encoding: 59143 59143 1446
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE70F
@@ -10629,6 +13161,8 @@ Encoding: 59151 59151 1447
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE718
@@ -10636,6 +13170,8 @@ Encoding: 59160 59160 1448
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE728
@@ -10643,6 +13179,8 @@ Encoding: 59176 59176 1449
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7A8
@@ -10651,6 +13189,8 @@ Width: 1024
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7B4
@@ -10658,6 +13198,8 @@ Encoding: 59316 59316 1451
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7B8
@@ -10665,6 +13207,8 @@ Encoding: 59320 59320 1452
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7BA
@@ -10672,6 +13216,8 @@ Encoding: 59322 59322 1453
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7C5
@@ -10679,6 +13225,8 @@ Encoding: 59333 59333 1454
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF001
@@ -10686,6 +13234,8 @@ Encoding: 61441 61441 1455
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF008
@@ -10693,6 +13243,8 @@ Encoding: 61448 61448 1456
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF02D
@@ -10700,6 +13252,8 @@ Encoding: 61485 61485 1457
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF075
@@ -10707,6 +13261,8 @@ Encoding: 61557 61557 1458
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0C5
@@ -10714,6 +13270,8 @@ Encoding: 61637 61637 1459
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF108
@@ -10721,6 +13279,8 @@ Encoding: 61704 61704 1460
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF155
@@ -10728,6 +13288,8 @@ Encoding: 61781 61781 1461
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF187
@@ -10735,6 +13297,8 @@ Encoding: 61831 61831 1462
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1EA
@@ -10742,6 +13306,8 @@ Encoding: 61930 61930 1463
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF308
@@ -10750,6 +13316,8 @@ Width: 1024
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF401
@@ -10758,6 +13326,8 @@ Width: 1024
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF42B
@@ -10765,6 +13335,8 @@ Encoding: 62507 62507 1466
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF447
@@ -10772,6 +13344,8 @@ Encoding: 62535 62535 1467
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF498
@@ -10779,6 +13353,8 @@ Encoding: 62616 62616 1468
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF81A
@@ -10786,6 +13362,8 @@ Encoding: 63514 63514 1469
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21E0
@@ -10793,6 +13371,8 @@ Encoding: 8672 8672 1470
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21E1
@@ -10800,6 +13380,8 @@ Encoding: 8673 8673 1471
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21E2
@@ -10807,6 +13389,8 @@ Encoding: 8674 8674 1472
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21E3
@@ -10814,6 +13398,8 @@ Encoding: 8675 8675 1473
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2601
@@ -10821,6 +13407,8 @@ Encoding: 9729 9729 1474
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2615
@@ -10828,6 +13416,8 @@ Encoding: 9749 9749 1475
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2638
@@ -10835,6 +13425,8 @@ Encoding: 9784 9784 1476
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2699
@@ -10842,6 +13434,8 @@ Encoding: 9881 9881 1477
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni26A0
@@ -10849,6 +13443,8 @@ Encoding: 9888 9888 1478
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2726
@@ -10856,6 +13452,8 @@ Encoding: 10022 10022 1479
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni276F
@@ -10863,6 +13461,8 @@ Encoding: 10095 10095 1480
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni276E
@@ -10870,6 +13470,8 @@ Encoding: 10094 10094 1481
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni279C
@@ -10877,6 +13479,8 @@ Encoding: 10140 10140 1482
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni27EA
@@ -10884,6 +13488,8 @@ Encoding: 10218 10218 1483
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni27EB
@@ -10891,6 +13497,8 @@ Encoding: 10219 10219 1484
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni27E8
@@ -10898,6 +13506,8 @@ Encoding: 10216 10216 1485
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni27E9
@@ -10905,6 +13515,8 @@ Encoding: 10217 10217 1486
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B22
@@ -10912,6 +13524,8 @@ Encoding: 11042 11042 1487
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE777
@@ -10919,6 +13533,8 @@ Encoding: 59255 59255 1488
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F333
@@ -10926,6 +13542,8 @@ Encoding: 127795 127795 1489
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F439
@@ -10933,6 +13551,8 @@ Encoding: 128057 128057 1490
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F40F
@@ -10940,6 +13560,8 @@ Encoding: 128015 128015 1491
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F52E
@@ -10947,13 +13569,17 @@ Encoding: 128302 128302 1492
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4E6
 Encoding: 128230 128230 1493
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F418
@@ -10961,6 +13587,8 @@ Encoding: 128024 128024 1494
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F40D
@@ -10968,6 +13596,8 @@ Encoding: 128013 128013 1495
 Width: 1890
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F48E
@@ -10975,13 +13605,17 @@ Encoding: 128142 128142 1496
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F980
 Encoding: 129408 129408 1497
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4A0
@@ -10989,6 +13623,8 @@ Encoding: 128160 128160 1498
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2164
@@ -10996,6 +13632,8 @@ Encoding: 8548 8548 1499
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: carriagereturn
@@ -11003,6 +13641,8 @@ Encoding: 8629 8629 1500
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: equivalence
@@ -11010,6 +13650,8 @@ Encoding: 8801 8801 1501
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: house
@@ -11017,6 +13659,8 @@ Encoding: 8962 8962 1502
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2318
@@ -11024,6 +13668,8 @@ Encoding: 8984 8984 1503
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni235F
@@ -11031,6 +13677,8 @@ Encoding: 9055 9055 1504
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2388
@@ -11038,6 +13686,8 @@ Encoding: 9096 9096 1505
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: H22073
@@ -11045,6 +13695,8 @@ Encoding: 9633 9633 1506
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: filledbox
@@ -11052,6 +13704,8 @@ Encoding: 9632 9632 1507
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: triagup
@@ -11059,6 +13713,8 @@ Encoding: 9650 9650 1508
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: triagdn
@@ -11066,6 +13722,8 @@ Encoding: 9660 9660 1509
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: circle
@@ -11073,6 +13731,8 @@ Encoding: 9675 9675 1510
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2610
@@ -11080,6 +13740,8 @@ Encoding: 9744 9744 1511
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2611
@@ -11087,6 +13749,8 @@ Encoding: 9745 9745 1512
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2612
@@ -11094,6 +13758,8 @@ Encoding: 9746 9746 1513
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni263F
@@ -11101,6 +13767,8 @@ Encoding: 9791 9791 1514
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni274E
@@ -11108,6 +13776,8 @@ Encoding: 10062 10062 1515
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2B50
@@ -11115,6 +13785,8 @@ Encoding: 11088 11088 1516
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0D4
@@ -11122,6 +13794,8 @@ Encoding: 57556 57556 1517
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0D2
@@ -11129,6 +13803,8 @@ Encoding: 57554 57554 1518
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B6
@@ -11136,6 +13812,8 @@ Encoding: 57526 57526 1519
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B7
@@ -11143,6 +13821,8 @@ Encoding: 57527 57527 1520
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0BA
@@ -11150,6 +13830,8 @@ Encoding: 57530 57530 1521
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B8
@@ -11157,6 +13839,8 @@ Encoding: 57528 57528 1522
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0B9
@@ -11164,6 +13848,8 @@ Encoding: 57529 57529 1523
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0BF
@@ -11171,6 +13857,8 @@ Encoding: 57535 57535 1524
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0BB
@@ -11178,6 +13866,8 @@ Encoding: 57531 57531 1525
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0BC
@@ -11185,6 +13875,8 @@ Encoding: 57532 57532 1526
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0BD
@@ -11192,6 +13884,8 @@ Encoding: 57533 57533 1527
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE0BE
@@ -11199,6 +13893,8 @@ Encoding: 57534 57534 1528
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE626
@@ -11206,6 +13902,8 @@ Encoding: 58918 58918 1529
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE755
@@ -11213,6 +13911,8 @@ Encoding: 59221 59221 1530
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE703
@@ -11220,6 +13920,8 @@ Encoding: 59139 59139 1531
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE729
@@ -11227,6 +13929,8 @@ Encoding: 59177 59177 1532
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F6E1
@@ -11234,6 +13938,8 @@ Encoding: 128737 128737 1533
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F608
@@ -11241,6 +13947,8 @@ Encoding: 128520 128520 1534
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F50B
@@ -11248,6 +13956,8 @@ Encoding: 128267 128267 1535
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F448
@@ -11255,6 +13965,8 @@ Encoding: 128072 128072 1536
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F447
@@ -11262,6 +13974,8 @@ Encoding: 128071 128071 1537
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F331
@@ -11269,6 +13983,8 @@ Encoding: 127793 127793 1538
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F31E
@@ -11276,6 +13992,8 @@ Encoding: 127774 127774 1539
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFBF1
@@ -11283,6 +14001,8 @@ Encoding: 64497 64497 1540
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF7B7
@@ -11290,6 +14010,8 @@ Encoding: 63415 63415 1541
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD03
@@ -11297,6 +14019,8 @@ Encoding: 64771 64771 1542
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF4A0
@@ -11304,6 +14028,8 @@ Encoding: 62624 62624 1543
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF49B
@@ -11311,6 +14037,8 @@ Encoding: 62619 62619 1544
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF489
@@ -11318,6 +14046,8 @@ Encoding: 62601 62601 1545
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF464
@@ -11325,6 +14055,8 @@ Encoding: 62564 62564 1546
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF461
@@ -11332,6 +14064,8 @@ Encoding: 62561 62561 1547
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF31B
@@ -11340,6 +14074,8 @@ Width: 1024
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE72D
@@ -11347,6 +14083,8 @@ Encoding: 59181 59181 1549
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE73F
@@ -11354,6 +14092,8 @@ Encoding: 59199 59199 1550
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE757
@@ -11361,6 +14101,8 @@ Encoding: 59223 59223 1551
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE756
@@ -11368,6 +14110,8 @@ Encoding: 59222 59222 1552
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE76E
@@ -11375,6 +14119,8 @@ Encoding: 59246 59246 1553
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE77F
@@ -11382,6 +14128,8 @@ Encoding: 59263 59263 1554
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFA7D
@@ -11389,6 +14137,8 @@ Encoding: 64125 64125 1555
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE244
@@ -11396,6 +14146,8 @@ Encoding: 57924 57924 1556
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF318
@@ -11403,6 +14155,8 @@ Encoding: 62232 62232 1557
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF319
@@ -11410,6 +14164,8 @@ Encoding: 62233 62233 1558
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF31C
@@ -11417,6 +14173,8 @@ Encoding: 62236 62236 1559
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF317
@@ -11424,6 +14182,8 @@ Encoding: 62231 62231 1560
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF00B
@@ -11431,6 +14191,8 @@ Encoding: 61451 61451 1561
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF00C
@@ -11438,6 +14200,8 @@ Encoding: 61452 61452 1562
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF00D
@@ -11445,6 +14209,8 @@ Encoding: 61453 61453 1563
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF013
@@ -11452,6 +14218,8 @@ Encoding: 61459 61459 1564
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF015
@@ -11459,6 +14227,8 @@ Encoding: 61461 61461 1565
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF01A
@@ -11466,6 +14236,8 @@ Encoding: 61466 61466 1566
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF01B
@@ -11473,6 +14245,8 @@ Encoding: 61467 61467 1567
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF01C
@@ -11480,6 +14254,8 @@ Encoding: 61468 61468 1568
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF023
@@ -11487,6 +14263,8 @@ Encoding: 61475 61475 1569
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF02B
@@ -11494,6 +14272,8 @@ Encoding: 61483 61483 1570
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF055
@@ -11501,6 +14281,8 @@ Encoding: 61525 61525 1571
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF056
@@ -11508,6 +14290,8 @@ Encoding: 61526 61526 1572
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF057
@@ -11515,6 +14299,8 @@ Encoding: 61527 61527 1573
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF058
@@ -11522,6 +14308,8 @@ Encoding: 61528 61528 1574
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF059
@@ -11529,6 +14317,8 @@ Encoding: 61529 61529 1575
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF05A
@@ -11536,6 +14326,8 @@ Encoding: 61530 61530 1576
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF06A
@@ -11543,6 +14335,8 @@ Encoding: 61546 61546 1577
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF073
@@ -11550,6 +14344,8 @@ Encoding: 61555 61555 1578
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF07B
@@ -11557,6 +14353,8 @@ Encoding: 61563 61563 1579
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF07C
@@ -11564,6 +14362,8 @@ Encoding: 61564 61564 1580
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF09C
@@ -11571,6 +14371,8 @@ Encoding: 61596 61596 1581
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0A0
@@ -11578,6 +14380,8 @@ Encoding: 61600 61600 1582
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0AE
@@ -11586,6 +14390,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0C3
@@ -11594,6 +14400,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0E4
@@ -11602,6 +14410,8 @@ Width: 945
 VWidth: 0
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni272D
@@ -11609,6 +14419,8 @@ Encoding: 10029 10029 1586
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2739
@@ -11616,6 +14428,8 @@ Encoding: 10041 10041 1587
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF113
@@ -11623,6 +14437,8 @@ Encoding: 61715 61715 1588
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF114
@@ -11630,6 +14446,8 @@ Encoding: 61716 61716 1589
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF115
@@ -11637,6 +14455,8 @@ Encoding: 61717 61717 1590
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF126
@@ -11644,6 +14464,8 @@ Encoding: 61734 61734 1591
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF16B
@@ -11651,6 +14473,8 @@ Encoding: 61803 61803 1592
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF17A
@@ -11658,6 +14482,8 @@ Encoding: 61818 61818 1593
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF17B
@@ -11665,6 +14491,8 @@ Encoding: 61819 61819 1594
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF185
@@ -11672,6 +14500,8 @@ Encoding: 61829 61829 1595
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF188
@@ -11679,6 +14509,8 @@ Encoding: 61832 61832 1596
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1BB
@@ -11686,6 +14518,8 @@ Encoding: 61883 61883 1597
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1BD
@@ -11693,6 +14527,8 @@ Encoding: 61885 61885 1598
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1D3
@@ -11700,6 +14536,8 @@ Encoding: 61907 61907 1599
 Width: 945
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF219
@@ -11707,6 +14545,8 @@ Encoding: 61977 61977 1600
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF250
@@ -11714,6 +14554,8 @@ Encoding: 62032 62032 1601
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF251
@@ -11721,6 +14563,8 @@ Encoding: 62033 62033 1602
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF252
@@ -11728,6 +14572,8 @@ Encoding: 62034 62034 1603
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF253
@@ -11735,6 +14581,8 @@ Encoding: 62035 62035 1604
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF254
@@ -11742,6 +14590,8 @@ Encoding: 62036 62036 1605
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF270
@@ -11749,6 +14599,8 @@ Encoding: 62064 62064 1606
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF296
@@ -11756,6 +14608,8 @@ Encoding: 62102 62102 1607
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF300
@@ -11763,6 +14617,8 @@ Encoding: 62208 62208 1608
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF301
@@ -11770,6 +14626,8 @@ Encoding: 62209 62209 1609
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF304
@@ -11777,6 +14635,8 @@ Encoding: 62212 62212 1610
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF305
@@ -11784,6 +14644,8 @@ Encoding: 62213 62213 1611
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF306
@@ -11791,6 +14653,8 @@ Encoding: 62214 62214 1612
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF307
@@ -11798,6 +14662,8 @@ Encoding: 62215 62215 1613
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF309
@@ -11805,6 +14671,8 @@ Encoding: 62217 62217 1614
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF30A
@@ -11812,6 +14680,8 @@ Encoding: 62218 62218 1615
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF30C
@@ -11819,6 +14689,8 @@ Encoding: 62220 62220 1616
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF30D
@@ -11826,6 +14698,8 @@ Encoding: 62221 62221 1617
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF30E
@@ -11833,6 +14707,8 @@ Encoding: 62222 62222 1618
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF310
@@ -11840,6 +14716,8 @@ Encoding: 62224 62224 1619
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF312
@@ -11847,6 +14725,8 @@ Encoding: 62226 62226 1620
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF313
@@ -11854,6 +14734,8 @@ Encoding: 62227 62227 1621
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF314
@@ -11861,6 +14743,8 @@ Encoding: 62228 62228 1622
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: smileface
@@ -11868,6 +14752,8 @@ Encoding: 9786 9786 1623
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni266C
@@ -11875,6 +14761,8 @@ Encoding: 9836 9836 1624
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2669
@@ -11882,6 +14770,8 @@ Encoding: 9833 9833 1625
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: musicalnote
@@ -11889,6 +14779,8 @@ Encoding: 9834 9834 1626
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: musicalnotedbl
@@ -11896,6 +14788,8 @@ Encoding: 9835 9835 1627
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni266D
@@ -11903,6 +14797,8 @@ Encoding: 9837 9837 1628
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni266E
@@ -11910,6 +14806,8 @@ Encoding: 9838 9838 1629
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni266F
@@ -11917,6 +14815,8 @@ Encoding: 9839 9839 1630
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni20BD
@@ -11924,6 +14824,8 @@ Encoding: 8381 8381 1631
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE000
@@ -11931,6 +14833,8 @@ Encoding: 57344 57344 1632
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE001
@@ -11938,6 +14842,8 @@ Encoding: 57345 57345 1633
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE002
@@ -11945,6 +14851,8 @@ Encoding: 57346 57346 1634
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE003
@@ -11952,6 +14860,8 @@ Encoding: 57347 57347 1635
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE004
@@ -11959,6 +14869,8 @@ Encoding: 57348 57348 1636
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE005
@@ -11966,6 +14878,8 @@ Encoding: 57349 57349 1637
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE006
@@ -11973,6 +14887,8 @@ Encoding: 57350 57350 1638
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE007
@@ -11980,6 +14896,8 @@ Encoding: 57351 57351 1639
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE008
@@ -11987,6 +14905,8 @@ Encoding: 57352 57352 1640
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE009
@@ -11994,6 +14914,8 @@ Encoding: 57353 57353 1641
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE00A
@@ -12001,6 +14923,8 @@ Encoding: 57354 57354 1642
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Uogonek
@@ -12008,6 +14932,8 @@ Encoding: 370 370 1643
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uogonek
@@ -12015,6 +14941,8 @@ Encoding: 371 371 1644
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Wcircumflex
@@ -12022,6 +14950,8 @@ Encoding: 372 372 1645
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: wcircumflex
@@ -12029,6 +14959,8 @@ Encoding: 373 373 1646
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ycircumflex
@@ -12036,6 +14968,8 @@ Encoding: 374 374 1647
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ycircumflex
@@ -12043,6 +14977,8 @@ Encoding: 375 375 1648
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Tbar
@@ -12050,6 +14986,8 @@ Encoding: 358 358 1649
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: tbar
@@ -12057,6 +14995,8 @@ Encoding: 359 359 1650
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: radical
@@ -12064,6 +15004,8 @@ Encoding: 8730 8730 1651
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii61352
@@ -12071,6 +15013,8 @@ Encoding: 8470 8470 1652
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B3
@@ -12078,6 +15022,8 @@ Encoding: 8627 8627 1653
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B4
@@ -12085,6 +15031,8 @@ Encoding: 8628 8628 1654
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B2
@@ -12092,6 +15040,8 @@ Encoding: 8626 8626 1655
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B1
@@ -12099,6 +15049,8 @@ Encoding: 8625 8625 1656
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B0
@@ -12106,6 +15058,8 @@ Encoding: 8624 8624 1657
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF111
@@ -12113,6 +15067,8 @@ Encoding: 61713 61713 1658
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF067
@@ -12120,6 +15076,8 @@ Encoding: 61543 61543 1659
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF068
@@ -12127,6 +15085,8 @@ Encoding: 61544 61544 1660
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF069
@@ -12134,6 +15094,8 @@ Encoding: 61545 61545 1661
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF016
@@ -12141,6 +15103,8 @@ Encoding: 61462 61462 1662
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C5
@@ -12148,6 +15112,8 @@ Encoding: 61893 61893 1663
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF15B
@@ -12155,6 +15121,8 @@ Encoding: 61787 61787 1664
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF15C
@@ -12162,6 +15130,8 @@ Encoding: 61788 61788 1665
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C0
@@ -12169,6 +15139,8 @@ Encoding: 61888 61888 1666
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C4
@@ -12176,6 +15148,8 @@ Encoding: 61892 61892 1667
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C3
@@ -12183,6 +15157,8 @@ Encoding: 61891 61891 1668
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C6
@@ -12190,6 +15166,8 @@ Encoding: 61894 61894 1669
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF03D
@@ -12197,6 +15175,8 @@ Encoding: 61501 61501 1670
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniEFFA
@@ -12204,6 +15184,8 @@ Encoding: 61434 61434 1671
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniEFFB
@@ -12211,6 +15193,8 @@ Encoding: 61435 61435 1672
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniEFFC
@@ -12218,6 +15202,8 @@ Encoding: 61436 61436 1673
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniEFFD
@@ -12225,6 +15211,8 @@ Encoding: 61437 61437 1674
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF031
@@ -12232,6 +15220,8 @@ Encoding: 61489 61489 1675
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF032
@@ -12239,6 +15229,8 @@ Encoding: 61490 61490 1676
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF033
@@ -12246,6 +15238,8 @@ Encoding: 61491 61491 1677
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE271
@@ -12253,6 +15247,8 @@ Encoding: 57969 57969 1678
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE204
@@ -12260,6 +15256,8 @@ Encoding: 57860 57860 1679
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C2
@@ -12267,6 +15265,8 @@ Encoding: 61890 61890 1680
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1C1
@@ -12274,6 +15274,8 @@ Encoding: 61889 61889 1681
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF410
@@ -12281,6 +15283,8 @@ Encoding: 62480 62480 1682
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE71E
@@ -12288,6 +15292,8 @@ Encoding: 59166 59166 1683
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE21E
@@ -12295,6 +15301,8 @@ Encoding: 57886 57886 1684
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE256
@@ -12302,6 +15310,8 @@ Encoding: 57942 57942 1685
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE781
@@ -12309,6 +15319,8 @@ Encoding: 59265 59265 1686
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE74E
@@ -12316,6 +15328,8 @@ Encoding: 59214 59214 1687
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE70E
@@ -12323,6 +15337,8 @@ Encoding: 59150 59150 1688
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE749
@@ -12330,6 +15346,8 @@ Encoding: 59209 59209 1689
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE74A
@@ -12337,6 +15355,8 @@ Encoding: 59210 59210 1690
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF718
@@ -12344,6 +15364,8 @@ Encoding: 63256 63256 1691
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF713
@@ -12351,6 +15373,8 @@ Encoding: 63251 63251 1692
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE758
@@ -12358,6 +15382,8 @@ Encoding: 59224 59224 1693
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE759
@@ -12365,6 +15391,8 @@ Encoding: 59225 59225 1694
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE796
@@ -12372,6 +15400,8 @@ Encoding: 59286 59286 1695
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE64E
@@ -12379,6 +15409,8 @@ Encoding: 58958 58958 1696
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE681
@@ -12386,6 +15418,8 @@ Encoding: 59009 59009 1697
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF09E
@@ -12393,6 +15427,8 @@ Encoding: 61598 61598 1698
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF440
@@ -12400,6 +15436,8 @@ Encoding: 62528 62528 1699
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7C4
@@ -12407,6 +15445,8 @@ Encoding: 59332 59332 1700
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF034
@@ -12414,6 +15454,8 @@ Encoding: 61492 61492 1701
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF035
@@ -12421,6 +15463,8 @@ Encoding: 61493 61493 1702
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF481
@@ -12428,6 +15472,8 @@ Encoding: 62593 62593 1703
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF482
@@ -12435,6 +15481,8 @@ Encoding: 62594 62594 1704
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF298
@@ -12442,6 +15490,8 @@ Encoding: 62104 62104 1705
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE28B
@@ -12449,6 +15499,8 @@ Encoding: 57995 57995 1706
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE28A
@@ -12456,6 +15508,8 @@ Encoding: 57994 57994 1707
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7B5
@@ -12463,6 +15517,8 @@ Encoding: 59317 59317 1708
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE5FC
@@ -12470,6 +15526,8 @@ Encoding: 58876 58876 1709
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF408
@@ -12477,6 +15535,8 @@ Encoding: 62472 62472 1710
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF121
@@ -12484,6 +15544,8 @@ Encoding: 61729 61729 1711
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE62A
@@ -12491,6 +15553,8 @@ Encoding: 58922 58922 1712
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0250
@@ -12498,6 +15562,8 @@ Encoding: 592 592 1713
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0251
@@ -12505,6 +15571,8 @@ Encoding: 593 593 1714
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0252
@@ -12512,6 +15580,8 @@ Encoding: 594 594 1715
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0254
@@ -12519,6 +15589,8 @@ Encoding: 596 596 1716
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0255
@@ -12526,6 +15598,8 @@ Encoding: 597 597 1717
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0256
@@ -12533,6 +15607,8 @@ Encoding: 598 598 1718
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0257
@@ -12540,6 +15616,8 @@ Encoding: 599 599 1719
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0258
@@ -12547,6 +15625,8 @@ Encoding: 600 600 1720
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0259
@@ -12554,6 +15634,8 @@ Encoding: 601 601 1721
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni025A
@@ -12561,6 +15643,8 @@ Encoding: 602 602 1722
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni025B
@@ -12568,6 +15652,8 @@ Encoding: 603 603 1723
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni025C
@@ -12575,6 +15661,8 @@ Encoding: 604 604 1724
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni025D
@@ -12582,6 +15670,8 @@ Encoding: 605 605 1725
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni025E
@@ -12589,6 +15679,8 @@ Encoding: 606 606 1726
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni025F
@@ -12596,6 +15688,8 @@ Encoding: 607 607 1727
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0260
@@ -12603,6 +15697,8 @@ Encoding: 608 608 1728
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0261
@@ -12610,6 +15706,8 @@ Encoding: 609 609 1729
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0262
@@ -12617,6 +15715,8 @@ Encoding: 610 610 1730
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0263
@@ -12624,6 +15724,8 @@ Encoding: 611 611 1731
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0264
@@ -12631,6 +15733,8 @@ Encoding: 612 612 1732
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0265
@@ -12638,6 +15742,8 @@ Encoding: 613 613 1733
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0266
@@ -12645,6 +15751,8 @@ Encoding: 614 614 1734
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0267
@@ -12652,6 +15760,8 @@ Encoding: 615 615 1735
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0241
@@ -12659,6 +15769,8 @@ Encoding: 577 577 1736
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0242
@@ -12666,6 +15778,8 @@ Encoding: 578 578 1737
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0253
@@ -12673,6 +15787,8 @@ Encoding: 595 595 1738
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni026F
@@ -12680,6 +15796,8 @@ Encoding: 623 623 1739
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0270
@@ -12687,6 +15805,8 @@ Encoding: 624 624 1740
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0271
@@ -12694,6 +15814,8 @@ Encoding: 625 625 1741
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0272
@@ -12701,6 +15823,8 @@ Encoding: 626 626 1742
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0273
@@ -12708,6 +15832,8 @@ Encoding: 627 627 1743
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0274
@@ -12715,6 +15841,8 @@ Encoding: 628 628 1744
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0275
@@ -12722,6 +15850,8 @@ Encoding: 629 629 1745
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0276
@@ -12729,6 +15859,8 @@ Encoding: 630 630 1746
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0277
@@ -12736,6 +15868,8 @@ Encoding: 631 631 1747
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0278
@@ -12743,6 +15877,8 @@ Encoding: 632 632 1748
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0279
@@ -12750,6 +15886,8 @@ Encoding: 633 633 1749
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni027A
@@ -12757,6 +15895,8 @@ Encoding: 634 634 1750
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni027B
@@ -12764,6 +15904,8 @@ Encoding: 635 635 1751
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni027C
@@ -12771,6 +15913,8 @@ Encoding: 636 636 1752
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni027D
@@ -12778,6 +15922,8 @@ Encoding: 637 637 1753
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni027E
@@ -12785,6 +15931,8 @@ Encoding: 638 638 1754
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni027F
@@ -12792,6 +15940,8 @@ Encoding: 639 639 1755
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0280
@@ -12799,6 +15949,8 @@ Encoding: 640 640 1756
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0281
@@ -12806,6 +15958,8 @@ Encoding: 641 641 1757
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0282
@@ -12813,6 +15967,8 @@ Encoding: 642 642 1758
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0283
@@ -12820,6 +15976,8 @@ Encoding: 643 643 1759
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0289
@@ -12827,6 +15985,8 @@ Encoding: 649 649 1760
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni028A
@@ -12834,6 +15994,8 @@ Encoding: 650 650 1761
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni028B
@@ -12841,6 +16003,8 @@ Encoding: 651 651 1762
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni028C
@@ -12848,6 +16012,8 @@ Encoding: 652 652 1763
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni028D
@@ -12855,6 +16021,8 @@ Encoding: 653 653 1764
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni028F
@@ -12862,6 +16030,8 @@ Encoding: 655 655 1765
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0290
@@ -12869,6 +16039,8 @@ Encoding: 656 656 1766
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0291
@@ -12876,6 +16048,8 @@ Encoding: 657 657 1767
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0292
@@ -12883,6 +16057,8 @@ Encoding: 658 658 1768
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0293
@@ -12890,6 +16066,8 @@ Encoding: 659 659 1769
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0294
@@ -12897,6 +16075,8 @@ Encoding: 660 660 1770
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0295
@@ -12904,6 +16084,8 @@ Encoding: 661 661 1771
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0296
@@ -12911,6 +16093,8 @@ Encoding: 662 662 1772
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0299
@@ -12918,6 +16102,8 @@ Encoding: 665 665 1773
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni029A
@@ -12925,6 +16111,8 @@ Encoding: 666 666 1774
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni029B
@@ -12932,6 +16120,8 @@ Encoding: 667 667 1775
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni029C
@@ -12939,6 +16129,8 @@ Encoding: 668 668 1776
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni029D
@@ -12946,6 +16138,8 @@ Encoding: 669 669 1777
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni029F
@@ -12953,6 +16147,8 @@ Encoding: 671 671 1778
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni029E
@@ -12960,6 +16156,8 @@ Encoding: 670 670 1779
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni028E
@@ -12967,6 +16165,8 @@ Encoding: 654 654 1780
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni026A
@@ -12974,6 +16174,8 @@ Encoding: 618 618 1781
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0268
@@ -12981,6 +16183,8 @@ Encoding: 616 616 1782
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0269
@@ -12988,6 +16192,8 @@ Encoding: 617 617 1783
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni026B
@@ -12995,6 +16201,8 @@ Encoding: 619 619 1784
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni026C
@@ -13002,6 +16210,8 @@ Encoding: 620 620 1785
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni026D
@@ -13009,6 +16219,8 @@ Encoding: 621 621 1786
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni026E
@@ -13016,6 +16228,8 @@ Encoding: 622 622 1787
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0286
@@ -13023,6 +16237,8 @@ Encoding: 646 646 1788
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0288
@@ -13030,6 +16246,8 @@ Encoding: 648 648 1789
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0287
@@ -13037,6 +16255,8 @@ Encoding: 647 647 1790
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0285
@@ -13044,6 +16264,8 @@ Encoding: 645 645 1791
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0284
@@ -13051,6 +16273,8 @@ Encoding: 644 644 1792
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0297
@@ -13058,6 +16282,8 @@ Encoding: 663 663 1793
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0298
@@ -13065,6 +16291,8 @@ Encoding: 664 664 1794
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02A1
@@ -13072,6 +16300,8 @@ Encoding: 673 673 1795
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02A2
@@ -13079,6 +16309,8 @@ Encoding: 674 674 1796
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02A0
@@ -13086,6 +16318,8 @@ Encoding: 672 672 1797
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: epsilontonos
@@ -13093,6 +16327,8 @@ Encoding: 941 941 1798
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: etatonos
@@ -13100,6 +16336,8 @@ Encoding: 942 942 1799
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: iotatonos
@@ -13107,6 +16345,8 @@ Encoding: 943 943 1800
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: upsilondieresistonos
@@ -13114,6 +16354,8 @@ Encoding: 944 944 1801
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: upsilondieresis
@@ -13121,6 +16363,8 @@ Encoding: 971 971 1802
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: iotadieresis
@@ -13128,6 +16372,8 @@ Encoding: 970 970 1803
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: omicrontonos
@@ -13135,6 +16381,8 @@ Encoding: 972 972 1804
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: upsilontonos
@@ -13142,6 +16390,8 @@ Encoding: 973 973 1805
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: omegatonos
@@ -13149,6 +16399,8 @@ Encoding: 974 974 1806
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Alphatonos
@@ -13156,6 +16408,8 @@ Encoding: 902 902 1807
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Epsilontonos
@@ -13163,6 +16417,8 @@ Encoding: 904 904 1808
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Etatonos
@@ -13170,6 +16426,8 @@ Encoding: 905 905 1809
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Iotatonos
@@ -13177,6 +16435,8 @@ Encoding: 906 906 1810
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Omicrontonos
@@ -13184,6 +16444,8 @@ Encoding: 908 908 1811
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Upsilontonos
@@ -13191,6 +16453,8 @@ Encoding: 910 910 1812
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Omegatonos
@@ -13198,6 +16462,8 @@ Encoding: 911 911 1813
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: iotadieresistonos
@@ -13205,6 +16471,8 @@ Encoding: 912 912 1814
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: phi1
@@ -13212,6 +16480,8 @@ Encoding: 981 981 1815
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03F4
@@ -13219,6 +16489,8 @@ Encoding: 1012 1012 1816
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03F8
@@ -13226,6 +16498,8 @@ Encoding: 1016 1016 1817
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03F7
@@ -13233,6 +16507,8 @@ Encoding: 1015 1015 1818
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03F9
@@ -13240,6 +16516,8 @@ Encoding: 1017 1017 1819
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03DB
@@ -13247,6 +16525,8 @@ Encoding: 987 987 1820
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03DA
@@ -13254,6 +16534,8 @@ Encoding: 986 986 1821
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03DC
@@ -13261,6 +16543,8 @@ Encoding: 988 988 1822
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni03DD
@@ -13268,6 +16552,8 @@ Encoding: 989 989 1823
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: aeacute
@@ -13275,6 +16561,8 @@ Encoding: 509 509 1824
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: AEacute
@@ -13282,6 +16570,8 @@ Encoding: 508 508 1825
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: oslashacute
@@ -13289,6 +16579,8 @@ Encoding: 511 511 1826
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Oslashacute
@@ -13296,6 +16588,8 @@ Encoding: 510 510 1827
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni018F
@@ -13303,6 +16597,8 @@ Encoding: 399 399 1828
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni018E
@@ -13310,6 +16606,8 @@ Encoding: 398 398 1829
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0191
@@ -13317,6 +16615,8 @@ Encoding: 401 401 1830
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni019C
@@ -13324,6 +16624,8 @@ Encoding: 412 412 1831
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni019E
@@ -13331,6 +16633,8 @@ Encoding: 414 414 1832
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni019D
@@ -13338,6 +16642,8 @@ Encoding: 413 413 1833
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni019F
@@ -13345,6 +16651,8 @@ Encoding: 415 415 1834
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ohorn
@@ -13352,6 +16660,8 @@ Encoding: 416 416 1835
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ohorn
@@ -13359,6 +16669,8 @@ Encoding: 417 417 1836
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A2
@@ -13366,6 +16678,8 @@ Encoding: 418 418 1837
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A3
@@ -13373,6 +16687,8 @@ Encoding: 419 419 1838
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A4
@@ -13380,6 +16696,8 @@ Encoding: 420 420 1839
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A5
@@ -13387,6 +16705,8 @@ Encoding: 421 421 1840
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B1
@@ -13394,6 +16714,8 @@ Encoding: 433 433 1841
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B2
@@ -13401,6 +16723,8 @@ Encoding: 434 434 1842
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B3
@@ -13408,6 +16732,8 @@ Encoding: 435 435 1843
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B4
@@ -13415,6 +16741,8 @@ Encoding: 436 436 1844
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B5
@@ -13422,6 +16750,8 @@ Encoding: 437 437 1845
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B6
@@ -13429,6 +16759,8 @@ Encoding: 438 438 1846
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B7
@@ -13436,6 +16768,8 @@ Encoding: 439 439 1847
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B8
@@ -13443,6 +16777,8 @@ Encoding: 440 440 1848
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01B9
@@ -13450,6 +16786,8 @@ Encoding: 441 441 1849
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01BA
@@ -13457,6 +16795,8 @@ Encoding: 442 442 1850
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01C2
@@ -13464,6 +16804,8 @@ Encoding: 450 450 1851
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01C1
@@ -13471,6 +16813,8 @@ Encoding: 449 449 1852
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01C0
@@ -13478,6 +16822,8 @@ Encoding: 448 448 1853
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01BE
@@ -13485,6 +16831,8 @@ Encoding: 446 446 1854
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF48A
@@ -13492,6 +16840,8 @@ Encoding: 62602 62602 1855
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFABF
@@ -13499,6 +16849,8 @@ Encoding: 64191 64191 1856
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2080
@@ -13506,6 +16858,8 @@ Encoding: 8320 8320 1857
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2084
@@ -13513,6 +16867,8 @@ Encoding: 8324 8324 1858
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2085
@@ -13520,6 +16876,8 @@ Encoding: 8325 8325 1859
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2086
@@ -13527,6 +16885,8 @@ Encoding: 8326 8326 1860
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2087
@@ -13534,6 +16894,8 @@ Encoding: 8327 8327 1861
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2088
@@ -13541,6 +16903,8 @@ Encoding: 8328 8328 1862
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2089
@@ -13548,6 +16912,8 @@ Encoding: 8329 8329 1863
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2082
@@ -13555,6 +16921,8 @@ Encoding: 8322 8322 1864
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2083
@@ -13562,6 +16930,8 @@ Encoding: 8323 8323 1865
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni207A
@@ -13569,6 +16939,8 @@ Encoding: 8314 8314 1866
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni207B
@@ -13576,6 +16948,8 @@ Encoding: 8315 8315 1867
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni207C
@@ -13583,6 +16957,8 @@ Encoding: 8316 8316 1868
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni207D
@@ -13590,6 +16966,8 @@ Encoding: 8317 8317 1869
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni207E
@@ -13597,6 +16975,8 @@ Encoding: 8318 8318 1870
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni207F
@@ -13604,6 +16984,8 @@ Encoding: 8319 8319 1871
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2071
@@ -13611,6 +16993,8 @@ Encoding: 8305 8305 1872
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni208C
@@ -13618,6 +17002,8 @@ Encoding: 8332 8332 1873
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni208D
@@ -13625,6 +17011,8 @@ Encoding: 8333 8333 1874
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni208A
@@ -13632,6 +17020,8 @@ Encoding: 8330 8330 1875
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni208E
@@ -13639,6 +17029,8 @@ Encoding: 8334 8334 1876
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni208B
@@ -13646,6 +17038,8 @@ Encoding: 8331 8331 1877
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: summation
@@ -13653,6 +17047,8 @@ Encoding: 8721 8721 1878
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: minus
@@ -13660,6 +17056,8 @@ Encoding: 8722 8722 1879
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2213
@@ -13667,6 +17065,8 @@ Encoding: 8723 8723 1880
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23CF
@@ -13674,6 +17074,8 @@ Encoding: 9167 9167 1881
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni240D
@@ -13681,6 +17083,8 @@ Encoding: 9229 9229 1882
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2690
@@ -13688,6 +17092,8 @@ Encoding: 9872 9872 1883
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2691
@@ -13695,6 +17101,8 @@ Encoding: 9873 9873 1884
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni276C
@@ -13702,6 +17110,8 @@ Encoding: 10092 10092 1885
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni276D
@@ -13709,6 +17119,8 @@ Encoding: 10093 10093 1886
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE725
@@ -13716,6 +17128,8 @@ Encoding: 59173 59173 1887
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE726
@@ -13723,6 +17137,8 @@ Encoding: 59174 59174 1888
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE727
@@ -13730,6 +17146,8 @@ Encoding: 59175 59175 1889
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: invsmileface
@@ -13737,6 +17155,8 @@ Encoding: 9787 9787 1890
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2596
@@ -13744,6 +17164,8 @@ Encoding: 9622 9622 1891
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2597
@@ -13751,6 +17173,8 @@ Encoding: 9623 9623 1892
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2598
@@ -13758,6 +17182,8 @@ Encoding: 9624 9624 1893
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2599
@@ -13765,6 +17191,8 @@ Encoding: 9625 9625 1894
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni259A
@@ -13772,6 +17200,8 @@ Encoding: 9626 9626 1895
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni259B
@@ -13779,6 +17209,8 @@ Encoding: 9627 9627 1896
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni259C
@@ -13786,6 +17218,8 @@ Encoding: 9628 9628 1897
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni259D
@@ -13793,6 +17227,8 @@ Encoding: 9629 9629 1898
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni259E
@@ -13800,6 +17236,8 @@ Encoding: 9630 9630 1899
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni259F
@@ -13807,6 +17245,8 @@ Encoding: 9631 9631 1900
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: approxequal
@@ -13814,6 +17254,8 @@ Encoding: 8776 8776 1901
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2249
@@ -13821,6 +17263,8 @@ Encoding: 8777 8777 1902
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2300
@@ -13828,6 +17272,8 @@ Encoding: 8960 8960 1903
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23E8
@@ -13835,6 +17281,8 @@ Encoding: 9192 9192 1904
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni27E6
@@ -13842,6 +17290,8 @@ Encoding: 10214 10214 1905
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni27E7
@@ -13849,6 +17299,8 @@ Encoding: 10215 10215 1906
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7AA
@@ -13856,6 +17308,8 @@ Encoding: 59306 59306 1907
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE7A3
@@ -13863,6 +17317,8 @@ Encoding: 59299 59299 1908
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF040
@@ -13870,6 +17326,8 @@ Encoding: 61504 61504 1909
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF053
@@ -13877,6 +17335,8 @@ Encoding: 61523 61523 1910
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF054
@@ -13884,6 +17344,8 @@ Encoding: 61524 61524 1911
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0B0
@@ -13891,6 +17353,8 @@ Encoding: 61616 61616 1912
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF13E
@@ -13898,6 +17362,8 @@ Encoding: 61758 61758 1913
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE54
@@ -13905,6 +17371,8 @@ Encoding: 65108 65108 1914
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE55
@@ -13912,6 +17380,8 @@ Encoding: 65109 65109 1915
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE56
@@ -13919,6 +17389,8 @@ Encoding: 65110 65110 1916
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE57
@@ -13926,6 +17398,8 @@ Encoding: 65111 65111 1917
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE58
@@ -13933,6 +17407,8 @@ Encoding: 65112 65112 1918
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE59
@@ -13940,6 +17416,8 @@ Encoding: 65113 65113 1919
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE5A
@@ -13947,6 +17425,8 @@ Encoding: 65114 65114 1920
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE5B
@@ -13954,6 +17434,8 @@ Encoding: 65115 65115 1921
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE5C
@@ -13961,6 +17443,8 @@ Encoding: 65116 65116 1922
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE5D
@@ -13968,6 +17452,8 @@ Encoding: 65117 65117 1923
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE5E
@@ -13975,6 +17461,8 @@ Encoding: 65118 65118 1924
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE62
@@ -13982,6 +17470,8 @@ Encoding: 65122 65122 1925
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE63
@@ -13989,6 +17479,8 @@ Encoding: 65123 65123 1926
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE64
@@ -13996,6 +17488,8 @@ Encoding: 65124 65124 1927
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE66
@@ -14003,6 +17497,8 @@ Encoding: 65126 65126 1928
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE65
@@ -14010,6 +17506,8 @@ Encoding: 65125 65125 1929
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE5F
@@ -14017,6 +17515,8 @@ Encoding: 65119 65119 1930
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE60
@@ -14024,6 +17524,8 @@ Encoding: 65120 65120 1931
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE61
@@ -14031,6 +17533,8 @@ Encoding: 65121 65121 1932
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE69
@@ -14038,6 +17542,8 @@ Encoding: 65129 65129 1933
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE6B
@@ -14045,6 +17551,8 @@ Encoding: 65131 65131 1934
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE68
@@ -14052,6 +17560,8 @@ Encoding: 65128 65128 1935
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFE6A
@@ -14059,6 +17569,8 @@ Encoding: 65130 65130 1936
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD42
@@ -14066,6 +17578,8 @@ Encoding: 64834 64834 1937
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF462
@@ -14073,6 +17587,8 @@ Encoding: 62562 62562 1938
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni23F3
@@ -14080,6 +17596,8 @@ Encoding: 9203 9203 1939
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0306
@@ -14087,6 +17605,8 @@ Encoding: 774 774 1940
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: tildecomb
@@ -14094,6 +17614,8 @@ Encoding: 771 771 1941
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0302
@@ -14101,6 +17623,8 @@ Encoding: 770 770 1942
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: acutecomb
@@ -14108,6 +17632,8 @@ Encoding: 769 769 1943
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gravecomb
@@ -14115,6 +17641,8 @@ Encoding: 768 768 1944
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0304
@@ -14122,6 +17650,8 @@ Encoding: 772 772 1945
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0305
@@ -14129,6 +17659,8 @@ Encoding: 773 773 1946
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0307
@@ -14136,6 +17668,8 @@ Encoding: 775 775 1947
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0308
@@ -14143,6 +17677,8 @@ Encoding: 776 776 1948
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni030A
@@ -14150,6 +17686,8 @@ Encoding: 778 778 1949
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni030B
@@ -14157,6 +17695,8 @@ Encoding: 779 779 1950
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni030C
@@ -14164,6 +17704,8 @@ Encoding: 780 780 1951
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: hookabovecomb
@@ -14171,6 +17713,8 @@ Encoding: 777 777 1952
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni030D
@@ -14178,6 +17722,8 @@ Encoding: 781 781 1953
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni030E
@@ -14185,6 +17731,8 @@ Encoding: 782 782 1954
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni030F
@@ -14192,6 +17740,8 @@ Encoding: 783 783 1955
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0311
@@ -14199,6 +17749,8 @@ Encoding: 785 785 1956
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0315
@@ -14206,6 +17758,8 @@ Encoding: 789 789 1957
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0313
@@ -14213,6 +17767,8 @@ Encoding: 787 787 1958
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0314
@@ -14220,6 +17776,8 @@ Encoding: 788 788 1959
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0310
@@ -14227,6 +17785,8 @@ Encoding: 784 784 1960
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0312
@@ -14234,6 +17794,8 @@ Encoding: 786 786 1961
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dotbelowcomb
@@ -14241,6 +17803,8 @@ Encoding: 803 803 1962
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni033D
@@ -14248,6 +17812,8 @@ Encoding: 829 829 1963
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni033F
@@ -14255,6 +17821,8 @@ Encoding: 831 831 1964
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0346
@@ -14262,6 +17830,8 @@ Encoding: 838 838 1965
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0347
@@ -14269,6 +17839,8 @@ Encoding: 839 839 1966
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0348
@@ -14276,6 +17848,8 @@ Encoding: 840 840 1967
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni033B
@@ -14283,6 +17857,8 @@ Encoding: 827 827 1968
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni033E
@@ -14290,6 +17866,8 @@ Encoding: 830 830 1969
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni033A
@@ -14297,6 +17875,8 @@ Encoding: 826 826 1970
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0316
@@ -14304,6 +17884,8 @@ Encoding: 790 790 1971
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0317
@@ -14311,6 +17893,8 @@ Encoding: 791 791 1972
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0318
@@ -14318,6 +17902,8 @@ Encoding: 792 792 1973
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0319
@@ -14325,6 +17911,8 @@ Encoding: 793 793 1974
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni031A
@@ -14332,6 +17920,8 @@ Encoding: 794 794 1975
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni031B
@@ -14339,6 +17929,8 @@ Encoding: 795 795 1976
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni031C
@@ -14346,6 +17938,8 @@ Encoding: 796 796 1977
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni031D
@@ -14353,6 +17947,8 @@ Encoding: 797 797 1978
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni031E
@@ -14360,6 +17956,8 @@ Encoding: 798 798 1979
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni031F
@@ -14367,6 +17965,8 @@ Encoding: 799 799 1980
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0320
@@ -14374,6 +17974,8 @@ Encoding: 800 800 1981
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0324
@@ -14381,6 +17983,8 @@ Encoding: 804 804 1982
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0325
@@ -14388,6 +17992,8 @@ Encoding: 805 805 1983
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0326
@@ -14395,6 +18001,8 @@ Encoding: 806 806 1984
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0327
@@ -14402,6 +18010,8 @@ Encoding: 807 807 1985
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0328
@@ -14409,6 +18019,8 @@ Encoding: 808 808 1986
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0329
@@ -14416,6 +18028,8 @@ Encoding: 809 809 1987
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni032A
@@ -14423,6 +18037,8 @@ Encoding: 810 810 1988
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni032B
@@ -14430,6 +18046,8 @@ Encoding: 811 811 1989
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni032C
@@ -14437,6 +18055,8 @@ Encoding: 812 812 1990
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni032D
@@ -14444,6 +18064,8 @@ Encoding: 813 813 1991
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni032E
@@ -14451,6 +18073,8 @@ Encoding: 814 814 1992
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni032F
@@ -14458,6 +18082,8 @@ Encoding: 815 815 1993
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0330
@@ -14465,6 +18091,8 @@ Encoding: 816 816 1994
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0331
@@ -14472,6 +18100,8 @@ Encoding: 817 817 1995
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0332
@@ -14479,6 +18109,8 @@ Encoding: 818 818 1996
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0333
@@ -14486,6 +18118,8 @@ Encoding: 819 819 1997
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni033C
@@ -14493,6129 +18127,8222 @@ Encoding: 828 828 1998
 Width: 1024
 Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0340
 Encoding: 832 832 1999
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
 Fore
 Refer: 1944 768 N 1 0 0 1 0 0 2
+Validated: 1
 EndChar
 
 StartChar: uni0341
 Encoding: 833 833 2000
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
 Fore
 Refer: 1943 769 N 1 0 0 1 0 0 2
+Validated: 1
 EndChar
 
 StartChar: uni0342
 Encoding: 834 834 2001
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
 Fore
 Refer: 1941 771 N 1 0 0 1 0 0 2
+Validated: 1
 EndChar
 
 StartChar: uni0343
 Encoding: 835 835 2002
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
 Fore
 Refer: 1958 787 N 1 0 0 1 0 0 2
+Validated: 1
 EndChar
 
 StartChar: uni203B
 Encoding: 8251 8251 2003
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: exclamdbl
 Encoding: 8252 8252 2004
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni203D
 Encoding: 8253 8253 2005
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni203E
 Encoding: 8254 8254 2006
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni205D
 Encoding: 8285 8285 2007
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni205E
 Encoding: 8286 8286 2008
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2E3D
 Encoding: 11837 11837 2009
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni237F
 Encoding: 9087 9087 2010
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22EF
 Encoding: 8943 8943 2011
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22EE
 Encoding: 8942 8942 2012
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD6
 Encoding: 8150 8150 2013
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD0
 Encoding: 8144 8144 2014
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD1
 Encoding: 8145 8145 2015
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F72
 Encoding: 8050 8050 2016
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F73
 Encoding: 8051 8051 2017
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F74
 Encoding: 8052 8052 2018
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F75
 Encoding: 8053 8053 2019
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F76
 Encoding: 8054 8054 2020
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F77
 Encoding: 8055 8055 2021
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE0
 Encoding: 8160 8160 2022
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE1
 Encoding: 8161 8161 2023
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE6
 Encoding: 8166 8166 2024
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F50
 Encoding: 8016 8016 2025
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F51
 Encoding: 8017 8017 2026
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F7A
 Encoding: 8058 8058 2027
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F7B
 Encoding: 8059 8059 2028
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F10
 Encoding: 7952 7952 2029
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F11
 Encoding: 7953 7953 2030
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F00
 Encoding: 7936 7936 2031
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F01
 Encoding: 7937 7937 2032
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F70
 Encoding: 8048 8048 2033
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F71
 Encoding: 8049 8049 2034
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB6
 Encoding: 8118 8118 2035
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB0
 Encoding: 8112 8112 2036
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB1
 Encoding: 8113 8113 2037
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F02
 Encoding: 7938 7938 2038
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F03
 Encoding: 7939 7939 2039
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F04
 Encoding: 7940 7940 2040
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F05
 Encoding: 7941 7941 2041
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F40
 Encoding: 8000 8000 2042
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F41
 Encoding: 8001 8001 2043
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F42
 Encoding: 8002 8002 2044
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F43
 Encoding: 8003 8003 2045
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F44
 Encoding: 8004 8004 2046
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F45
 Encoding: 8005 8005 2047
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F78
 Encoding: 8056 8056 2048
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F79
 Encoding: 8057 8057 2049
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F20
 Encoding: 7968 7968 2050
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F21
 Encoding: 7969 7969 2051
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F22
 Encoding: 7970 7970 2052
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F23
 Encoding: 7971 7971 2053
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F24
 Encoding: 7972 7972 2054
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F25
 Encoding: 7973 7973 2055
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC6
 Encoding: 8134 8134 2056
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F7C
 Encoding: 8060 8060 2057
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F7D
 Encoding: 8061 8061 2058
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F60
 Encoding: 8032 8032 2059
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F61
 Encoding: 8033 8033 2060
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F62
 Encoding: 8034 8034 2061
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F63
 Encoding: 8035 8035 2062
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F64
 Encoding: 8036 8036 2063
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F65
 Encoding: 8037 8037 2064
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F08
 Encoding: 7944 7944 2065
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F09
 Encoding: 7945 7945 2066
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F0A
 Encoding: 7946 7946 2067
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F0B
 Encoding: 7947 7947 2068
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F0C
 Encoding: 7948 7948 2069
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F0D
 Encoding: 7949 7949 2070
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F52
 Encoding: 8018 8018 2071
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F53
 Encoding: 8019 8019 2072
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F54
 Encoding: 8020 8020 2073
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F55
 Encoding: 8021 8021 2074
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB2
 Encoding: 8114 8114 2075
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB3
 Encoding: 8115 8115 2076
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB4
 Encoding: 8116 8116 2077
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB7
 Encoding: 8119 8119 2078
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB8
 Encoding: 8120 8120 2079
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FB9
 Encoding: 8121 8121 2080
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FBA
 Encoding: 8122 8122 2081
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FBB
 Encoding: 8123 8123 2082
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FBC
 Encoding: 8124 8124 2083
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC2
 Encoding: 8130 8130 2084
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC3
 Encoding: 8131 8131 2085
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC4
 Encoding: 8132 8132 2086
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC7
 Encoding: 8135 8135 2087
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD2
 Encoding: 8146 8146 2088
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD3
 Encoding: 8147 8147 2089
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD7
 Encoding: 8151 8151 2090
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F30
 Encoding: 7984 7984 2091
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F31
 Encoding: 7985 7985 2092
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F32
 Encoding: 7986 7986 2093
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F33
 Encoding: 7987 7987 2094
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F34
 Encoding: 7988 7988 2095
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F35
 Encoding: 7989 7989 2096
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F80
 Encoding: 8064 8064 2097
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F81
 Encoding: 8065 8065 2098
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F82
 Encoding: 8066 8066 2099
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F83
 Encoding: 8067 8067 2100
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F84
 Encoding: 8068 8068 2101
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F85
 Encoding: 8069 8069 2102
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F90
 Encoding: 8080 8080 2103
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F91
 Encoding: 8081 8081 2104
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F92
 Encoding: 8082 8082 2105
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F93
 Encoding: 8083 8083 2106
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F94
 Encoding: 8084 8084 2107
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F95
 Encoding: 8085 8085 2108
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA0
 Encoding: 8096 8096 2109
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA1
 Encoding: 8097 8097 2110
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA2
 Encoding: 8098 8098 2111
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA3
 Encoding: 8099 8099 2112
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA4
 Encoding: 8100 8100 2113
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA5
 Encoding: 8101 8101 2114
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE2
 Encoding: 8162 8162 2115
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE3
 Encoding: 8163 8163 2116
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE4
 Encoding: 8164 8164 2117
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE5
 Encoding: 8165 8165 2118
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF2
 Encoding: 8178 8178 2119
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF3
 Encoding: 8179 8179 2120
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF4
 Encoding: 8180 8180 2121
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF6
 Encoding: 8182 8182 2122
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF7
 Encoding: 8183 8183 2123
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2090
 Encoding: 8336 8336 2124
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2092
 Encoding: 8338 8338 2125
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2093
 Encoding: 8339 8339 2126
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2091
 Encoding: 8337 8337 2127
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2094
 Encoding: 8340 8340 2128
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2095
 Encoding: 8341 8341 2129
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2096
 Encoding: 8342 8342 2130
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2098
 Encoding: 8344 8344 2131
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2099
 Encoding: 8345 8345 2132
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni209A
 Encoding: 8346 8346 2133
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni209B
 Encoding: 8347 8347 2134
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni209C
 Encoding: 8348 8348 2135
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2097
 Encoding: 8343 8343 2136
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F12
 Encoding: 7954 7954 2137
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F13
 Encoding: 7955 7955 2138
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F14
 Encoding: 7956 7956 2139
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F15
 Encoding: 7957 7957 2140
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F18
 Encoding: 7960 7960 2141
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F19
 Encoding: 7961 7961 2142
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F1A
 Encoding: 7962 7962 2143
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F1B
 Encoding: 7963 7963 2144
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F1C
 Encoding: 7964 7964 2145
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F1D
 Encoding: 7965 7965 2146
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F28
 Encoding: 7976 7976 2147
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F29
 Encoding: 7977 7977 2148
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F2A
 Encoding: 7978 7978 2149
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F2B
 Encoding: 7979 7979 2150
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F2C
 Encoding: 7980 7980 2151
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F2D
 Encoding: 7981 7981 2152
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F38
 Encoding: 7992 7992 2153
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F39
 Encoding: 7993 7993 2154
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F3A
 Encoding: 7994 7994 2155
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F3B
 Encoding: 7995 7995 2156
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F3C
 Encoding: 7996 7996 2157
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F3D
 Encoding: 7997 7997 2158
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F48
 Encoding: 8008 8008 2159
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F49
 Encoding: 8009 8009 2160
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F4A
 Encoding: 8010 8010 2161
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F4B
 Encoding: 8011 8011 2162
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F4C
 Encoding: 8012 8012 2163
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F4D
 Encoding: 8013 8013 2164
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F59
 Encoding: 8025 8025 2165
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F5B
 Encoding: 8027 8027 2166
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F5D
 Encoding: 8029 8029 2167
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F68
 Encoding: 8040 8040 2168
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA8
 Encoding: 8104 8104 2169
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FFA
 Encoding: 8186 8186 2170
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FFB
 Encoding: 8187 8187 2171
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FFC
 Encoding: 8188 8188 2172
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F69
 Encoding: 8041 8041 2173
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F6A
 Encoding: 8042 8042 2174
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F6B
 Encoding: 8043 8043 2175
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F6C
 Encoding: 8044 8044 2176
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F6D
 Encoding: 8045 8045 2177
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F88
 Encoding: 8072 8072 2178
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F89
 Encoding: 8073 8073 2179
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F8A
 Encoding: 8074 8074 2180
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F8B
 Encoding: 8075 8075 2181
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F8C
 Encoding: 8076 8076 2182
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F8D
 Encoding: 8077 8077 2183
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F98
 Encoding: 8088 8088 2184
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F99
 Encoding: 8089 8089 2185
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F9A
 Encoding: 8090 8090 2186
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F9B
 Encoding: 8091 8091 2187
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F9C
 Encoding: 8092 8092 2188
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1F9D
 Encoding: 8093 8093 2189
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FA9
 Encoding: 8105 8105 2190
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FAA
 Encoding: 8106 8106 2191
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FAB
 Encoding: 8107 8107 2192
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FAC
 Encoding: 8108 8108 2193
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FAD
 Encoding: 8109 8109 2194
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC8
 Encoding: 8136 8136 2195
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FC9
 Encoding: 8137 8137 2196
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FCA
 Encoding: 8138 8138 2197
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FCB
 Encoding: 8139 8139 2198
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FCC
 Encoding: 8140 8140 2199
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD8
 Encoding: 8152 8152 2200
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FD9
 Encoding: 8153 8153 2201
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FDA
 Encoding: 8154 8154 2202
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FDB
 Encoding: 8155 8155 2203
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE8
 Encoding: 8168 8168 2204
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FE9
 Encoding: 8169 8169 2205
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FEA
 Encoding: 8170 8170 2206
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FEB
 Encoding: 8171 8171 2207
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FEC
 Encoding: 8172 8172 2208
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF8
 Encoding: 8184 8184 2209
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1FF9
 Encoding: 8185 8185 2210
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0181
 Encoding: 385 385 2211
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0182
 Encoding: 386 386 2212
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0184
 Encoding: 388 388 2213
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0180
 Encoding: 384 384 2214
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0183
 Encoding: 387 387 2215
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0185
 Encoding: 389 389 2216
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0186
 Encoding: 390 390 2217
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0187
 Encoding: 391 391 2218
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0188
 Encoding: 392 392 2219
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0189
 Encoding: 393 393 2220
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni018A
 Encoding: 394 394 2221
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni018B
 Encoding: 395 395 2222
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni018C
 Encoding: 396 396 2223
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni018D
 Encoding: 397 397 2224
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0190
 Encoding: 400 400 2225
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0198
 Encoding: 408 408 2226
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0199
 Encoding: 409 409 2227
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: longs
 Encoding: 383 383 2228
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0193
 Encoding: 403 403 2229
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0194
 Encoding: 404 404 2230
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0195
 Encoding: 405 405 2231
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0196
 Encoding: 406 406 2232
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0197
 Encoding: 407 407 2233
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni019A
 Encoding: 410 410 2234
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni019B
 Encoding: 411 411 2235
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A6
 Encoding: 422 422 2236
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A7
 Encoding: 423 423 2237
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A8
 Encoding: 424 424 2238
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01A9
 Encoding: 425 425 2239
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01AA
 Encoding: 426 426 2240
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01AB
 Encoding: 427 427 2241
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01AC
 Encoding: 428 428 2242
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01AD
 Encoding: 429 429 2243
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01AE
 Encoding: 430 430 2244
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Uhorn
 Encoding: 431 431 2245
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uhorn
 Encoding: 432 432 2246
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01DE
 Encoding: 478 478 2247
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E0
 Encoding: 480 480 2248
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01DF
 Encoding: 479 479 2249
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E1
 Encoding: 481 481 2250
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D3
 Encoding: 467 467 2251
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D5
 Encoding: 469 469 2252
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D7
 Encoding: 471 471 2253
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D9
 Encoding: 473 473 2254
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01DB
 Encoding: 475 475 2255
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D4
 Encoding: 468 468 2256
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D6
 Encoding: 470 470 2257
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D8
 Encoding: 472 472 2258
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01DA
 Encoding: 474 474 2259
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01DC
 Encoding: 476 476 2260
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E3
 Encoding: 483 483 2261
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E2
 Encoding: 482 482 2262
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2043
 Encoding: 8259 8259 2263
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: fraction
 Encoding: 8260 8260 2264
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2045
 Encoding: 8261 8261 2265
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2046
 Encoding: 8262 8262 2266
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A2
 Encoding: 5794 5794 2267
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A3
 Encoding: 5795 5795 2268
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A5
 Encoding: 5797 5797 2269
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A6
 Encoding: 5798 5798 2270
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A8
 Encoding: 5800 5800 2271
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A9
 Encoding: 5801 5801 2272
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16AA
 Encoding: 5802 5802 2273
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16AB
 Encoding: 5803 5803 2274
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16AC
 Encoding: 5804 5804 2275
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni16A4
 Encoding: 5796 5796 2276
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2056
 Encoding: 8278 8278 2277
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2058
 Encoding: 8280 8280 2278
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2059
 Encoding: 8281 8281 2279
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni205C
 Encoding: 8284 8284 2280
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni205A
 Encoding: 8282 8282 2281
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni205B
 Encoding: 8283 8283 2282
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni20BF
 Encoding: 8383 8383 2283
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii57636
 Encoding: 8362 8362 2284
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: lira
 Encoding: 8356 8356 2285
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2163
 Encoding: 8547 8547 2286
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2162
 Encoding: 8546 8546 2287
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2161
 Encoding: 8545 8545 2288
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2160
 Encoding: 8544 8544 2289
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2165
 Encoding: 8549 8549 2290
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2168
 Encoding: 8552 8552 2291
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2169
 Encoding: 8553 8553 2292
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni216A
 Encoding: 8554 8554 2293
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2170
 Encoding: 8560 8560 2294
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2171
 Encoding: 8561 8561 2295
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2172
 Encoding: 8562 8562 2296
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2173
 Encoding: 8563 8563 2297
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2174
 Encoding: 8564 8564 2298
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2175
 Encoding: 8565 8565 2299
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2178
 Encoding: 8568 8568 2300
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2179
 Encoding: 8569 8569 2301
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni217A
 Encoding: 8570 8570 2302
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni222D
 Encoding: 8749 8749 2303
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni222C
 Encoding: 8748 8748 2304
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: integral
 Encoding: 8747 8747 2305
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B6
 Encoding: 8630 8630 2306
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B7
 Encoding: 8631 8631 2307
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21B8
 Encoding: 8632 8632 2308
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21BA
 Encoding: 8634 8634 2309
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21BB
 Encoding: 8635 8635 2310
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21BC
 Encoding: 8636 8636 2311
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21BD
 Encoding: 8637 8637 2312
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21C0
 Encoding: 8640 8640 2313
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21C1
 Encoding: 8641 8641 2314
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21C2
 Encoding: 8642 8642 2315
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21C3
 Encoding: 8643 8643 2316
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21BE
 Encoding: 8638 8638 2317
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21BF
 Encoding: 8639 8639 2318
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21CB
 Encoding: 8651 8651 2319
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21CC
 Encoding: 8652 8652 2320
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21F1
 Encoding: 8689 8689 2321
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21F2
 Encoding: 8690 8690 2322
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A2
 Encoding: 8610 8610 2323
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A4
 Encoding: 8612 8612 2324
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A9
 Encoding: 8617 8617 2325
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A3
 Encoding: 8611 8611 2326
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A6
 Encoding: 8614 8614 2327
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21AA
 Encoding: 8618 8618 2328
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A5
 Encoding: 8613 8613 2329
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21A7
 Encoding: 8615 8615 2330
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21AB
 Encoding: 8619 8619 2331
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni21AC
 Encoding: 8620 8620 2332
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22A1
 Encoding: 8865 8865 2333
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22B2
 Encoding: 8882 8882 2334
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22B3
 Encoding: 8883 8883 2335
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22B4
 Encoding: 8884 8884 2336
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22B5
 Encoding: 8885 8885 2337
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22C4
 Encoding: 8900 8900 2338
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dotmath
 Encoding: 8901 8901 2339
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22C6
 Encoding: 8902 8902 2340
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22F0
 Encoding: 8944 8944 2341
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22F1
 Encoding: 8945 8945 2342
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni231C
 Encoding: 8988 8988 2343
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni231D
 Encoding: 8989 8989 2344
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni231E
 Encoding: 8990 8990 2345
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni231F
 Encoding: 8991 8991 2346
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2308
 Encoding: 8968 8968 2347
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2309
 Encoding: 8969 8969 2348
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni230A
 Encoding: 8970 8970 2349
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni230B
 Encoding: 8971 8971 2350
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni230C
 Encoding: 8972 8972 2351
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni230D
 Encoding: 8973 8973 2352
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni230E
 Encoding: 8974 8974 2353
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni230F
 Encoding: 8975 8975 2354
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: integraltp
 Encoding: 8992 8992 2355
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: integralbt
 Encoding: 8993 8993 2356
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2400
 Encoding: 9216 9216 2357
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2408
 Encoding: 9224 9224 2358
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni240C
 Encoding: 9228 9228 2359
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni240E
 Encoding: 9230 9230 2360
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01CD
 Encoding: 461 461 2361
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01CF
 Encoding: 463 463 2362
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01CE
 Encoding: 462 462 2363
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D0
 Encoding: 464 464 2364
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D1
 Encoding: 465 465 2365
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01D2
 Encoding: 466 466 2366
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Gcaron
 Encoding: 486 486 2367
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: gcaron
 Encoding: 487 487 2368
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E8
 Encoding: 488 488 2369
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E9
 Encoding: 489 489 2370
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01DD
 Encoding: 477 477 2371
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01BB
 Encoding: 443 443 2372
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01BC
 Encoding: 444 444 2373
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01BD
 Encoding: 445 445 2374
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01BF
 Encoding: 447 447 2375
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01EC
 Encoding: 492 492 2376
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01ED
 Encoding: 493 493 2377
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01EA
 Encoding: 490 490 2378
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01EB
 Encoding: 491 491 2379
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01EF
 Encoding: 495 495 2380
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01EE
 Encoding: 494 494 2381
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F0
 Encoding: 496 496 2382
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F4
 Encoding: 500 500 2383
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F5
 Encoding: 501 501 2384
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F6
 Encoding: 502 502 2385
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F7
 Encoding: 503 503 2386
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F8
 Encoding: 504 504 2387
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01F9
 Encoding: 505 505 2388
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Aringacute
 Encoding: 506 506 2389
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: aringacute
 Encoding: 507 507 2390
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0200
 Encoding: 512 512 2391
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0201
 Encoding: 513 513 2392
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0202
 Encoding: 514 514 2393
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0203
 Encoding: 515 515 2394
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0204
 Encoding: 516 516 2395
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0206
 Encoding: 518 518 2396
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0205
 Encoding: 517 517 2397
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0207
 Encoding: 519 519 2398
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E4
 Encoding: 484 484 2399
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni01E5
 Encoding: 485 485 2400
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0208
 Encoding: 520 520 2401
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni020A
 Encoding: 522 522 2402
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0209
 Encoding: 521 521 2403
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni020B
 Encoding: 523 523 2404
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni020C
 Encoding: 524 524 2405
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni020D
 Encoding: 525 525 2406
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni020E
 Encoding: 526 526 2407
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni020F
 Encoding: 527 527 2408
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0214
 Encoding: 532 532 2409
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0215
 Encoding: 533 533 2410
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0210
 Encoding: 528 528 2411
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0212
 Encoding: 530 530 2412
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0211
 Encoding: 529 529 2413
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0213
 Encoding: 531 531 2414
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0216
 Encoding: 534 534 2415
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0217
 Encoding: 535 535 2416
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni021E
 Encoding: 542 542 2417
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni021F
 Encoding: 543 543 2418
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Scommaaccent
 Encoding: 536 536 2419
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni021A
 Encoding: 538 538 2420
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: scommaaccent
 Encoding: 537 537 2421
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni021B
 Encoding: 539 539 2422
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0226
 Encoding: 550 550 2423
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0227
 Encoding: 551 551 2424
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0228
 Encoding: 552 552 2425
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0229
 Encoding: 553 553 2426
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni022E
 Encoding: 558 558 2427
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni022F
 Encoding: 559 559 2428
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0232
 Encoding: 562 562 2429
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0233
 Encoding: 563 563 2430
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni022B
 Encoding: 555 555 2431
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni022D
 Encoding: 557 557 2432
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0231
 Encoding: 561 561 2433
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0224
 Encoding: 548 548 2434
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0225
 Encoding: 549 549 2435
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0220
 Encoding: 544 544 2436
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni021C
 Encoding: 540 540 2437
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni021D
 Encoding: 541 541 2438
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA0
 Encoding: 7840 7840 2439
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA1
 Encoding: 7841 7841 2440
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA2
 Encoding: 7842 7842 2441
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA3
 Encoding: 7843 7843 2442
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA4
 Encoding: 7844 7844 2443
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA5
 Encoding: 7845 7845 2444
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA6
 Encoding: 7846 7846 2445
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EA7
 Encoding: 7847 7847 2446
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EAA
 Encoding: 7850 7850 2447
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EAB
 Encoding: 7851 7851 2448
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EAC
 Encoding: 7852 7852 2449
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EAD
 Encoding: 7853 7853 2450
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EAE
 Encoding: 7854 7854 2451
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EAF
 Encoding: 7855 7855 2452
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB0
 Encoding: 7856 7856 2453
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB1
 Encoding: 7857 7857 2454
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB2
 Encoding: 7858 7858 2455
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB3
 Encoding: 7859 7859 2456
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB4
 Encoding: 7860 7860 2457
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB5
 Encoding: 7861 7861 2458
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB6
 Encoding: 7862 7862 2459
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB7
 Encoding: 7863 7863 2460
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB8
 Encoding: 7864 7864 2461
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EB9
 Encoding: 7865 7865 2462
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E00
 Encoding: 7680 7680 2463
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E02
 Encoding: 7682 7682 2464
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E04
 Encoding: 7684 7684 2465
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E06
 Encoding: 7686 7686 2466
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E08
 Encoding: 7688 7688 2467
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E0A
 Encoding: 7690 7690 2468
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E0C
 Encoding: 7692 7692 2469
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E0E
 Encoding: 7694 7694 2470
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E10
 Encoding: 7696 7696 2471
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E12
 Encoding: 7698 7698 2472
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E14
 Encoding: 7700 7700 2473
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E16
 Encoding: 7702 7702 2474
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E18
 Encoding: 7704 7704 2475
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E1A
 Encoding: 7706 7706 2476
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E1C
 Encoding: 7708 7708 2477
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E1E
 Encoding: 7710 7710 2478
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E20
 Encoding: 7712 7712 2479
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E22
 Encoding: 7714 7714 2480
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E24
 Encoding: 7716 7716 2481
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E26
 Encoding: 7718 7718 2482
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E28
 Encoding: 7720 7720 2483
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E2A
 Encoding: 7722 7722 2484
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E2C
 Encoding: 7724 7724 2485
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E2E
 Encoding: 7726 7726 2486
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E30
 Encoding: 7728 7728 2487
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E32
 Encoding: 7730 7730 2488
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E34
 Encoding: 7732 7732 2489
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E36
 Encoding: 7734 7734 2490
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E38
 Encoding: 7736 7736 2491
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E3A
 Encoding: 7738 7738 2492
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E3C
 Encoding: 7740 7740 2493
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E3E
 Encoding: 7742 7742 2494
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E40
 Encoding: 7744 7744 2495
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E42
 Encoding: 7746 7746 2496
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E44
 Encoding: 7748 7748 2497
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E46
 Encoding: 7750 7750 2498
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E48
 Encoding: 7752 7752 2499
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E4A
 Encoding: 7754 7754 2500
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E4C
 Encoding: 7756 7756 2501
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E4E
 Encoding: 7758 7758 2502
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E50
 Encoding: 7760 7760 2503
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E52
 Encoding: 7762 7762 2504
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E54
 Encoding: 7764 7764 2505
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E56
 Encoding: 7766 7766 2506
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E58
 Encoding: 7768 7768 2507
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E5A
 Encoding: 7770 7770 2508
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E5C
 Encoding: 7772 7772 2509
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E5E
 Encoding: 7774 7774 2510
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E60
 Encoding: 7776 7776 2511
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E62
 Encoding: 7778 7778 2512
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E64
 Encoding: 7780 7780 2513
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E66
 Encoding: 7782 7782 2514
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E68
 Encoding: 7784 7784 2515
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E6A
 Encoding: 7786 7786 2516
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E6C
 Encoding: 7788 7788 2517
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E6E
 Encoding: 7790 7790 2518
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E70
 Encoding: 7792 7792 2519
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E72
 Encoding: 7794 7794 2520
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E74
 Encoding: 7796 7796 2521
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E76
 Encoding: 7798 7798 2522
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E78
 Encoding: 7800 7800 2523
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E7A
 Encoding: 7802 7802 2524
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E7C
 Encoding: 7804 7804 2525
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E7E
 Encoding: 7806 7806 2526
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Wgrave
 Encoding: 7808 7808 2527
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Wacute
 Encoding: 7810 7810 2528
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Wdieresis
 Encoding: 7812 7812 2529
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E86
 Encoding: 7814 7814 2530
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E88
 Encoding: 7816 7816 2531
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E8A
 Encoding: 7818 7818 2532
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E8C
 Encoding: 7820 7820 2533
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E8E
 Encoding: 7822 7822 2534
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E90
 Encoding: 7824 7824 2535
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E92
 Encoding: 7826 7826 2536
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E94
 Encoding: 7828 7828 2537
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E01
 Encoding: 7681 7681 2538
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E03
 Encoding: 7683 7683 2539
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E05
 Encoding: 7685 7685 2540
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E07
 Encoding: 7687 7687 2541
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E09
 Encoding: 7689 7689 2542
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E0B
 Encoding: 7691 7691 2543
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E0D
 Encoding: 7693 7693 2544
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E0F
 Encoding: 7695 7695 2545
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E11
 Encoding: 7697 7697 2546
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E13
 Encoding: 7699 7699 2547
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E15
 Encoding: 7701 7701 2548
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E17
 Encoding: 7703 7703 2549
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E19
 Encoding: 7705 7705 2550
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E1B
 Encoding: 7707 7707 2551
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E1D
 Encoding: 7709 7709 2552
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E1F
 Encoding: 7711 7711 2553
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E21
 Encoding: 7713 7713 2554
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E23
 Encoding: 7715 7715 2555
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E25
 Encoding: 7717 7717 2556
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E27
 Encoding: 7719 7719 2557
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E29
 Encoding: 7721 7721 2558
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E2B
 Encoding: 7723 7723 2559
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E2D
 Encoding: 7725 7725 2560
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E2F
 Encoding: 7727 7727 2561
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E31
 Encoding: 7729 7729 2562
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E33
 Encoding: 7731 7731 2563
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E35
 Encoding: 7733 7733 2564
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E37
 Encoding: 7735 7735 2565
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E39
 Encoding: 7737 7737 2566
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E3B
 Encoding: 7739 7739 2567
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E3D
 Encoding: 7741 7741 2568
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E3F
 Encoding: 7743 7743 2569
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E41
 Encoding: 7745 7745 2570
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E43
 Encoding: 7747 7747 2571
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E45
 Encoding: 7749 7749 2572
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E47
 Encoding: 7751 7751 2573
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E49
 Encoding: 7753 7753 2574
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E4B
 Encoding: 7755 7755 2575
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E4D
 Encoding: 7757 7757 2576
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E4F
 Encoding: 7759 7759 2577
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E51
 Encoding: 7761 7761 2578
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E53
 Encoding: 7763 7763 2579
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E55
 Encoding: 7765 7765 2580
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E57
 Encoding: 7767 7767 2581
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E59
 Encoding: 7769 7769 2582
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E5B
 Encoding: 7771 7771 2583
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E5D
 Encoding: 7773 7773 2584
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E5F
 Encoding: 7775 7775 2585
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E61
 Encoding: 7777 7777 2586
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E63
 Encoding: 7779 7779 2587
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E65
 Encoding: 7781 7781 2588
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E67
 Encoding: 7783 7783 2589
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E69
 Encoding: 7785 7785 2590
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E6B
 Encoding: 7787 7787 2591
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E6D
 Encoding: 7789 7789 2592
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E6F
 Encoding: 7791 7791 2593
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E71
 Encoding: 7793 7793 2594
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E73
 Encoding: 7795 7795 2595
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E75
 Encoding: 7797 7797 2596
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E77
 Encoding: 7799 7799 2597
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E79
 Encoding: 7801 7801 2598
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E7B
 Encoding: 7803 7803 2599
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E7D
 Encoding: 7805 7805 2600
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E7F
 Encoding: 7807 7807 2601
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: wgrave
 Encoding: 7809 7809 2602
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: wacute
 Encoding: 7811 7811 2603
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: wdieresis
 Encoding: 7813 7813 2604
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E87
 Encoding: 7815 7815 2605
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E89
 Encoding: 7817 7817 2606
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E8B
 Encoding: 7819 7819 2607
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E8D
 Encoding: 7821 7821 2608
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E8F
 Encoding: 7823 7823 2609
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E91
 Encoding: 7825 7825 2610
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E93
 Encoding: 7827 7827 2611
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E95
 Encoding: 7829 7829 2612
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E96
 Encoding: 7830 7830 2613
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E97
 Encoding: 7831 7831 2614
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E98
 Encoding: 7832 7832 2615
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E99
 Encoding: 7833 7833 2616
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E9A
 Encoding: 7834 7834 2617
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EBA
 Encoding: 7866 7866 2618
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EBB
 Encoding: 7867 7867 2619
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EBC
 Encoding: 7868 7868 2620
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EBD
 Encoding: 7869 7869 2621
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EBE
 Encoding: 7870 7870 2622
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EBF
 Encoding: 7871 7871 2623
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC0
 Encoding: 7872 7872 2624
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC1
 Encoding: 7873 7873 2625
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC4
 Encoding: 7876 7876 2626
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC5
 Encoding: 7877 7877 2627
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC6
 Encoding: 7878 7878 2628
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC7
 Encoding: 7879 7879 2629
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC8
 Encoding: 7880 7880 2630
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EC9
 Encoding: 7881 7881 2631
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ECA
 Encoding: 7882 7882 2632
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ECB
 Encoding: 7883 7883 2633
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ECC
 Encoding: 7884 7884 2634
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ECD
 Encoding: 7885 7885 2635
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ECE
 Encoding: 7886 7886 2636
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ECF
 Encoding: 7887 7887 2637
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED0
 Encoding: 7888 7888 2638
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED1
 Encoding: 7889 7889 2639
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED2
 Encoding: 7890 7890 2640
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED3
 Encoding: 7891 7891 2641
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED6
 Encoding: 7894 7894 2642
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED7
 Encoding: 7895 7895 2643
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED8
 Encoding: 7896 7896 2644
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1ED9
 Encoding: 7897 7897 2645
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EDA
 Encoding: 7898 7898 2646
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EDB
 Encoding: 7899 7899 2647
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EDC
 Encoding: 7900 7900 2648
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EDD
 Encoding: 7901 7901 2649
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EDE
 Encoding: 7902 7902 2650
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EDF
 Encoding: 7903 7903 2651
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE0
 Encoding: 7904 7904 2652
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE1
 Encoding: 7905 7905 2653
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE2
 Encoding: 7906 7906 2654
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE3
 Encoding: 7907 7907 2655
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE4
 Encoding: 7908 7908 2656
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE5
 Encoding: 7909 7909 2657
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE6
 Encoding: 7910 7910 2658
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE7
 Encoding: 7911 7911 2659
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE8
 Encoding: 7912 7912 2660
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EE9
 Encoding: 7913 7913 2661
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EEA
 Encoding: 7914 7914 2662
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EEB
 Encoding: 7915 7915 2663
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EEC
 Encoding: 7916 7916 2664
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EED
 Encoding: 7917 7917 2665
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EEE
 Encoding: 7918 7918 2666
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EEF
 Encoding: 7919 7919 2667
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF0
 Encoding: 7920 7920 2668
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF1
 Encoding: 7921 7921 2669
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Ygrave
 Encoding: 7922 7922 2670
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ygrave
 Encoding: 7923 7923 2671
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF4
 Encoding: 7924 7924 2672
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF5
 Encoding: 7925 7925 2673
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF6
 Encoding: 7926 7926 2674
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF7
 Encoding: 7927 7927 2675
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF8
 Encoding: 7928 7928 2676
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1EF9
 Encoding: 7929 7929 2677
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E9B
 Encoding: 7835 7835 2678
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E9C
 Encoding: 7836 7836 2679
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E9D
 Encoding: 7837 7837 2680
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni1E9F
 Encoding: 7839 7839 2681
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02CA
 Encoding: 714 714 2682
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02CB
 Encoding: 715 715 2683
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02C9
 Encoding: 713 713 2684
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: breve
 Encoding: 728 728 2685
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: dotaccent
 Encoding: 729 729 2686
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ring
 Encoding: 730 730 2687
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ogonek
 Encoding: 731 731 2688
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: hungarumlaut
 Encoding: 733 733 2689
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: caron
 Encoding: 711 711 2690
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02C8
 Encoding: 712 712 2691
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02BB
 Encoding: 699 699 2692
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii57929
 Encoding: 700 700 2693
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: afii64937
 Encoding: 701 701 2694
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D6
 Encoding: 726 726 2695
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D7
 Encoding: 727 727 2696
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D4
 Encoding: 724 724 2697
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D5
 Encoding: 725 725 2698
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02DF
 Encoding: 735 735 2699
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02E0
 Encoding: 736 736 2700
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F3
 Encoding: 755 755 2701
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F7
 Encoding: 759 759 2702
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02B9
 Encoding: 697 697 2703
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02BA
 Encoding: 698 698 2704
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D0
 Encoding: 720 720 2705
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D1
 Encoding: 721 721 2706
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D2
 Encoding: 722 722 2707
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02D3
 Encoding: 723 723 2708
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F6
 Encoding: 758 758 2709
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F5
 Encoding: 757 757 2710
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02FD
 Encoding: 765 765 2711
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02FE
 Encoding: 766 766 2712
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F9
 Encoding: 761 761 2713
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02FA
 Encoding: 762 762 2714
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02FB
 Encoding: 763 763 2715
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02FC
 Encoding: 764 764 2716
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F4
 Encoding: 756 756 2717
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02EF
 Encoding: 751 751 2718
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F0
 Encoding: 752 752 2719
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F1
 Encoding: 753 753 2720
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02F2
 Encoding: 754 754 2721
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02EC
 Encoding: 748 748 2722
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02ED
 Encoding: 749 749 2723
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02CC
 Encoding: 716 716 2724
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02CD
 Encoding: 717 717 2725
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02CE
 Encoding: 718 718 2726
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02CF
 Encoding: 719 719 2727
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02E1
 Encoding: 737 737 2728
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02E2
 Encoding: 738 738 2729
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02E3
 Encoding: 739 739 2730
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02E4
 Encoding: 740 740 2731
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02C2
 Encoding: 706 706 2732
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02C3
 Encoding: 707 707 2733
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02C4
 Encoding: 708 708 2734
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni02C5
 Encoding: 709 709 2735
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2000
 Encoding: 8192 8192 2736
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2001
 Encoding: 8193 8193 2737
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2002
 Encoding: 8194 8194 2738
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2003
 Encoding: 8195 8195 2739
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2004
 Encoding: 8196 8196 2740
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2005
 Encoding: 8197 8197 2741
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2006
 Encoding: 8198 8198 2742
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2007
 Encoding: 8199 8199 2743
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2008
 Encoding: 8200 8200 2744
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2009
 Encoding: 8201 8201 2745
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni200A
 Encoding: 8202 8202 2746
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni202F
 Encoding: 8239 8239 2747
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: angleleft
 Encoding: 9001 9001 2748
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: angleright
 Encoding: 9002 9002 2749
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni240B
 Encoding: 9227 9227 2750
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25C9
 Encoding: 9673 9673 2751
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25C7
 Encoding: 9671 9671 2752
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25C8
 Encoding: 9672 9672 2753
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25CE
 Encoding: 9678 9678 2754
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25D0
 Encoding: 9680 9680 2755
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25D1
 Encoding: 9681 9681 2756
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25D2
 Encoding: 9682 9682 2757
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25D3
 Encoding: 9683 9683 2758
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25D4
 Encoding: 9684 9684 2759
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25D5
 Encoding: 9685 9685 2760
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F4
 Encoding: 9716 9716 2761
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F5
 Encoding: 9717 9717 2762
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F6
 Encoding: 9718 9718 2763
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F7
 Encoding: 9719 9719 2764
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F0
 Encoding: 9712 9712 2765
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F1
 Encoding: 9713 9713 2766
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F2
 Encoding: 9714 9714 2767
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25F3
 Encoding: 9715 9715 2768
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25A3
 Encoding: 9635 9635 2769
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25A2
 Encoding: 9634 9634 2770
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: H18543
 Encoding: 9642 9642 2771
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: H18551
 Encoding: 9643 9643 2772
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni25C6
 Encoding: 9670 9670 2773
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF014
 Encoding: 61460 61460 2774
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF48E
 Encoding: 62606 62606 2775
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF1F8
 Encoding: 61944 61944 2776
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2744
 Encoding: 10052 10052 2777
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE702
 Encoding: 59138 59138 2778
 Width: 945
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF260
 Encoding: 62048 62048 2779
 Width: 945
 VWidth: 0
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniE716
 Encoding: 59158 59158 2780
 Width: 945
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF071
 Encoding: 61553 61553 2781
 Width: 945
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0C4
 Encoding: 61636 61636 2782
 Width: 945
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF0E7
 Encoding: 61671 61671 2783
 Width: 945
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF15D
 Encoding: 61789 61789 2784
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF15E
 Encoding: 61790 61790 2785
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF425
 Encoding: 62501 62501 2786
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF449
 Encoding: 62537 62537 2787
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF475
 Encoding: 62581 62581 2788
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF49E
 Encoding: 62622 62622 2789
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF529
 Encoding: 62761 62761 2790
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF5EB
 Encoding: 62955 62955 2791
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: three.denominator
 Encoding: 63064 63064 2792
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: four.denominator
 Encoding: 63065 63065 2793
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: seven.numerator
 Encoding: 63080 63080 2794
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: Wcircumflex.small
 Encoding: 63142 63142 2795
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF71C
 Encoding: 63260 63260 2796
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF74A
 Encoding: 63306 63306 2797
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF783
 Encoding: 63363 63363 2798
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF794
 Encoding: 63380 63380 2799
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: ucircumflex.sc
 Encoding: 63483 63483 2800
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF816
 Encoding: 63510 63510 2801
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF834
 Encoding: 63540 63540 2802
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF835
 Encoding: 63541 63541 2803
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF89F
 Encoding: 63647 63647 2804
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF8D7
 Encoding: 63703 63703 2805
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF8FE
 Encoding: 63742 63742 2806
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFAB6
 Encoding: 64182 64182 2807
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFC2E
 Encoding: 64558 64558 2808
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFCE4
 Encoding: 64740 64740 2809
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniFD32
 Encoding: 64818 64818 2810
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2176
 Encoding: 8566 8566 2811
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2177
 Encoding: 8567 8567 2812
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni217B
 Encoding: 8571 8571 2813
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: parenright.numerator
 Encoding: 63026 63026 2814
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: parenleft.numerator
 Encoding: 63025 63025 2815
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F311
 Encoding: 127761 127761 2816
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F312
 Encoding: 127762 127762 2817
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F313
 Encoding: 127763 127763 2818
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F314
 Encoding: 127764 127764 2819
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F315
 Encoding: 127765 127765 2820
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F316
 Encoding: 127766 127766 2821
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F317
 Encoding: 127767 127767 2822
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F318
 Encoding: 127768 127768 2823
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni0CA0
 Encoding: 3232 3232 2824
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni26D4
 Encoding: 9940 9940 2825
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2728
 Encoding: 10024 10024 2826
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2753
 Encoding: 10067 10067 2827
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F379
 Encoding: 127865 127865 2828
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F381
 Encoding: 127873 127873 2829
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F41B
 Encoding: 128027 128027 2830
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F47D
 Encoding: 128125 128125 2831
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4A1
 Encoding: 128161 128161 2832
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4A5
 Encoding: 128165 128165 2833
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4BC
 Encoding: 128188 128188 2834
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4D6
 Encoding: 128214 128214 2835
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F4E1
 Encoding: 128225 128225 2836
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F510
 Encoding: 128272 128272 2837
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F511
 Encoding: 128273 128273 2838
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F517
 Encoding: 128279 128279 2839
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F527
 Encoding: 128295 128295 2840
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F5A8
 Encoding: 128424 128424 2841
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F60A
 Encoding: 128522 128522 2842
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F680
 Encoding: 128640 128640 2843
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F6E0
 Encoding: 128736 128736 2844
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F937
 Encoding: 129335 129335 2845
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F42B
 Encoding: 128043 128043 2846
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: u1F42A
 Encoding: 128042 128042 2847
 Width: 1890
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: logicaland
 Encoding: 8743 8743 2848
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: logicalor
 Encoding: 8744 8744 2849
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: intersection
 Encoding: 8745 8745 2850
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: union
 Encoding: 8746 8746 2851
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: propersubset
 Encoding: 8834 8834 2852
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: propersuperset
 Encoding: 8835 8835 2853
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: notsubset
 Encoding: 8836 8836 2854
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2285
 Encoding: 8837 8837 2855
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: reflexsubset
 Encoding: 8838 8838 2856
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: reflexsuperset
 Encoding: 8839 8839 2857
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2288
 Encoding: 8840 8840 2858
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni2289
 Encoding: 8841 8841 2859
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni228A
 Encoding: 8842 8842 2860
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni228B
 Encoding: 8843 8843 2861
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22C0
 Encoding: 8896 8896 2862
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22C1
 Encoding: 8897 8897 2863
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22C2
 Encoding: 8898 8898 2864
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uni22C3
 Encoding: 8899 8899 2865
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF293
 Encoding: 62099 62099 2866
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF294
 Encoding: 62100 62100 2867
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF5AE
 Encoding: 62894 62894 2868
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF5AF
 Encoding: 62895 62895 2869
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF5B1
 Encoding: 62897 62897 2870
 Width: 1024
-Flags: HW
+Flags: W
 LayerCount: 2
+Fore
+Validated: 1
 EndChar
 
 StartChar: uniF5B2
 Encoding: 62898 62898 2871
 Width: 1024
-Flags: HW
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF499
+Encoding: 62617 62617 2872
+Width: 945
+VWidth: 0
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF832
+Encoding: 63538 63538 2873
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF833
+Encoding: 63539 63539 2874
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF836
+Encoding: 63542 63542 2875
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF837
+Encoding: 63543 63543 2876
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF44A
+Encoding: 62538 62538 2877
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF44B
+Encoding: 62539 62539 2878
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF431
+Encoding: 62513 62513 2879
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF432
+Encoding: 62514 62514 2880
+Width: 1024
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF433
+Encoding: 62515 62515 2881
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF434
+Encoding: 62516 62516 2882
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF40E
+Encoding: 62478 62478 2883
+Width: 1024
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF4A5
+Encoding: 62629 62629 2884
+Width: 1024
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF40F
+Encoding: 62479 62479 2885
+Width: 1024
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF411
+Encoding: 62481 62481 2886
+Width: 1024
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF413
+Encoding: 62483 62483 2887
+Width: 1024
+Flags: W
+LayerCount: 2
+Fore
+Validated: 1
+EndChar
+
+StartChar: uniF71E
+Encoding: 63262 63262 2888
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniE235
+Encoding: 57909 57909 2889
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF886
+Encoding: 63622 63622 2890
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF72A
+Encoding: 63274 63274 2891
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF722
+Encoding: 63266 63266 2892
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF71A
+Encoding: 63258 63258 2893
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF72B
+Encoding: 63275 63275 2894
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF72D
+Encoding: 63277 63277 2895
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF53B
+Encoding: 62779 62779 2896
+Width: 945
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF83C
+Encoding: 63548 63548 2897
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF144
+Encoding: 61764 61764 2898
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF423
+Encoding: 62499 62499 2899
+Width: 945
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF5BD
+Encoding: 62909 62909 2900
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: guillemotright.cap
+Encoding: 63159 63159 2901
+Width: 945
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: guilsinglleft.cap
+Encoding: 63160 63160 2902
+Width: 945
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: guilsinglright.cap
+Encoding: 63161 63161 2903
+Width: 945
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: dollar.oldstyle
+Encoding: 63268 63268 2904
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF7D9
+Encoding: 63449 63449 2905
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF5BC
+Encoding: 62908 62908 2906
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: Lcommaaccent.small
+Encoding: 63116 63116 2907
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniFB68
+Encoding: 64360 64360 2908
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF831
+Encoding: 63537 63537 2909
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF55C
+Encoding: 62812 62812 2910
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF544
+Encoding: 62788 62788 2911
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF54C
+Encoding: 62796 62796 2912
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF553
+Encoding: 62803 62803 2913
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF55B
+Encoding: 62811 62811 2914
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF55A
+Encoding: 62810 62810 2915
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF541
+Encoding: 62785 62785 2916
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF542
+Encoding: 62786 62786 2917
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF543
+Encoding: 62787 62787 2918
+Width: 1024
+Flags: W
+LayerCount: 2
+EndChar
+
+StartChar: uniF54B
+Encoding: 62795 62795 2919
+Width: 1024
+Flags: W
 LayerCount: 2
 EndChar
 EndChars
-BitmapFont: 13 2873 10 3 1
+BitmapFont: 13 2935 10 3 1
 BDFStartProperties: 42
 FONT 1 "-slavfox-Cozette-Medium-R-Normal--13-120-75-75-M-60-ISO10646-1"
 COMMENT 0 "(c) 2020-2022 Slavfox"
@@ -23899,8 +29626,8 @@ BDFChar: 1617 62221 6 0 6 -2 7
 0R3N`rdI%Yptu,P
 BDFChar: 1618 62222 6 0 6 1 6
 r.<@#69YAL
-BDFChar: 1619 62224 6 0 6 -2 9
-!"]DY#S9D8Jq?BM
+BDFChar: 1619 62224 6 0 6 -2 8
+&-sBa&4F*]Jj_Qu
 BDFChar: 1620 62226 6 1 5 1 5
 k_Q19VuQet
 BDFChar: 1621 62227 6 0 6 -1 8
@@ -23945,7 +29672,7 @@ BDFChar: 1640 57352 6 0 6 0 7
 +966'hTfpc
 BDFChar: 1641 57353 6 2 3 -1 8
 ^qdb$^qd_c^q]pM
-BDFChar: 1642 57354 6 1 6 0 7
+BDFChar: 1642 57354 6 1 5 0 7
 G]7'cpb6)@
 BDFChar: 1643 370 6 1 5 -2 7
 LkpkCLkpk++><cq
@@ -24044,9 +29771,9 @@ BDFChar: 1689 59209 6 0 6 0 7
 BDFChar: 1690 59210 6 0 6 0 7
 'GQ!E./Zn<
 BDFChar: 1691 63256 6 0 5 0 7
-n<f`!KS5$V
-BDFChar: 1692 63251 6 0 5 0 7
 n<f`!["Pga
+BDFChar: 1692 63251 6 0 5 0 7
+n<f`!KS5$V
 BDFChar: 1693 59224 6 0 6 0 7
 'GQ!E./Zn<
 BDFChar: 1694 59225 6 0 6 -3 9
@@ -24179,8 +29906,8 @@ BDFChar: 1757 641 6 1 5 0 5
 LkplVM!tBE
 BDFChar: 1758 642 6 1 5 -3 5
 G^s`=#k3@p?iU0,
-BDFChar: 1759 643 6 1 6 -3 8
-$kNs]&.fBa&.fC\
+BDFChar: 1759 643 6 2 6 -3 8
+(a'qD+<VdL+<VfB
 BDFChar: 1760 649 6 0 6 0 5
 6q%#B6p(GL
 BDFChar: 1761 650 6 1 5 0 5
@@ -25113,7 +30840,7 @@ BDFChar: 2224 397 6 1 5 -3 5
 E/9=+Li=IJ?iU0,
 BDFChar: 2225 400 6 1 5 0 7
 E/9$`J:NGp
-BDFChar: 2226 408 6 1 6 0 7
+BDFChar: 2226 408 6 1 5 0 7
 OJo,9OH>9S
 BDFChar: 2227 409 6 1 5 0 8
 5bNX`OJ(NnL]@DT
@@ -26401,12 +32128,136 @@ BDFChar: 2868 62894 6 0 4 -1 6
 +L#N50PI[5
 BDFChar: 2869 62895 6 0 6 -1 6
 ,dM/?12=*?
-BDFChar: -1 62896 6 0 0 0 0
-z
 BDFChar: 2870 62897 6 0 5 -1 6
 +L#N50PIg9
 BDFChar: 2871 62898 6 0 4 -1 8
 +L#N50PI[5!2okt
+BDFChar: 2872 62617 6 0 6 -1 6
+HmgBk7"#"5
+BDFChar: 2873 63538 6 0 6 0 6
+4u0RD^4>tY
+BDFChar: 2874 63539 6 0 6 0 6
+4uT.D^4>tY
+BDFChar: 2875 63542 6 0 6 1 5
+CkB6MC]FG8
+BDFChar: 2876 63543 6 0 6 0 6
+J8CskMJN=o
+BDFChar: 2877 62538 6 2 4 1 5
+JAC*YJ,fQL
+BDFChar: 2878 62539 6 1 5 2 4
+pi%>U
+BDFChar: 2879 62513 6 2 4 2 5
+5i=mm
+BDFChar: 2880 62514 6 1 4 2 4
++RgKR
+BDFChar: 2881 62515 6 2 4 1 4
+5X=6m
+BDFChar: 2882 62516 6 1 4 2 4
+5k%#=
+BDFChar: 2883 62478 6 0 5 0 7
+n<f`!["Pga
+BDFChar: 2884 62629 6 0 5 0 7
+n<f`!["Pga
+BDFChar: 2885 62479 6 0 5 0 7
+n<f`aPe;\I
+BDFChar: 2886 62481 6 0 5 0 7
+n<f`AUqFYD
+BDFChar: 2887 62483 6 1 5 1 5
+i;!*Bp](9o
+BDFChar: 2888 63262 6 0 5 0 7
+n<f`aPe;\I
+BDFChar: -1 63263 6 0 0 0 0
+z
+BDFChar: 2889 57909 6 0 6 0 6
+3#MM3^+_MH
+BDFChar: 2890 63622 6 2 5 0 6
+?r0*R5et/8
+BDFChar: -1 63623 6 0 0 0 0
+z
+BDFChar: 2891 63274 6 0 5 0 7
+nEAs2P`1k)
+BDFChar: 2892 63266 6 0 5 0 7
+n<f`!S<UDY
+BDFChar: -1 63264 6 0 0 0 0
+z
+BDFChar: -1 63253 6 0 0 0 0
+z
+BDFChar: 2893 63258 6 0 5 0 7
+n<f`!e>1Ul
+BDFChar: 2894 63275 6 0 5 0 7
+n<f`!eC:St
+BDFChar: -1 63267 6 0 0 0 0
+z
+BDFChar: 2895 63277 6 0 6 0 8
+n;)a\U6:CcrVuou
+BDFChar: -1 63327 6 0 0 0 0
+z
+BDFChar: -1 63328 6 0 0 0 0
+z
+BDFChar: -1 63329 6 0 0 0 0
+z
+BDFChar: -1 63330 6 0 0 0 0
+z
+BDFChar: -1 63331 6 0 0 0 0
+z
+BDFChar: 2896 62779 6 0 6 0 6
+rW)r;rr2ls
+BDFChar: 2897 63548 6 0 6 0 7
+3)k9!I)`16
+BDFChar: 2898 61764 6 0 4 1 5
+E7i7aDu]k<
+BDFChar: 2899 62499 6 0 6 0 6
+-oh3Br\u;+
+BDFChar: 2900 62909 6 0 6 0 5
+D"@/fo'QJX
+BDFChar: 2901 63159 6 0 6 0 7
+I)c/5Jp`/t
+BDFChar: 2902 63160 6 0 5 1 6
+E/=9sS6u<s
+BDFChar: 2903 63161 6 0 5 1 6
+E/=!sS7hm&
+BDFChar: 2904 63268 6 0 5 0 7
+n<f`AUqFYD
+BDFChar: -1 63269 6 0 0 0 0
+z
+BDFChar: 2905 63449 6 0 6 0 7
++F#/`RZ^&u
+BDFChar: 2906 62908 6 0 6 0 6
+ro3A*mc+3G
+BDFChar: 2907 63116 6 0 6 0 6
+rr0Xg^>f+l
+BDFChar: 2908 64360 6 0 6 0 6
+p`M%/-m/cq
+BDFChar: 2909 63537 6 0 6 0 6
+4sI_<^4>tY
+BDFChar: 2910 62812 6 1 5 1 5
++E48%+92BA
+BDFChar: 2911 62788 6 1 5 1 5
++<[V%+92BA
+BDFChar: 2912 62796 6 1 5 1 5
++@,]e+92BA
+BDFChar: 2913 62803 6 1 5 1 5
++;";Z+92BA
+BDFChar: 2914 62811 6 1 5 1 5
+GShi"J,fQL
+BDFChar: 2915 62810 6 1 5 1 5
+nA(]Y#QOi)
+BDFChar: 2916 62785 6 1 5 1 5
+#`t^pn,NFg
+BDFChar: 2917 62786 6 1 5 1 5
+J4M(*GQ7^D
+BDFChar: 2918 62787 6 0 6 0 6
+Wbh)'mVJm'
+BDFChar: -1 62789 6 0 0 0 0
+z
+BDFChar: -1 62797 6 0 0 0 0
+z
+BDFChar: -1 62804 6 0 0 0 0
+z
+BDFChar: -1 62790 6 0 0 0 0
+z
+BDFChar: 2919 62795 6 0 6 0 6
+m`)7,WlFH,
 BDFRefChar: 1999 1944 0 0 N
 BDFRefChar: 2000 1943 0 0 N
 BDFRefChar: 2001 1941 0 0 N


### PR DESCRIPTION
I added a few, mostly miscellaneous icons. I also copied some icons to others which are identical in Nerd Fonts because some TUI programs use the versions not already present in this font.

## ADDITIONS
- U+F431 - U+F434 "arrow-<x>"
- U+F44A & U+F44B "triangle-right/down"
- U+F499 "beaker"
- U+F832 "library-music"
- U+F833 "library-plus"
- U+F836 "link"
- U+F837 "link-off"

![image](https://user-images.githubusercontent.com/36683489/205235844-af0faa4c-aab3-4289-ae1a-0877fd8665ab.png)

## COPIES
- U+F40E and U+F4A5 copied from U+F718 (intended file-document)
- U+F40F copied from U+F1C5
- U+F411 copied from U+F1C1
- U+F413 copied from U+E5FF


## CHANGES
- U+F713 "file" swapped with U+F718 "file-document". Previously, "file" showed text while "file-document" did not. This change follows the Nerd Fonts convention.

(Side note, it appears as if FontForge automatically validated and tagged every glyph in the sfd when I updated it. The font still builds fine, but I do wonder if this is undesirable)