### PR TITLE
Some phonetic and logic characters (and also the Prisma nerd fonts characters)

### DIFF
--- a/Cozette/Cozette.sfd
+++ b/Cozette/Cozette.sfd
@@ -22,7 +22,7 @@ OS2Version: 1
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: -2082812035
-ModificationTime: 1670648610
+ModificationTime: 1670787313
 PfmFamily: 49
 TTFWeight: 500
 TTFWidth: 5
@@ -119,11 +119,11 @@ NameList: AGL with PUA
 DisplaySize: 13
 AntiAlias: 1
 FitToEm: 0
-WinInfo: 62606 46 14
+WinInfo: 1160 58 17
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 524288 262144 174762 0 -1048576 174762 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 1114112 2920
+BeginChars: 1114112 2939
 
 StartChar: uni0000
 Encoding: 0 0 0
@@ -26341,8 +26341,141 @@ Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
+
+StartChar: uni1D47
+Encoding: 7495 7495 2920
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni1D50
+Encoding: 7504 7504 2921
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni1D51
+Encoding: 7505 7505 2922
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni1DAE
+Encoding: 7598 7598 2923
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni1DAF
+Encoding: 7599 7599 2924
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni22BC
+Encoding: 8892 8892 2925
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni22BB
+Encoding: 8891 8891 2926
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni22BD
+Encoding: 8893 8893 2927
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni02E6
+Encoding: 742 742 2928
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni02E7
+Encoding: 743 743 2929
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni02E8
+Encoding: 744 744 2930
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni02E9
+Encoding: 745 745 2931
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni023F
+Encoding: 575 575 2932
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni0240
+Encoding: 576 576 2933
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni0236
+Encoding: 566 566 2934
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni0235
+Encoding: 565 565 2935
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni0234
+Encoding: 564 564 2936
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uniFA35
+Encoding: 64053 64053 2937
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uniFA36
+Encoding: 64054 64054 2938
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
 EndChars
-BitmapFont: 13 2921 10 3 1
+BitmapFont: 13 2966 10 3 1
 BDFStartProperties: 42
 FONT 1 "-slavfox-Cozette-Medium-R-Normal--13-120-75-75-M-60-ISO10646-1"
 COMMENT 0 "(c) 2020-2022 Slavfox"
@@ -32228,6 +32361,98 @@ BDFChar: 2918 62787 6 0 6 0 6
 Wbh)'mVJm'
 BDFChar: 2919 62795 6 0 6 0 6
 m`)7,WlFH,
+BDFChar: -1 688 6 1 4 4 9
+J:QR>OH9GB
+BDFChar: -1 689 6 1 4 4 9
+@"@0sOH9GB
+BDFChar: -1 690 6 1 2 3 8
+5QF&75_&h7
+BDFChar: -1 695 6 1 5 6 8
+W2NMm
+BDFChar: -1 704 6 1 4 5 9
+@#uKr5QCca
+BDFChar: -1 705 6 1 4 5 9
+@$!Vr+92BA
+BDFChar: 2920 7495 6 1 4 4 9
+J:QR>OPg*=
+BDFChar: -1 7496 6 1 4 4 9
+&.ifBODk1"
+BDFChar: -1 7498 6 1 4 4 8
+?kDgh?iU0,
+BDFChar: -1 7501 6 1 4 2 8
+E0-0#&.i4L
+BDFChar: 2921 7504 6 1 5 4 8
+d&<nAVuQet
+BDFChar: 2922 7505 6 1 4 1 8
+T[8d^O:Vt2
+BDFChar: -1 7580 6 1 3 5 8
+@"<c8
+BDFChar: -1 7596 6 1 5 4 8
+d&<lK&-)\1
+BDFChar: 2923 7598 6 0 4 1 8
+:hWBj83fFj
+BDFChar: 2924 7599 6 1 5 1 8
+T[8d^O:Vs/
+BDFChar: -1 7600 6 1 4 5 8
+OO14n
+BDFChar: 2925 8892 6 1 5 0 9
+p])EZ:f'uELkl$2
+BDFChar: 2926 8891 6 1 5 0 9
+Lkpj`:f&8W!;HNo
+BDFChar: 2927 8893 6 1 5 0 9
+p]-,+LepoE+<UXa
+BDFChar: -1 741 6 1 4 0 8
+n.6-B&.fBa&-)\1
+BDFChar: 2928 742 6 1 4 0 8
+&.n=B&.fBa&-)\1
+BDFChar: 2929 743 6 1 4 0 8
+&.fBan.6-B&-)\1
+BDFChar: 2930 744 6 1 4 0 8
+&.fBa&.n=B&-)\1
+BDFChar: 2931 745 6 1 4 0 8
+&.fBa&.fBan,NFg
+BDFChar: -1 691 6 1 4 4 8
+i/iJ>J,fQL
+BDFChar: -1 692 6 1 4 4 8
+&.fD7Du]k<
+BDFChar: -1 693 6 1 5 1 8
+&.fD7E"EQd
+BDFChar: -1 694 6 1 4 4 8
+OHAC^huE`W
+BDFChar: 2932 575 6 1 5 -2 5
+G^s`=#k5V`
+BDFChar: 2933 576 6 1 5 -2 5
+p^eQ5J:PEh
+BDFChar: 2934 566 6 1 4 0 7
+5X=g(5[[E]
+BDFChar: 2935 565 6 1 6 0 5
+i/j%fPc+Q^
+BDFChar: 2936 564 6 2 5 0 8
+^d(.M5X8^RhuE`W
+BDFChar: 2937 64053 6 0 6 0 6
+&3)XsI/a*F
+BDFChar: 2938 64054 6 0 6 0 6
+&1Aqp7"YC<
+BDFChar: -1 64105 6 1 5 1 5
+q"Ojap](9o
+BDFChar: -1 64111 6 1 5 1 5
+f[p2VfDkmO
+BDFChar: -1 64110 6 1 5 0 6
+p]1*ap]1'h
+BDFChar: -1 64109 6 1 5 1 5
+fYH,VfDkmO
+BDFChar: -1 64108 6 1 5 1 5
+W2QYnVuQet
+BDFChar: -1 64107 6 0 5 1 5
+0XS3o0E;(Q
+BDFChar: -1 64106 6 0 5 1 5
+['[3IZiC(+
+BDFChar: -1 64112 6 1 5 1 5
+p]1'hp](9o
+BDFChar: -1 64143 6 0 0 0 0
+z
+BDFChar: -1 58173 6 0 0 0 0
+z
 BDFRefChar: 1999 1944 0 0 N
 BDFRefChar: 2000 1943 0 0 N
 BDFRefChar: 2001 1941 0 0 N


### PR DESCRIPTION
This pull request includes additions in these blocks:

 - Spacing Modifier Letters (U+02E6 through U+02E9)
 - Phonetic Extensions (U+1D47, U+1D50, U+1D51)
 - Phonetic Extensions Supplement (U+1DAE, U+1DAF)
 - Mathematical Operators (U+22BB, U+22BC, U+22BD)

as well as Nerd Fonts characters U+FA35 and U+FA36.