### PR TITLE
Add Nix flake for declarative build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ dmypy.json
 *.ttf
 *.otf
 .vim
+.direnv
+.envrc
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746183838,
+        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -10,14 +10,24 @@
       in {
         devShells = {
           default = pkgs.mkShellNoCC {
-            packages = with pkgs.python312Packages; [ black mypy isort ruff ];
+            packages = with pkgs; [
+              # BitsNPicas GUI wrapped with java
+              self.packages.${system}.bitsnpicas-bin
+              # FontForge GUI
+              fontforge-gtk
+              # Python tools
+              python312Packages.black
+              python312Packages.mypy
+              python312Packages.isort
+              python312Packages.ruff
+            ];
           };
         };
         packages = rec {
           # BitsNPicas needs to be fetched here since `nix build` is sandboxed
           # and does not have internet access
           bitsnpicas = pkgs.stdenvNoCC.mkDerivation rec {
-            pname = "BitsNPicas";
+            pname = "bitsnpicas";
             version = "2.1";
             src = pkgs.fetchFromGitHub {
               owner = "kreativekorp";
@@ -38,6 +48,12 @@
             '';
           };
 
+          # Shell script to run the BitsNPicas GUI
+          bitsnpicas-bin = pkgs.writeShellScriptBin "bitsnpicas" ''
+            ${pkgs.zulu23}/bin/java -jar ${bitsnpicas}/BitsNPicas.jar $@
+          '';
+
+          # Derivation to build and install cozette
           cozette = pkgs.stdenvNoCC.mkDerivation {
             pname = "cozette";
             version = "1.28.0";

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "A bitmap programming font optimized for coziness";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system};
+      in {
+        devShells = {
+          default = pkgs.mkShellNoCC {
+            packages = with pkgs.python312Packages; [ black mypy isort ruff ];
+          };
+        };
+        packages = rec {
+          # BitsNPicas needs to be fetched here since `nix build` is sandboxed
+          # and does not have internet access
+          bitsnpicas = pkgs.stdenvNoCC.mkDerivation rec {
+            pname = "BitsNPicas";
+            version = "2.1";
+            src = pkgs.fetchFromGitHub {
+              owner = "kreativekorp";
+              repo = "bitsnpicas";
+              rev = "v${version}";
+              hash = "sha256-hw7UuzesqpmnTjgpfikAIYyY70ni7BxjaUtHAPEdkXI=";
+            };
+            buildInputs = [ pkgs.zulu23 pkgs.zip ];
+            buildPhase = ''
+              cd main/java/BitsNPicas
+              make
+            '';
+            installPhase = ''
+              mkdir -p $out
+              cp BitsNPicas.jar $out
+              cp KeyEdit.jar $out
+              cp MapEdit.jar $out
+            '';
+          };
+
+          cozette = pkgs.stdenvNoCC.mkDerivation {
+            pname = "cozette";
+            version = "1.28.0";
+
+            src = ./.;
+
+            buildInputs = with pkgs; [
+              (pkgs.python312.withPackages (ppkgs:
+                with ppkgs; [
+                  numpy
+                  pillow
+                  fonttools
+                  crayons
+                  gitpython
+                  setuptools
+                  pip
+                ]))
+              fontforge
+              zulu23
+            ];
+
+            configurePhase = ''
+              mkdir -p deps
+              cp ${bitsnpicas}/BitsNPicas.jar deps/
+            '';
+
+            buildPhase = ''
+              patchShebangs bitsnpicas.sh
+              python3 build.py fonts
+            '';
+
+            installPhase = ''
+              runHook preInstall
+
+              cd build
+
+              install -Dm644 *.ttf -t $out/share/fonts/truetype
+              install -Dm644 *.otf -t $out/share/fonts/opentype
+              install -Dm644 *.bdf -t $out/share/fonts/misc
+              install -Dm644 *.otb -t $out/share/fonts/misc
+              install -Dm644 *.woff -t $out/share/fonts/woff
+              install -Dm644 *.woff2 -t $out/share/fonts/woff2
+
+              runHook postInstall
+            '';
+          };
+          default = cozette;
+        };
+      });
+}


### PR DESCRIPTION
The Cozette package on Nixpkgs simply fetches the latest build from the releases tab, making development difficult and preventing Nix users from building the latest commit.

This PR adds a Nix flake which can declaratively build and install Cozette. 

## BitsNPicas
As part of this process, the flake builds a derivation for BitsNPicas:

```nix
# BitsNPicas needs to be fetched here since `nix build` is sandboxed
# and does not have internet access
bitsnpicas = pkgs.stdenvNoCC.mkDerivation rec {
  pname = "bitsnpicas";
  version = "2.1";
  src = pkgs.fetchFromGitHub {
    owner = "kreativekorp";
    repo = "bitsnpicas";
    rev = "v${version}";
    hash = "sha256-hw7UuzesqpmnTjgpfikAIYyY70ni7BxjaUtHAPEdkXI=";
  };
  buildInputs = [ pkgs.zulu23 pkgs.zip ];
  buildPhase = ''
    cd main/java/BitsNPicas
    make
  '';
  installPhase = ''
    mkdir -p $out
    cp BitsNPicas.jar $out
    cp KeyEdit.jar $out
    cp MapEdit.jar $out
  '';
};
```

## Cozette
The Cozette derivation installs these `.jar`s into the `deps/` folder, meaning that the existing shell scripts in the repository do not need to be modified. 

```nix
configurePhase = ''
  mkdir -p deps
  cp ${bitsnpicas}/BitsNPicas.jar deps/
'';
```

## Dev Shell
The flake also provides a development shell for Cozette, including python tools (black, mypy, isort, ruff), as well as FontForge (`fontforge-gtk`) and a wrapper for the BitsNPicas GUI.

```nix
default = pkgs.mkShellNoCC {
  packages = with pkgs; [
    # BitsNPicas GUI wrapped with java
    self.packages.${system}.bitsnpicas-bin
    # FontForge GUI
    fontforge-gtk
    # Python tools
    python312Packages.black
    python312Packages.mypy
    python312Packages.isort
    python312Packages.ruff
  ];
};

