### PR TITLE
[JP] Basic kanji and some other stuff

### DIFF
--- a/Cozette/Cozette.sfd
+++ b/Cozette/Cozette.sfd
@@ -22,7 +22,7 @@ OS2Version: 1
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: -2082812035
-ModificationTime: 1746723672
+ModificationTime: 1746826264
 PfmFamily: 49
 TTFWeight: 500
 TTFWidth: 5
@@ -121,11 +121,11 @@ DisplaySize: 13
 AntiAlias: 1
 FitToEm: 0
 WidthSeparation: 307
-WinInfo: 2176 32 20
+WinInfo: 3213 27 17
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 524288 262144 174762 0 -1048576 174762 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 1114112 5983
+BeginChars: 1114112 5982
 
 StartChar: uni0000
 Encoding: 0 0 0
@@ -29373,7 +29373,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3246 12363 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni304D
@@ -29391,7 +29391,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3248 12365 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni304F
@@ -29409,7 +29409,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3250 12367 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3051
@@ -29427,7 +29427,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3252 12369 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3053
@@ -29445,7 +29445,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3254 12371 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3055
@@ -29463,7 +29463,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3256 12373 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3057
@@ -29481,7 +29481,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3258 12375 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3059
@@ -29499,7 +29499,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3260 12377 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni305B
@@ -29517,7 +29517,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3262 12379 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni305D
@@ -29535,7 +29535,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3264 12381 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni305F
@@ -29553,7 +29553,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3266 12383 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3061
@@ -29571,7 +29571,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3268 12385 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3063
@@ -29598,7 +29598,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3271 12388 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3066
@@ -29616,7 +29616,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3273 12390 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3068
@@ -29634,7 +29634,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3275 12392 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni306A
@@ -29697,7 +29697,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3282 12399 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3071
@@ -29706,7 +29706,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3282 12399 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni307C
@@ -29715,7 +29715,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3287 12411 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni307D
@@ -29724,7 +29724,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3287 12411 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni307B
@@ -29751,7 +29751,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3288 12402 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3075
@@ -29769,7 +29769,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3288 12402 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3076
@@ -29778,7 +29778,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3290 12405 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3078
@@ -29796,7 +29796,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3290 12405 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3079
@@ -29805,7 +29805,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3293 12408 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni307A
@@ -29814,7 +29814,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3293 12408 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni307E
@@ -30021,7 +30021,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3241 12358 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni3095
@@ -30075,7 +30075,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3324 12445 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni309F
@@ -30201,7 +30201,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3338 12459 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30AD
@@ -30219,7 +30219,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3340 12461 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30AF
@@ -30237,7 +30237,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3342 12463 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30B1
@@ -30255,7 +30255,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3344 12465 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30B3
@@ -30273,7 +30273,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3346 12467 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30B5
@@ -30291,7 +30291,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3348 12469 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30B7
@@ -30309,7 +30309,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3350 12471 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30B9
@@ -30327,7 +30327,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3352 12473 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30BB
@@ -30345,7 +30345,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3354 12475 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30BD
@@ -30363,7 +30363,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3356 12477 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30BF
@@ -30380,8 +30380,6 @@ Encoding: 12480 12480 3359
 Width: 1890
 Flags: HW
 LayerCount: 2
-Fore
-Validated: 1
 EndChar
 
 StartChar: uni30C1
@@ -30399,7 +30397,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3360 12481 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30C3
@@ -30426,7 +30424,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3363 12484 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30C6
@@ -30444,7 +30442,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3365 12486 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30C8
@@ -30462,7 +30460,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3367 12488 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30CA
@@ -30525,7 +30523,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3374 12495 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D1
@@ -30534,7 +30532,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3374 12495 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D2
@@ -30552,7 +30550,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3377 12498 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D4
@@ -30561,7 +30559,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3377 12498 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D5
@@ -30579,7 +30577,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3380 12501 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D7
@@ -30588,7 +30586,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3380 12501 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D8
@@ -30597,7 +30595,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3293 12408 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30D9
@@ -30606,7 +30604,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3295 12409 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30DA
@@ -30615,7 +30613,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3296 12410 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30DB
@@ -30633,7 +30631,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3386 12507 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30DD
@@ -30642,7 +30640,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3386 12507 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30DE
@@ -30849,7 +30847,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3333 12454 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30F5
@@ -30876,7 +30874,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3406 12527 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30F8
@@ -30885,7 +30883,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3407 12528 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30F9
@@ -30894,7 +30892,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3408 12529 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30FA
@@ -30903,7 +30901,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3409 12530 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30FB
@@ -30939,7 +30937,7 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 Fore
-Validated: 1
+Refer: 3420 12541 N 1 0 0 1 0 0 2
 EndChar
 
 StartChar: uni30FF
@@ -33298,17 +33296,8 @@ Fore
 Validated: 1
 EndChar
 
-StartChar: uni3040
-Encoding: 12352 12352 3684
-Width: 1890
-Flags: W
-LayerCount: 2
-Fore
-Validated: 1
-EndChar
-
 StartChar: u1FB00
-Encoding: 129792 129792 3685
+Encoding: 129792 129792 3684
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33317,7 +33306,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB01
-Encoding: 129793 129793 3686
+Encoding: 129793 129793 3685
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33326,7 +33315,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB02
-Encoding: 129794 129794 3687
+Encoding: 129794 129794 3686
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33335,7 +33324,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB03
-Encoding: 129795 129795 3688
+Encoding: 129795 129795 3687
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33344,7 +33333,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB04
-Encoding: 129796 129796 3689
+Encoding: 129796 129796 3688
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33353,7 +33342,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB05
-Encoding: 129797 129797 3690
+Encoding: 129797 129797 3689
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33362,7 +33351,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB06
-Encoding: 129798 129798 3691
+Encoding: 129798 129798 3690
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33371,7 +33360,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB07
-Encoding: 129799 129799 3692
+Encoding: 129799 129799 3691
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33380,7 +33369,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB08
-Encoding: 129800 129800 3693
+Encoding: 129800 129800 3692
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33389,7 +33378,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB09
-Encoding: 129801 129801 3694
+Encoding: 129801 129801 3693
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33398,7 +33387,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB0A
-Encoding: 129802 129802 3695
+Encoding: 129802 129802 3694
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33407,7 +33396,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB0B
-Encoding: 129803 129803 3696
+Encoding: 129803 129803 3695
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33416,7 +33405,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB0C
-Encoding: 129804 129804 3697
+Encoding: 129804 129804 3696
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33425,7 +33414,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB0D
-Encoding: 129805 129805 3698
+Encoding: 129805 129805 3697
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33434,7 +33423,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB0E
-Encoding: 129806 129806 3699
+Encoding: 129806 129806 3698
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33443,7 +33432,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB0F
-Encoding: 129807 129807 3700
+Encoding: 129807 129807 3699
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33452,7 +33441,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB10
-Encoding: 129808 129808 3701
+Encoding: 129808 129808 3700
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33461,7 +33450,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB11
-Encoding: 129809 129809 3702
+Encoding: 129809 129809 3701
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33470,7 +33459,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB12
-Encoding: 129810 129810 3703
+Encoding: 129810 129810 3702
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33479,7 +33468,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB13
-Encoding: 129811 129811 3704
+Encoding: 129811 129811 3703
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33488,7 +33477,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB14
-Encoding: 129812 129812 3705
+Encoding: 129812 129812 3704
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33497,7 +33486,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB15
-Encoding: 129813 129813 3706
+Encoding: 129813 129813 3705
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33506,7 +33495,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB16
-Encoding: 129814 129814 3707
+Encoding: 129814 129814 3706
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33515,7 +33504,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB17
-Encoding: 129815 129815 3708
+Encoding: 129815 129815 3707
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33524,7 +33513,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB18
-Encoding: 129816 129816 3709
+Encoding: 129816 129816 3708
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33533,7 +33522,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB19
-Encoding: 129817 129817 3710
+Encoding: 129817 129817 3709
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33542,7 +33531,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB1A
-Encoding: 129818 129818 3711
+Encoding: 129818 129818 3710
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33551,7 +33540,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB1B
-Encoding: 129819 129819 3712
+Encoding: 129819 129819 3711
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33560,7 +33549,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB1C
-Encoding: 129820 129820 3713
+Encoding: 129820 129820 3712
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33569,7 +33558,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB1D
-Encoding: 129821 129821 3714
+Encoding: 129821 129821 3713
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33578,7 +33567,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB1E
-Encoding: 129822 129822 3715
+Encoding: 129822 129822 3714
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33587,7 +33576,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB1F
-Encoding: 129823 129823 3716
+Encoding: 129823 129823 3715
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33596,7 +33585,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB20
-Encoding: 129824 129824 3717
+Encoding: 129824 129824 3716
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33605,7 +33594,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB21
-Encoding: 129825 129825 3718
+Encoding: 129825 129825 3717
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33614,7 +33603,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB22
-Encoding: 129826 129826 3719
+Encoding: 129826 129826 3718
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33623,7 +33612,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB23
-Encoding: 129827 129827 3720
+Encoding: 129827 129827 3719
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33632,7 +33621,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB24
-Encoding: 129828 129828 3721
+Encoding: 129828 129828 3720
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33641,7 +33630,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB25
-Encoding: 129829 129829 3722
+Encoding: 129829 129829 3721
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33650,7 +33639,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB26
-Encoding: 129830 129830 3723
+Encoding: 129830 129830 3722
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33659,7 +33648,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB27
-Encoding: 129831 129831 3724
+Encoding: 129831 129831 3723
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33668,7 +33657,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB28
-Encoding: 129832 129832 3725
+Encoding: 129832 129832 3724
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33677,7 +33666,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB29
-Encoding: 129833 129833 3726
+Encoding: 129833 129833 3725
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33686,7 +33675,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB2A
-Encoding: 129834 129834 3727
+Encoding: 129834 129834 3726
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33695,7 +33684,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB2B
-Encoding: 129835 129835 3728
+Encoding: 129835 129835 3727
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33704,7 +33693,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB2C
-Encoding: 129836 129836 3729
+Encoding: 129836 129836 3728
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33713,7 +33702,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB2D
-Encoding: 129837 129837 3730
+Encoding: 129837 129837 3729
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33722,7 +33711,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB2E
-Encoding: 129838 129838 3731
+Encoding: 129838 129838 3730
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33731,7 +33720,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB2F
-Encoding: 129839 129839 3732
+Encoding: 129839 129839 3731
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33740,7 +33729,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB30
-Encoding: 129840 129840 3733
+Encoding: 129840 129840 3732
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33749,7 +33738,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB31
-Encoding: 129841 129841 3734
+Encoding: 129841 129841 3733
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33758,7 +33747,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB32
-Encoding: 129842 129842 3735
+Encoding: 129842 129842 3734
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33767,7 +33756,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB33
-Encoding: 129843 129843 3736
+Encoding: 129843 129843 3735
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33776,7 +33765,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB34
-Encoding: 129844 129844 3737
+Encoding: 129844 129844 3736
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33785,7 +33774,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB35
-Encoding: 129845 129845 3738
+Encoding: 129845 129845 3737
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33794,7 +33783,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB36
-Encoding: 129846 129846 3739
+Encoding: 129846 129846 3738
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33803,7 +33792,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB37
-Encoding: 129847 129847 3740
+Encoding: 129847 129847 3739
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33812,7 +33801,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB38
-Encoding: 129848 129848 3741
+Encoding: 129848 129848 3740
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33821,7 +33810,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB39
-Encoding: 129849 129849 3742
+Encoding: 129849 129849 3741
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33830,7 +33819,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB3A
-Encoding: 129850 129850 3743
+Encoding: 129850 129850 3742
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33839,7 +33828,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FB3B
-Encoding: 129851 129851 3744
+Encoding: 129851 129851 3743
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33848,7 +33837,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC21
-Encoding: 117793 117793 3745
+Encoding: 117793 117793 3744
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33857,7 +33846,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC22
-Encoding: 117794 117794 3746
+Encoding: 117794 117794 3745
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33866,7 +33855,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC23
-Encoding: 117795 117795 3747
+Encoding: 117795 117795 3746
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33875,7 +33864,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC24
-Encoding: 117796 117796 3748
+Encoding: 117796 117796 3747
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33884,7 +33873,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC25
-Encoding: 117797 117797 3749
+Encoding: 117797 117797 3748
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33893,7 +33882,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC26
-Encoding: 117798 117798 3750
+Encoding: 117798 117798 3749
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33902,7 +33891,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC27
-Encoding: 117799 117799 3751
+Encoding: 117799 117799 3750
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33911,7 +33900,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC28
-Encoding: 117800 117800 3752
+Encoding: 117800 117800 3751
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33920,7 +33909,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC29
-Encoding: 117801 117801 3753
+Encoding: 117801 117801 3752
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33929,7 +33918,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC2A
-Encoding: 117802 117802 3754
+Encoding: 117802 117802 3753
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33938,7 +33927,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC2B
-Encoding: 117803 117803 3755
+Encoding: 117803 117803 3754
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33947,7 +33936,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC2C
-Encoding: 117804 117804 3756
+Encoding: 117804 117804 3755
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33956,7 +33945,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC2D
-Encoding: 117805 117805 3757
+Encoding: 117805 117805 3756
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33965,7 +33954,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC2E
-Encoding: 117806 117806 3758
+Encoding: 117806 117806 3757
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33974,7 +33963,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CC2F
-Encoding: 117807 117807 3759
+Encoding: 117807 117807 3758
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33983,7 +33972,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE51
-Encoding: 118353 118353 3760
+Encoding: 118353 118353 3759
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -33992,7 +33981,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE52
-Encoding: 118354 118354 3761
+Encoding: 118354 118354 3760
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34001,7 +33990,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE53
-Encoding: 118355 118355 3762
+Encoding: 118355 118355 3761
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34010,7 +33999,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE54
-Encoding: 118356 118356 3763
+Encoding: 118356 118356 3762
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34019,7 +34008,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE55
-Encoding: 118357 118357 3764
+Encoding: 118357 118357 3763
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34028,7 +34017,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE56
-Encoding: 118358 118358 3765
+Encoding: 118358 118358 3764
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34037,7 +34026,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE57
-Encoding: 118359 118359 3766
+Encoding: 118359 118359 3765
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34046,7 +34035,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE58
-Encoding: 118360 118360 3767
+Encoding: 118360 118360 3766
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34055,7 +34044,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE59
-Encoding: 118361 118361 3768
+Encoding: 118361 118361 3767
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34064,7 +34053,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE5A
-Encoding: 118362 118362 3769
+Encoding: 118362 118362 3768
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34073,7 +34062,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE5B
-Encoding: 118363 118363 3770
+Encoding: 118363 118363 3769
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34082,7 +34071,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE5C
-Encoding: 118364 118364 3771
+Encoding: 118364 118364 3770
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34091,7 +34080,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE5D
-Encoding: 118365 118365 3772
+Encoding: 118365 118365 3771
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34100,7 +34089,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE5E
-Encoding: 118366 118366 3773
+Encoding: 118366 118366 3772
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34109,7 +34098,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE5F
-Encoding: 118367 118367 3774
+Encoding: 118367 118367 3773
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34118,7 +34107,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE60
-Encoding: 118368 118368 3775
+Encoding: 118368 118368 3774
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34127,7 +34116,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE61
-Encoding: 118369 118369 3776
+Encoding: 118369 118369 3775
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34136,7 +34125,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE62
-Encoding: 118370 118370 3777
+Encoding: 118370 118370 3776
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34145,7 +34134,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE63
-Encoding: 118371 118371 3778
+Encoding: 118371 118371 3777
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34154,7 +34143,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE64
-Encoding: 118372 118372 3779
+Encoding: 118372 118372 3778
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34163,7 +34152,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE65
-Encoding: 118373 118373 3780
+Encoding: 118373 118373 3779
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34172,7 +34161,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE66
-Encoding: 118374 118374 3781
+Encoding: 118374 118374 3780
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34181,7 +34170,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE67
-Encoding: 118375 118375 3782
+Encoding: 118375 118375 3781
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34190,7 +34179,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE68
-Encoding: 118376 118376 3783
+Encoding: 118376 118376 3782
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34199,7 +34188,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE69
-Encoding: 118377 118377 3784
+Encoding: 118377 118377 3783
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34208,7 +34197,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE6A
-Encoding: 118378 118378 3785
+Encoding: 118378 118378 3784
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34217,7 +34206,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE6B
-Encoding: 118379 118379 3786
+Encoding: 118379 118379 3785
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34226,7 +34215,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE6C
-Encoding: 118380 118380 3787
+Encoding: 118380 118380 3786
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34235,7 +34224,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE6D
-Encoding: 118381 118381 3788
+Encoding: 118381 118381 3787
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34244,7 +34233,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE6E
-Encoding: 118382 118382 3789
+Encoding: 118382 118382 3788
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34253,7 +34242,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE6F
-Encoding: 118383 118383 3790
+Encoding: 118383 118383 3789
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34262,7 +34251,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE70
-Encoding: 118384 118384 3791
+Encoding: 118384 118384 3790
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34271,7 +34260,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE71
-Encoding: 118385 118385 3792
+Encoding: 118385 118385 3791
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34280,7 +34269,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE72
-Encoding: 118386 118386 3793
+Encoding: 118386 118386 3792
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34289,7 +34278,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE73
-Encoding: 118387 118387 3794
+Encoding: 118387 118387 3793
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34298,7 +34287,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE74
-Encoding: 118388 118388 3795
+Encoding: 118388 118388 3794
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34307,7 +34296,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE75
-Encoding: 118389 118389 3796
+Encoding: 118389 118389 3795
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34316,7 +34305,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE76
-Encoding: 118390 118390 3797
+Encoding: 118390 118390 3796
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34325,7 +34314,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE77
-Encoding: 118391 118391 3798
+Encoding: 118391 118391 3797
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34334,7 +34323,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE78
-Encoding: 118392 118392 3799
+Encoding: 118392 118392 3798
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34343,7 +34332,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE79
-Encoding: 118393 118393 3800
+Encoding: 118393 118393 3799
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34352,7 +34341,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE7A
-Encoding: 118394 118394 3801
+Encoding: 118394 118394 3800
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34361,7 +34350,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE7B
-Encoding: 118395 118395 3802
+Encoding: 118395 118395 3801
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34370,7 +34359,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE7C
-Encoding: 118396 118396 3803
+Encoding: 118396 118396 3802
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34379,7 +34368,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE7D
-Encoding: 118397 118397 3804
+Encoding: 118397 118397 3803
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34388,7 +34377,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE7E
-Encoding: 118398 118398 3805
+Encoding: 118398 118398 3804
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34397,7 +34386,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE7F
-Encoding: 118399 118399 3806
+Encoding: 118399 118399 3805
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34406,7 +34395,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE80
-Encoding: 118400 118400 3807
+Encoding: 118400 118400 3806
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34415,7 +34404,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE81
-Encoding: 118401 118401 3808
+Encoding: 118401 118401 3807
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34424,7 +34413,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE82
-Encoding: 118402 118402 3809
+Encoding: 118402 118402 3808
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34433,7 +34422,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE83
-Encoding: 118403 118403 3810
+Encoding: 118403 118403 3809
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34442,7 +34431,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE84
-Encoding: 118404 118404 3811
+Encoding: 118404 118404 3810
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34451,7 +34440,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE85
-Encoding: 118405 118405 3812
+Encoding: 118405 118405 3811
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34460,7 +34449,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE86
-Encoding: 118406 118406 3813
+Encoding: 118406 118406 3812
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34469,7 +34458,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE87
-Encoding: 118407 118407 3814
+Encoding: 118407 118407 3813
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34478,7 +34467,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE88
-Encoding: 118408 118408 3815
+Encoding: 118408 118408 3814
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34487,7 +34476,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE89
-Encoding: 118409 118409 3816
+Encoding: 118409 118409 3815
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34496,7 +34485,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE8A
-Encoding: 118410 118410 3817
+Encoding: 118410 118410 3816
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34505,7 +34494,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE8B
-Encoding: 118411 118411 3818
+Encoding: 118411 118411 3817
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34514,7 +34503,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE8C
-Encoding: 118412 118412 3819
+Encoding: 118412 118412 3818
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34523,7 +34512,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE8D
-Encoding: 118413 118413 3820
+Encoding: 118413 118413 3819
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34532,7 +34521,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE8E
-Encoding: 118414 118414 3821
+Encoding: 118414 118414 3820
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34541,7 +34530,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CE8F
-Encoding: 118415 118415 3822
+Encoding: 118415 118415 3821
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34550,7 +34539,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF0
-Encoding: 130032 130032 3823
+Encoding: 130032 130032 3822
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34559,7 +34548,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF1
-Encoding: 130033 130033 3824
+Encoding: 130033 130033 3823
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34568,7 +34557,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF2
-Encoding: 130034 130034 3825
+Encoding: 130034 130034 3824
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34577,7 +34566,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF3
-Encoding: 130035 130035 3826
+Encoding: 130035 130035 3825
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34586,7 +34575,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF4
-Encoding: 130036 130036 3827
+Encoding: 130036 130036 3826
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34595,7 +34584,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF5
-Encoding: 130037 130037 3828
+Encoding: 130037 130037 3827
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34604,7 +34593,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF6
-Encoding: 130038 130038 3829
+Encoding: 130038 130038 3828
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34613,7 +34602,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF7
-Encoding: 130039 130039 3830
+Encoding: 130039 130039 3829
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34622,7 +34611,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF8
-Encoding: 130040 130040 3831
+Encoding: 130040 130040 3830
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34631,7 +34620,7 @@ Validated: 1
 EndChar
 
 StartChar: u1FBF9
-Encoding: 130041 130041 3832
+Encoding: 130041 130041 3831
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34640,7 +34629,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF0
-Encoding: 118000 118000 3833
+Encoding: 118000 118000 3832
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34649,7 +34638,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF1
-Encoding: 118001 118001 3834
+Encoding: 118001 118001 3833
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34658,7 +34647,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF2
-Encoding: 118002 118002 3835
+Encoding: 118002 118002 3834
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34667,7 +34656,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF3
-Encoding: 118003 118003 3836
+Encoding: 118003 118003 3835
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34676,7 +34665,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF4
-Encoding: 118004 118004 3837
+Encoding: 118004 118004 3836
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34685,7 +34674,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF5
-Encoding: 118005 118005 3838
+Encoding: 118005 118005 3837
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34694,7 +34683,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF6
-Encoding: 118006 118006 3839
+Encoding: 118006 118006 3838
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34703,7 +34692,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF7
-Encoding: 118007 118007 3840
+Encoding: 118007 118007 3839
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34712,7 +34701,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF8
-Encoding: 118008 118008 3841
+Encoding: 118008 118008 3840
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34721,7 +34710,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCF9
-Encoding: 118009 118009 3842
+Encoding: 118009 118009 3841
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34730,7 +34719,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCD6
-Encoding: 117974 117974 3843
+Encoding: 117974 117974 3842
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34739,7 +34728,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCD7
-Encoding: 117975 117975 3844
+Encoding: 117975 117975 3843
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34748,7 +34737,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCD8
-Encoding: 117976 117976 3845
+Encoding: 117976 117976 3844
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34757,7 +34746,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCD9
-Encoding: 117977 117977 3846
+Encoding: 117977 117977 3845
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34766,7 +34755,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCDA
-Encoding: 117978 117978 3847
+Encoding: 117978 117978 3846
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34775,7 +34764,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCDB
-Encoding: 117979 117979 3848
+Encoding: 117979 117979 3847
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34784,7 +34773,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCDC
-Encoding: 117980 117980 3849
+Encoding: 117980 117980 3848
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34793,7 +34782,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCDD
-Encoding: 117981 117981 3850
+Encoding: 117981 117981 3849
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34802,7 +34791,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCDE
-Encoding: 117982 117982 3851
+Encoding: 117982 117982 3850
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34811,7 +34800,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCDF
-Encoding: 117983 117983 3852
+Encoding: 117983 117983 3851
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34820,7 +34809,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE0
-Encoding: 117984 117984 3853
+Encoding: 117984 117984 3852
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34829,7 +34818,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE1
-Encoding: 117985 117985 3854
+Encoding: 117985 117985 3853
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34838,7 +34827,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE2
-Encoding: 117986 117986 3855
+Encoding: 117986 117986 3854
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34847,7 +34836,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE3
-Encoding: 117987 117987 3856
+Encoding: 117987 117987 3855
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34856,7 +34845,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE4
-Encoding: 117988 117988 3857
+Encoding: 117988 117988 3856
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34865,7 +34854,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE5
-Encoding: 117989 117989 3858
+Encoding: 117989 117989 3857
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34874,7 +34863,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE6
-Encoding: 117990 117990 3859
+Encoding: 117990 117990 3858
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34883,7 +34872,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE7
-Encoding: 117991 117991 3860
+Encoding: 117991 117991 3859
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34892,7 +34881,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE8
-Encoding: 117992 117992 3861
+Encoding: 117992 117992 3860
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34901,7 +34890,7 @@ Validated: 1
 EndChar
 
 StartChar: u1CCE9
-Encoding: 117993 117993 3862
+Encoding: 117993 117993 3861
 Width: 1024
 Flags: W
 LayerCount: 2
@@ -34910,14840 +34899,14840 @@ Validated: 1
 EndChar
 
 StartChar: u1CCEA
-Encoding: 117994 117994 3863
+Encoding: 117994 117994 3862
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCEB
-Encoding: 117995 117995 3864
+Encoding: 117995 117995 3863
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCEC
-Encoding: 117996 117996 3865
+Encoding: 117996 117996 3864
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCED
-Encoding: 117997 117997 3866
+Encoding: 117997 117997 3865
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCEE
-Encoding: 117998 117998 3867
+Encoding: 117998 117998 3866
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCEF
-Encoding: 117999 117999 3868
+Encoding: 117999 117999 3867
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB3C
-Encoding: 129852 129852 3869
+Encoding: 129852 129852 3868
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB3D
-Encoding: 129853 129853 3870
+Encoding: 129853 129853 3869
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB3E
-Encoding: 129854 129854 3871
+Encoding: 129854 129854 3870
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB3F
-Encoding: 129855 129855 3872
+Encoding: 129855 129855 3871
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB40
-Encoding: 129856 129856 3873
+Encoding: 129856 129856 3872
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB41
-Encoding: 129857 129857 3874
+Encoding: 129857 129857 3873
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB42
-Encoding: 129858 129858 3875
+Encoding: 129858 129858 3874
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB43
-Encoding: 129859 129859 3876
+Encoding: 129859 129859 3875
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB44
-Encoding: 129860 129860 3877
+Encoding: 129860 129860 3876
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB45
-Encoding: 129861 129861 3878
+Encoding: 129861 129861 3877
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB46
-Encoding: 129862 129862 3879
+Encoding: 129862 129862 3878
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB47
-Encoding: 129863 129863 3880
+Encoding: 129863 129863 3879
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB48
-Encoding: 129864 129864 3881
+Encoding: 129864 129864 3880
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB49
-Encoding: 129865 129865 3882
+Encoding: 129865 129865 3881
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB4A
-Encoding: 129866 129866 3883
+Encoding: 129866 129866 3882
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB4B
-Encoding: 129867 129867 3884
+Encoding: 129867 129867 3883
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB4C
-Encoding: 129868 129868 3885
+Encoding: 129868 129868 3884
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB4D
-Encoding: 129869 129869 3886
+Encoding: 129869 129869 3885
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB4E
-Encoding: 129870 129870 3887
+Encoding: 129870 129870 3886
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB4F
-Encoding: 129871 129871 3888
+Encoding: 129871 129871 3887
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB50
-Encoding: 129872 129872 3889
+Encoding: 129872 129872 3888
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB51
-Encoding: 129873 129873 3890
+Encoding: 129873 129873 3889
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB52
-Encoding: 129874 129874 3891
+Encoding: 129874 129874 3890
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB53
-Encoding: 129875 129875 3892
+Encoding: 129875 129875 3891
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB54
-Encoding: 129876 129876 3893
+Encoding: 129876 129876 3892
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB55
-Encoding: 129877 129877 3894
+Encoding: 129877 129877 3893
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB56
-Encoding: 129878 129878 3895
+Encoding: 129878 129878 3894
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB57
-Encoding: 129879 129879 3896
+Encoding: 129879 129879 3895
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB58
-Encoding: 129880 129880 3897
+Encoding: 129880 129880 3896
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB59
-Encoding: 129881 129881 3898
+Encoding: 129881 129881 3897
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB5A
-Encoding: 129882 129882 3899
+Encoding: 129882 129882 3898
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB5B
-Encoding: 129883 129883 3900
+Encoding: 129883 129883 3899
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB5C
-Encoding: 129884 129884 3901
+Encoding: 129884 129884 3900
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB5D
-Encoding: 129885 129885 3902
+Encoding: 129885 129885 3901
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB5E
-Encoding: 129886 129886 3903
+Encoding: 129886 129886 3902
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB5F
-Encoding: 129887 129887 3904
+Encoding: 129887 129887 3903
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB60
-Encoding: 129888 129888 3905
+Encoding: 129888 129888 3904
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB61
-Encoding: 129889 129889 3906
+Encoding: 129889 129889 3905
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB62
-Encoding: 129890 129890 3907
+Encoding: 129890 129890 3906
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB63
-Encoding: 129891 129891 3908
+Encoding: 129891 129891 3907
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB64
-Encoding: 129892 129892 3909
+Encoding: 129892 129892 3908
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB65
-Encoding: 129893 129893 3910
+Encoding: 129893 129893 3909
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB66
-Encoding: 129894 129894 3911
+Encoding: 129894 129894 3910
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB67
-Encoding: 129895 129895 3912
+Encoding: 129895 129895 3911
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB68
-Encoding: 129896 129896 3913
+Encoding: 129896 129896 3912
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB69
-Encoding: 129897 129897 3914
+Encoding: 129897 129897 3913
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB6A
-Encoding: 129898 129898 3915
+Encoding: 129898 129898 3914
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB6B
-Encoding: 129899 129899 3916
+Encoding: 129899 129899 3915
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB6C
-Encoding: 129900 129900 3917
+Encoding: 129900 129900 3916
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB6E
-Encoding: 129902 129902 3918
+Encoding: 129902 129902 3917
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB6D
-Encoding: 129901 129901 3919
+Encoding: 129901 129901 3918
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB6F
-Encoding: 129903 129903 3920
+Encoding: 129903 129903 3919
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB9A
-Encoding: 129946 129946 3921
+Encoding: 129946 129946 3920
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB9B
-Encoding: 129947 129947 3922
+Encoding: 129947 129947 3921
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E2
-Encoding: 9698 9698 3923
+Encoding: 9698 9698 3922
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E3
-Encoding: 9699 9699 3924
+Encoding: 9699 9699 3923
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E4
-Encoding: 9700 9700 3925
+Encoding: 9700 9700 3924
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E5
-Encoding: 9701 9701 3926
+Encoding: 9701 9701 3925
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB95
-Encoding: 129941 129941 3927
+Encoding: 129941 129941 3926
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB96
-Encoding: 129942 129942 3928
+Encoding: 129942 129942 3927
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB97
-Encoding: 129943 129943 3929
+Encoding: 129943 129943 3928
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB98
-Encoding: 129944 129944 3930
+Encoding: 129944 129944 3929
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB99
-Encoding: 129945 129945 3931
+Encoding: 129945 129945 3930
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB8C
-Encoding: 129932 129932 3932
+Encoding: 129932 129932 3931
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB8D
-Encoding: 129933 129933 3933
+Encoding: 129933 129933 3932
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB8E
-Encoding: 129934 129934 3934
+Encoding: 129934 129934 3933
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB8F
-Encoding: 129935 129935 3935
+Encoding: 129935 129935 3934
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB90
-Encoding: 129936 129936 3936
+Encoding: 129936 129936 3935
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB91
-Encoding: 129937 129937 3937
+Encoding: 129937 129937 3936
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB92
-Encoding: 129938 129938 3938
+Encoding: 129938 129938 3937
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB94
-Encoding: 129940 129940 3939
+Encoding: 129940 129940 3938
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB9C
-Encoding: 129948 129948 3940
+Encoding: 129948 129948 3939
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB9D
-Encoding: 129949 129949 3941
+Encoding: 129949 129949 3940
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB9E
-Encoding: 129950 129950 3942
+Encoding: 129950 129950 3941
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB9F
-Encoding: 129951 129951 3943
+Encoding: 129951 129951 3942
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE4
-Encoding: 130020 130020 3944
+Encoding: 130020 130020 3943
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE5
-Encoding: 130021 130021 3945
+Encoding: 130021 130021 3944
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE6
-Encoding: 130022 130022 3946
+Encoding: 130022 130022 3945
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE7
-Encoding: 130023 130023 3947
+Encoding: 130023 130023 3946
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE0
-Encoding: 130016 130016 3948
+Encoding: 130016 130016 3947
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE1
-Encoding: 130017 130017 3949
+Encoding: 130017 130017 3948
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE2
-Encoding: 130018 130018 3950
+Encoding: 130018 130018 3949
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE3
-Encoding: 130019 130019 3951
+Encoding: 130019 130019 3950
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE8
-Encoding: 130024 130024 3952
+Encoding: 130024 130024 3951
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBE9
-Encoding: 130025 130025 3953
+Encoding: 130025 130025 3952
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBEA
-Encoding: 130026 130026 3954
+Encoding: 130026 130026 3953
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBEB
-Encoding: 130027 130027 3955
+Encoding: 130027 130027 3954
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBEC
-Encoding: 130028 130028 3956
+Encoding: 130028 130028 3955
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBED
-Encoding: 130029 130029 3957
+Encoding: 130029 130029 3956
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBEE
-Encoding: 130030 130030 3958
+Encoding: 130030 130030 3957
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBEF
-Encoding: 130031 130031 3959
+Encoding: 130031 130031 3958
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD0
-Encoding: 130000 130000 3960
+Encoding: 130000 130000 3959
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD1
-Encoding: 130001 130001 3961
+Encoding: 130001 130001 3960
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD2
-Encoding: 130002 130002 3962
+Encoding: 130002 130002 3961
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD3
-Encoding: 130003 130003 3963
+Encoding: 130003 130003 3962
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD4
-Encoding: 130004 130004 3964
+Encoding: 130004 130004 3963
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD5
-Encoding: 130005 130005 3965
+Encoding: 130005 130005 3964
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD6
-Encoding: 130006 130006 3966
+Encoding: 130006 130006 3965
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD7
-Encoding: 130007 130007 3967
+Encoding: 130007 130007 3966
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD8
-Encoding: 130008 130008 3968
+Encoding: 130008 130008 3967
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBD9
-Encoding: 130009 130009 3969
+Encoding: 130009 130009 3968
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBDA
-Encoding: 130010 130010 3970
+Encoding: 130010 130010 3969
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBDB
-Encoding: 130011 130011 3971
+Encoding: 130011 130011 3970
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBDC
-Encoding: 130012 130012 3972
+Encoding: 130012 130012 3971
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBDD
-Encoding: 130013 130013 3973
+Encoding: 130013 130013 3972
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBDE
-Encoding: 130014 130014 3974
+Encoding: 130014 130014 3973
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBDF
-Encoding: 130015 130015 3975
+Encoding: 130015 130015 3974
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA0
-Encoding: 129952 129952 3976
+Encoding: 129952 129952 3975
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA1
-Encoding: 129953 129953 3977
+Encoding: 129953 129953 3976
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA2
-Encoding: 129954 129954 3978
+Encoding: 129954 129954 3977
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA3
-Encoding: 129955 129955 3979
+Encoding: 129955 129955 3978
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA4
-Encoding: 129956 129956 3980
+Encoding: 129956 129956 3979
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA5
-Encoding: 129957 129957 3981
+Encoding: 129957 129957 3980
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA6
-Encoding: 129958 129958 3982
+Encoding: 129958 129958 3981
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA7
-Encoding: 129959 129959 3983
+Encoding: 129959 129959 3982
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA8
-Encoding: 129960 129960 3984
+Encoding: 129960 129960 3983
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBA9
-Encoding: 129961 129961 3985
+Encoding: 129961 129961 3984
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBAA
-Encoding: 129962 129962 3986
+Encoding: 129962 129962 3985
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBAB
-Encoding: 129963 129963 3987
+Encoding: 129963 129963 3986
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBAC
-Encoding: 129964 129964 3988
+Encoding: 129964 129964 3987
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBAD
-Encoding: 129965 129965 3989
+Encoding: 129965 129965 3988
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBAE
-Encoding: 129966 129966 3990
+Encoding: 129966 129966 3989
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE1A
-Encoding: 118298 118298 3991
+Encoding: 118298 118298 3990
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE1B
-Encoding: 118299 118299 3992
+Encoding: 118299 118299 3991
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE1C
-Encoding: 118300 118300 3993
+Encoding: 118300 118300 3992
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE1D
-Encoding: 118301 118301 3994
+Encoding: 118301 118301 3993
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE1E
-Encoding: 118302 118302 3995
+Encoding: 118302 118302 3994
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE1F
-Encoding: 118303 118303 3996
+Encoding: 118303 118303 3995
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE20
-Encoding: 118304 118304 3997
+Encoding: 118304 118304 3996
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE21
-Encoding: 118305 118305 3998
+Encoding: 118305 118305 3997
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE22
-Encoding: 118306 118306 3999
+Encoding: 118306 118306 3998
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE23
-Encoding: 118307 118307 4000
+Encoding: 118307 118307 3999
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE24
-Encoding: 118308 118308 4001
+Encoding: 118308 118308 4000
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE25
-Encoding: 118309 118309 4002
+Encoding: 118309 118309 4001
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE26
-Encoding: 118310 118310 4003
+Encoding: 118310 118310 4002
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE27
-Encoding: 118311 118311 4004
+Encoding: 118311 118311 4003
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE28
-Encoding: 118312 118312 4005
+Encoding: 118312 118312 4004
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE29
-Encoding: 118313 118313 4006
+Encoding: 118313 118313 4005
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE2A
-Encoding: 118314 118314 4007
+Encoding: 118314 118314 4006
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE2B
-Encoding: 118315 118315 4008
+Encoding: 118315 118315 4007
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE2C
-Encoding: 118316 118316 4009
+Encoding: 118316 118316 4008
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE2D
-Encoding: 118317 118317 4010
+Encoding: 118317 118317 4009
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE2E
-Encoding: 118318 118318 4011
+Encoding: 118318 118318 4010
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE2F
-Encoding: 118319 118319 4012
+Encoding: 118319 118319 4011
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE30
-Encoding: 118320 118320 4013
+Encoding: 118320 118320 4012
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE31
-Encoding: 118321 118321 4014
+Encoding: 118321 118321 4013
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE32
-Encoding: 118322 118322 4015
+Encoding: 118322 118322 4014
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE33
-Encoding: 118323 118323 4016
+Encoding: 118323 118323 4015
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE34
-Encoding: 118324 118324 4017
+Encoding: 118324 118324 4016
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE35
-Encoding: 118325 118325 4018
+Encoding: 118325 118325 4017
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE36
-Encoding: 118326 118326 4019
+Encoding: 118326 118326 4018
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE37
-Encoding: 118327 118327 4020
+Encoding: 118327 118327 4019
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE38
-Encoding: 118328 118328 4021
+Encoding: 118328 118328 4020
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE39
-Encoding: 118329 118329 4022
+Encoding: 118329 118329 4021
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE3A
-Encoding: 118330 118330 4023
+Encoding: 118330 118330 4022
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE3B
-Encoding: 118331 118331 4024
+Encoding: 118331 118331 4023
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE3C
-Encoding: 118332 118332 4025
+Encoding: 118332 118332 4024
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE3D
-Encoding: 118333 118333 4026
+Encoding: 118333 118333 4025
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE3E
-Encoding: 118334 118334 4027
+Encoding: 118334 118334 4026
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE3F
-Encoding: 118335 118335 4028
+Encoding: 118335 118335 4027
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE40
-Encoding: 118336 118336 4029
+Encoding: 118336 118336 4028
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE41
-Encoding: 118337 118337 4030
+Encoding: 118337 118337 4029
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE42
-Encoding: 118338 118338 4031
+Encoding: 118338 118338 4030
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE43
-Encoding: 118339 118339 4032
+Encoding: 118339 118339 4031
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE44
-Encoding: 118340 118340 4033
+Encoding: 118340 118340 4032
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE45
-Encoding: 118341 118341 4034
+Encoding: 118341 118341 4033
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE46
-Encoding: 118342 118342 4035
+Encoding: 118342 118342 4034
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE47
-Encoding: 118343 118343 4036
+Encoding: 118343 118343 4035
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE48
-Encoding: 118344 118344 4037
+Encoding: 118344 118344 4036
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE49
-Encoding: 118345 118345 4038
+Encoding: 118345 118345 4037
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE4A
-Encoding: 118346 118346 4039
+Encoding: 118346 118346 4038
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE4B
-Encoding: 118347 118347 4040
+Encoding: 118347 118347 4039
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE4C
-Encoding: 118348 118348 4041
+Encoding: 118348 118348 4040
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE4D
-Encoding: 118349 118349 4042
+Encoding: 118349 118349 4041
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE4E
-Encoding: 118350 118350 4043
+Encoding: 118350 118350 4042
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE4F
-Encoding: 118351 118351 4044
+Encoding: 118351 118351 4043
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE50
-Encoding: 118352 118352 4045
+Encoding: 118352 118352 4044
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB70
-Encoding: 129904 129904 4046
+Encoding: 129904 129904 4045
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB71
-Encoding: 129905 129905 4047
+Encoding: 129905 129905 4046
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB72
-Encoding: 129906 129906 4048
+Encoding: 129906 129906 4047
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB73
-Encoding: 129907 129907 4049
+Encoding: 129907 129907 4048
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB74
-Encoding: 129908 129908 4050
+Encoding: 129908 129908 4049
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB75
-Encoding: 129909 129909 4051
+Encoding: 129909 129909 4050
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB76
-Encoding: 129910 129910 4052
+Encoding: 129910 129910 4051
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB77
-Encoding: 129911 129911 4053
+Encoding: 129911 129911 4052
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB78
-Encoding: 129912 129912 4054
+Encoding: 129912 129912 4053
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB79
-Encoding: 129913 129913 4055
+Encoding: 129913 129913 4054
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB7A
-Encoding: 129914 129914 4056
+Encoding: 129914 129914 4055
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB7B
-Encoding: 129915 129915 4057
+Encoding: 129915 129915 4056
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB7C
-Encoding: 129916 129916 4058
+Encoding: 129916 129916 4057
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB7D
-Encoding: 129917 129917 4059
+Encoding: 129917 129917 4058
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB7E
-Encoding: 129918 129918 4060
+Encoding: 129918 129918 4059
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB7F
-Encoding: 129919 129919 4061
+Encoding: 129919 129919 4060
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB80
-Encoding: 129920 129920 4062
+Encoding: 129920 129920 4061
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB81
-Encoding: 129921 129921 4063
+Encoding: 129921 129921 4062
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB82
-Encoding: 129922 129922 4064
+Encoding: 129922 129922 4063
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB83
-Encoding: 129923 129923 4065
+Encoding: 129923 129923 4064
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB84
-Encoding: 129924 129924 4066
+Encoding: 129924 129924 4065
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB85
-Encoding: 129925 129925 4067
+Encoding: 129925 129925 4066
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB86
-Encoding: 129926 129926 4068
+Encoding: 129926 129926 4067
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB87
-Encoding: 129927 129927 4069
+Encoding: 129927 129927 4068
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB88
-Encoding: 129928 129928 4070
+Encoding: 129928 129928 4069
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB89
-Encoding: 129929 129929 4071
+Encoding: 129929 129929 4070
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB8A
-Encoding: 129930 129930 4072
+Encoding: 129930 129930 4071
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FB8B
-Encoding: 129931 129931 4073
+Encoding: 129931 129931 4072
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBAF
-Encoding: 129967 129967 4074
+Encoding: 129967 129967 4073
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB0
-Encoding: 129968 129968 4075
+Encoding: 129968 129968 4074
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC1
-Encoding: 129985 129985 4076
+Encoding: 129985 129985 4075
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBBB
-Encoding: 129979 129979 4077
+Encoding: 129979 129979 4076
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBBC
-Encoding: 129980 129980 4078
+Encoding: 129980 129980 4077
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC5
-Encoding: 129989 129989 4079
+Encoding: 129989 129989 4078
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC6
-Encoding: 129990 129990 4080
+Encoding: 129990 129990 4079
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC7
-Encoding: 129991 129991 4081
+Encoding: 129991 129991 4080
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC8
-Encoding: 129992 129992 4082
+Encoding: 129992 129992 4081
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC9
-Encoding: 129993 129993 4083
+Encoding: 129993 129993 4082
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBCA
-Encoding: 129994 129994 4084
+Encoding: 129994 129994 4083
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBCB
-Encoding: 129995 129995 4085
+Encoding: 129995 129995 4084
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBCE
-Encoding: 129998 129998 4086
+Encoding: 129998 129998 4085
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBCF
-Encoding: 129999 129999 4087
+Encoding: 129999 129999 4086
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBCD
-Encoding: 129997 129997 4088
+Encoding: 129997 129997 4087
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBCC
-Encoding: 129996 129996 4089
+Encoding: 129996 129996 4088
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB8
-Encoding: 129976 129976 4090
+Encoding: 129976 129976 4089
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB7
-Encoding: 129975 129975 4091
+Encoding: 129975 129975 4090
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB6
-Encoding: 129974 129974 4092
+Encoding: 129974 129974 4091
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB5
-Encoding: 129973 129973 4093
+Encoding: 129973 129973 4092
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC0
-Encoding: 129984 129984 4094
+Encoding: 129984 129984 4093
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB4
-Encoding: 129972 129972 4095
+Encoding: 129972 129972 4094
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB1
-Encoding: 129969 129969 4096
+Encoding: 129969 129969 4095
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB2
-Encoding: 129970 129970 4097
+Encoding: 129970 129970 4096
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB3
-Encoding: 129971 129971 4098
+Encoding: 129971 129971 4097
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBB9
-Encoding: 129977 129977 4099
+Encoding: 129977 129977 4098
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBBA
-Encoding: 129978 129978 4100
+Encoding: 129978 129978 4099
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBBD
-Encoding: 129981 129981 4101
+Encoding: 129981 129981 4100
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBBE
-Encoding: 129982 129982 4102
+Encoding: 129982 129982 4101
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBBF
-Encoding: 129983 129983 4103
+Encoding: 129983 129983 4102
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC4
-Encoding: 129988 129988 4104
+Encoding: 129988 129988 4103
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC2
-Encoding: 129986 129986 4105
+Encoding: 129986 129986 4104
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FBC3
-Encoding: 129987 129987 4106
+Encoding: 129987 129987 4105
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B0
-Encoding: 129200 129200 4107
+Encoding: 129200 129200 4106
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B1
-Encoding: 129201 129201 4108
+Encoding: 129201 129201 4107
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B3
-Encoding: 129203 129203 4109
+Encoding: 129203 129203 4108
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B4
-Encoding: 129204 129204 4110
+Encoding: 129204 129204 4109
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B5
-Encoding: 129205 129205 4111
+Encoding: 129205 129205 4110
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B7
-Encoding: 129207 129207 4112
+Encoding: 129207 129207 4111
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B6
-Encoding: 129206 129206 4113
+Encoding: 129206 129206 4112
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B8
-Encoding: 129208 129208 4114
+Encoding: 129208 129208 4113
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B9
-Encoding: 129209 129209 4115
+Encoding: 129209 129209 4114
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8BA
-Encoding: 129210 129210 4116
+Encoding: 129210 129210 4115
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8BB
-Encoding: 129211 129211 4117
+Encoding: 129211 129211 4116
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F8B2
-Encoding: 129202 129202 4118
+Encoding: 129202 129202 4117
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2427
-Encoding: 9255 9255 4119
+Encoding: 9255 9255 4118
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2428
-Encoding: 9256 9256 4120
+Encoding: 9256 9256 4119
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2429
-Encoding: 9257 9257 4121
+Encoding: 9257 9257 4120
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2401
-Encoding: 9217 9217 4122
+Encoding: 9217 9217 4121
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2402
-Encoding: 9218 9218 4123
+Encoding: 9218 9218 4122
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2403
-Encoding: 9219 9219 4124
+Encoding: 9219 9219 4123
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2404
-Encoding: 9220 9220 4125
+Encoding: 9220 9220 4124
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2405
-Encoding: 9221 9221 4126
+Encoding: 9221 9221 4125
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2406
-Encoding: 9222 9222 4127
+Encoding: 9222 9222 4126
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2407
-Encoding: 9223 9223 4128
+Encoding: 9223 9223 4127
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2410
-Encoding: 9232 9232 4129
+Encoding: 9232 9232 4128
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2411
-Encoding: 9233 9233 4130
+Encoding: 9233 9233 4129
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2412
-Encoding: 9234 9234 4131
+Encoding: 9234 9234 4130
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2413
-Encoding: 9235 9235 4132
+Encoding: 9235 9235 4131
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2414
-Encoding: 9236 9236 4133
+Encoding: 9236 9236 4132
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2415
-Encoding: 9237 9237 4134
+Encoding: 9237 9237 4133
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2416
-Encoding: 9238 9238 4135
+Encoding: 9238 9238 4134
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2417
-Encoding: 9239 9239 4136
+Encoding: 9239 9239 4135
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2418
-Encoding: 9240 9240 4137
+Encoding: 9240 9240 4136
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2419
-Encoding: 9241 9241 4138
+Encoding: 9241 9241 4137
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni241A
-Encoding: 9242 9242 4139
+Encoding: 9242 9242 4138
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni241B
-Encoding: 9243 9243 4140
+Encoding: 9243 9243 4139
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2421
-Encoding: 9249 9249 4141
+Encoding: 9249 9249 4140
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2422
-Encoding: 9250 9250 4142
+Encoding: 9250 9250 4141
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2423
-Encoding: 9251 9251 4143
+Encoding: 9251 9251 4142
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2425
-Encoding: 9253 9253 4144
+Encoding: 9253 9253 4143
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2426
-Encoding: 9254 9254 4145
+Encoding: 9254 9254 4144
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE0B
-Encoding: 118283 118283 4146
+Encoding: 118283 118283 4145
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE0C
-Encoding: 118284 118284 4147
+Encoding: 118284 118284 4146
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE0A
-Encoding: 118282 118282 4148
+Encoding: 118282 118282 4147
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE09
-Encoding: 118281 118281 4149
+Encoding: 118281 118281 4148
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE0D
-Encoding: 118285 118285 4150
+Encoding: 118285 118285 4149
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE0E
-Encoding: 118286 118286 4151
+Encoding: 118286 118286 4150
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE0F
-Encoding: 118287 118287 4152
+Encoding: 118287 118287 4151
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE13
-Encoding: 118291 118291 4153
+Encoding: 118291 118291 4152
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE14
-Encoding: 118292 118292 4154
+Encoding: 118292 118292 4153
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE15
-Encoding: 118293 118293 4155
+Encoding: 118293 118293 4154
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE16
-Encoding: 118294 118294 4156
+Encoding: 118294 118294 4155
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE17
-Encoding: 118295 118295 4157
+Encoding: 118295 118295 4156
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE18
-Encoding: 118296 118296 4158
+Encoding: 118296 118296 4157
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE19
-Encoding: 118297 118297 4159
+Encoding: 118297 118297 4158
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE10
-Encoding: 118288 118288 4160
+Encoding: 118288 118288 4159
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE11
-Encoding: 118289 118289 4161
+Encoding: 118289 118289 4160
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE12
-Encoding: 118290 118290 4162
+Encoding: 118290 118290 4161
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE08
-Encoding: 118280 118280 4163
+Encoding: 118280 118280 4162
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE07
-Encoding: 118279 118279 4164
+Encoding: 118279 118279 4163
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE06
-Encoding: 118278 118278 4165
+Encoding: 118278 118278 4164
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE05
-Encoding: 118277 118277 4166
+Encoding: 118277 118277 4165
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE04
-Encoding: 118276 118276 4167
+Encoding: 118276 118276 4166
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE03
-Encoding: 118275 118275 4168
+Encoding: 118275 118275 4167
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE02
-Encoding: 118274 118274 4169
+Encoding: 118274 118274 4168
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE01
-Encoding: 118273 118273 4170
+Encoding: 118273 118273 4169
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE00
-Encoding: 118272 118272 4171
+Encoding: 118272 118272 4170
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC30
-Encoding: 117808 117808 4172
+Encoding: 117808 117808 4171
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC31
-Encoding: 117809 117809 4173
+Encoding: 117809 117809 4172
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC32
-Encoding: 117810 117810 4174
+Encoding: 117810 117810 4173
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC33
-Encoding: 117811 117811 4175
+Encoding: 117811 117811 4174
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC34
-Encoding: 117812 117812 4176
+Encoding: 117812 117812 4175
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC35
-Encoding: 117813 117813 4177
+Encoding: 117813 117813 4176
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC36
-Encoding: 117814 117814 4178
+Encoding: 117814 117814 4177
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC37
-Encoding: 117815 117815 4179
+Encoding: 117815 117815 4178
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC38
-Encoding: 117816 117816 4180
+Encoding: 117816 117816 4179
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC39
-Encoding: 117817 117817 4181
+Encoding: 117817 117817 4180
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC3A
-Encoding: 117818 117818 4182
+Encoding: 117818 117818 4181
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC3B
-Encoding: 117819 117819 4183
+Encoding: 117819 117819 4182
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC3C
-Encoding: 117820 117820 4184
+Encoding: 117820 117820 4183
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC3D
-Encoding: 117821 117821 4185
+Encoding: 117821 117821 4184
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC3E
-Encoding: 117822 117822 4186
+Encoding: 117822 117822 4185
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC3F
-Encoding: 117823 117823 4187
+Encoding: 117823 117823 4186
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC40
-Encoding: 117824 117824 4188
+Encoding: 117824 117824 4187
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC41
-Encoding: 117825 117825 4189
+Encoding: 117825 117825 4188
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC42
-Encoding: 117826 117826 4190
+Encoding: 117826 117826 4189
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC43
-Encoding: 117827 117827 4191
+Encoding: 117827 117827 4190
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC44
-Encoding: 117828 117828 4192
+Encoding: 117828 117828 4191
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC45
-Encoding: 117829 117829 4193
+Encoding: 117829 117829 4192
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC46
-Encoding: 117830 117830 4194
+Encoding: 117830 117830 4193
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC47
-Encoding: 117831 117831 4195
+Encoding: 117831 117831 4194
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE90
-Encoding: 118416 118416 4196
+Encoding: 118416 118416 4195
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE91
-Encoding: 118417 118417 4197
+Encoding: 118417 118417 4196
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE92
-Encoding: 118418 118418 4198
+Encoding: 118418 118418 4197
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE93
-Encoding: 118419 118419 4199
+Encoding: 118419 118419 4198
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE94
-Encoding: 118420 118420 4200
+Encoding: 118420 118420 4199
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE95
-Encoding: 118421 118421 4201
+Encoding: 118421 118421 4200
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE96
-Encoding: 118422 118422 4202
+Encoding: 118422 118422 4201
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE97
-Encoding: 118423 118423 4203
+Encoding: 118423 118423 4202
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE98
-Encoding: 118424 118424 4204
+Encoding: 118424 118424 4203
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE99
-Encoding: 118425 118425 4205
+Encoding: 118425 118425 4204
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE9A
-Encoding: 118426 118426 4206
+Encoding: 118426 118426 4205
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE9B
-Encoding: 118427 118427 4207
+Encoding: 118427 118427 4206
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE9C
-Encoding: 118428 118428 4208
+Encoding: 118428 118428 4207
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE9D
-Encoding: 118429 118429 4209
+Encoding: 118429 118429 4208
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE9E
-Encoding: 118430 118430 4210
+Encoding: 118430 118430 4209
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CE9F
-Encoding: 118431 118431 4211
+Encoding: 118431 118431 4210
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA0
-Encoding: 118432 118432 4212
+Encoding: 118432 118432 4211
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA1
-Encoding: 118433 118433 4213
+Encoding: 118433 118433 4212
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA2
-Encoding: 118434 118434 4214
+Encoding: 118434 118434 4213
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA3
-Encoding: 118435 118435 4215
+Encoding: 118435 118435 4214
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA4
-Encoding: 118436 118436 4216
+Encoding: 118436 118436 4215
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA5
-Encoding: 118437 118437 4217
+Encoding: 118437 118437 4216
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA6
-Encoding: 118438 118438 4218
+Encoding: 118438 118438 4217
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA7
-Encoding: 118439 118439 4219
+Encoding: 118439 118439 4218
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA8
-Encoding: 118440 118440 4220
+Encoding: 118440 118440 4219
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEA9
-Encoding: 118441 118441 4221
+Encoding: 118441 118441 4220
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEAA
-Encoding: 118442 118442 4222
+Encoding: 118442 118442 4221
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEAB
-Encoding: 118443 118443 4223
+Encoding: 118443 118443 4222
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEAC
-Encoding: 118444 118444 4224
+Encoding: 118444 118444 4223
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEAD
-Encoding: 118445 118445 4225
+Encoding: 118445 118445 4224
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEAE
-Encoding: 118446 118446 4226
+Encoding: 118446 118446 4225
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEAF
-Encoding: 118447 118447 4227
+Encoding: 118447 118447 4226
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD00
-Encoding: 118016 118016 4228
+Encoding: 118016 118016 4227
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD01
-Encoding: 118017 118017 4229
+Encoding: 118017 118017 4228
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD02
-Encoding: 118018 118018 4230
+Encoding: 118018 118018 4229
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD03
-Encoding: 118019 118019 4231
+Encoding: 118019 118019 4230
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD04
-Encoding: 118020 118020 4232
+Encoding: 118020 118020 4231
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD05
-Encoding: 118021 118021 4233
+Encoding: 118021 118021 4232
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD06
-Encoding: 118022 118022 4234
+Encoding: 118022 118022 4233
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD07
-Encoding: 118023 118023 4235
+Encoding: 118023 118023 4234
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD08
-Encoding: 118024 118024 4236
+Encoding: 118024 118024 4235
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD09
-Encoding: 118025 118025 4237
+Encoding: 118025 118025 4236
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD0A
-Encoding: 118026 118026 4238
+Encoding: 118026 118026 4237
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD0B
-Encoding: 118027 118027 4239
+Encoding: 118027 118027 4238
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD0C
-Encoding: 118028 118028 4240
+Encoding: 118028 118028 4239
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD0D
-Encoding: 118029 118029 4241
+Encoding: 118029 118029 4240
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD0E
-Encoding: 118030 118030 4242
+Encoding: 118030 118030 4241
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD0F
-Encoding: 118031 118031 4243
+Encoding: 118031 118031 4242
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD10
-Encoding: 118032 118032 4244
+Encoding: 118032 118032 4243
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD11
-Encoding: 118033 118033 4245
+Encoding: 118033 118033 4244
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD12
-Encoding: 118034 118034 4246
+Encoding: 118034 118034 4245
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD13
-Encoding: 118035 118035 4247
+Encoding: 118035 118035 4246
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD14
-Encoding: 118036 118036 4248
+Encoding: 118036 118036 4247
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD15
-Encoding: 118037 118037 4249
+Encoding: 118037 118037 4248
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD16
-Encoding: 118038 118038 4250
+Encoding: 118038 118038 4249
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD17
-Encoding: 118039 118039 4251
+Encoding: 118039 118039 4250
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD18
-Encoding: 118040 118040 4252
+Encoding: 118040 118040 4251
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD19
-Encoding: 118041 118041 4253
+Encoding: 118041 118041 4252
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD1A
-Encoding: 118042 118042 4254
+Encoding: 118042 118042 4253
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD1B
-Encoding: 118043 118043 4255
+Encoding: 118043 118043 4254
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD1C
-Encoding: 118044 118044 4256
+Encoding: 118044 118044 4255
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD1D
-Encoding: 118045 118045 4257
+Encoding: 118045 118045 4256
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD1E
-Encoding: 118046 118046 4258
+Encoding: 118046 118046 4257
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD1F
-Encoding: 118047 118047 4259
+Encoding: 118047 118047 4258
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD20
-Encoding: 118048 118048 4260
+Encoding: 118048 118048 4259
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD21
-Encoding: 118049 118049 4261
+Encoding: 118049 118049 4260
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD22
-Encoding: 118050 118050 4262
+Encoding: 118050 118050 4261
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD23
-Encoding: 118051 118051 4263
+Encoding: 118051 118051 4262
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD24
-Encoding: 118052 118052 4264
+Encoding: 118052 118052 4263
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD25
-Encoding: 118053 118053 4265
+Encoding: 118053 118053 4264
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD26
-Encoding: 118054 118054 4266
+Encoding: 118054 118054 4265
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD27
-Encoding: 118055 118055 4267
+Encoding: 118055 118055 4266
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD28
-Encoding: 118056 118056 4268
+Encoding: 118056 118056 4267
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD29
-Encoding: 118057 118057 4269
+Encoding: 118057 118057 4268
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD2A
-Encoding: 118058 118058 4270
+Encoding: 118058 118058 4269
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD2C
-Encoding: 118060 118060 4271
+Encoding: 118060 118060 4270
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD2B
-Encoding: 118059 118059 4272
+Encoding: 118059 118059 4271
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD2D
-Encoding: 118061 118061 4273
+Encoding: 118061 118061 4272
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD2E
-Encoding: 118062 118062 4274
+Encoding: 118062 118062 4273
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD2F
-Encoding: 118063 118063 4275
+Encoding: 118063 118063 4274
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD30
-Encoding: 118064 118064 4276
+Encoding: 118064 118064 4275
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD31
-Encoding: 118065 118065 4277
+Encoding: 118065 118065 4276
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD32
-Encoding: 118066 118066 4278
+Encoding: 118066 118066 4277
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD33
-Encoding: 118067 118067 4279
+Encoding: 118067 118067 4278
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD34
-Encoding: 118068 118068 4280
+Encoding: 118068 118068 4279
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD35
-Encoding: 118069 118069 4281
+Encoding: 118069 118069 4280
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD36
-Encoding: 118070 118070 4282
+Encoding: 118070 118070 4281
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD37
-Encoding: 118071 118071 4283
+Encoding: 118071 118071 4282
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD38
-Encoding: 118072 118072 4284
+Encoding: 118072 118072 4283
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD39
-Encoding: 118073 118073 4285
+Encoding: 118073 118073 4284
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD3A
-Encoding: 118074 118074 4286
+Encoding: 118074 118074 4285
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD3B
-Encoding: 118075 118075 4287
+Encoding: 118075 118075 4286
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD3C
-Encoding: 118076 118076 4288
+Encoding: 118076 118076 4287
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD3D
-Encoding: 118077 118077 4289
+Encoding: 118077 118077 4288
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD3E
-Encoding: 118078 118078 4290
+Encoding: 118078 118078 4289
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD3F
-Encoding: 118079 118079 4291
+Encoding: 118079 118079 4290
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD40
-Encoding: 118080 118080 4292
+Encoding: 118080 118080 4291
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD41
-Encoding: 118081 118081 4293
+Encoding: 118081 118081 4292
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD42
-Encoding: 118082 118082 4294
+Encoding: 118082 118082 4293
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD43
-Encoding: 118083 118083 4295
+Encoding: 118083 118083 4294
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD44
-Encoding: 118084 118084 4296
+Encoding: 118084 118084 4295
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD45
-Encoding: 118085 118085 4297
+Encoding: 118085 118085 4296
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD46
-Encoding: 118086 118086 4298
+Encoding: 118086 118086 4297
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD47
-Encoding: 118087 118087 4299
+Encoding: 118087 118087 4298
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD48
-Encoding: 118088 118088 4300
+Encoding: 118088 118088 4299
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD49
-Encoding: 118089 118089 4301
+Encoding: 118089 118089 4300
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD4A
-Encoding: 118090 118090 4302
+Encoding: 118090 118090 4301
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD4B
-Encoding: 118091 118091 4303
+Encoding: 118091 118091 4302
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD4C
-Encoding: 118092 118092 4304
+Encoding: 118092 118092 4303
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD4D
-Encoding: 118093 118093 4305
+Encoding: 118093 118093 4304
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD4E
-Encoding: 118094 118094 4306
+Encoding: 118094 118094 4305
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD4F
-Encoding: 118095 118095 4307
+Encoding: 118095 118095 4306
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD50
-Encoding: 118096 118096 4308
+Encoding: 118096 118096 4307
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD51
-Encoding: 118097 118097 4309
+Encoding: 118097 118097 4308
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD52
-Encoding: 118098 118098 4310
+Encoding: 118098 118098 4309
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD53
-Encoding: 118099 118099 4311
+Encoding: 118099 118099 4310
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD54
-Encoding: 118100 118100 4312
+Encoding: 118100 118100 4311
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD55
-Encoding: 118101 118101 4313
+Encoding: 118101 118101 4312
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD56
-Encoding: 118102 118102 4314
+Encoding: 118102 118102 4313
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD57
-Encoding: 118103 118103 4315
+Encoding: 118103 118103 4314
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD58
-Encoding: 118104 118104 4316
+Encoding: 118104 118104 4315
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD59
-Encoding: 118105 118105 4317
+Encoding: 118105 118105 4316
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD5A
-Encoding: 118106 118106 4318
+Encoding: 118106 118106 4317
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD5B
-Encoding: 118107 118107 4319
+Encoding: 118107 118107 4318
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD5C
-Encoding: 118108 118108 4320
+Encoding: 118108 118108 4319
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD5D
-Encoding: 118109 118109 4321
+Encoding: 118109 118109 4320
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD5E
-Encoding: 118110 118110 4322
+Encoding: 118110 118110 4321
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD5F
-Encoding: 118111 118111 4323
+Encoding: 118111 118111 4322
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD60
-Encoding: 118112 118112 4324
+Encoding: 118112 118112 4323
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD61
-Encoding: 118113 118113 4325
+Encoding: 118113 118113 4324
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD62
-Encoding: 118114 118114 4326
+Encoding: 118114 118114 4325
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD63
-Encoding: 118115 118115 4327
+Encoding: 118115 118115 4326
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD64
-Encoding: 118116 118116 4328
+Encoding: 118116 118116 4327
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD65
-Encoding: 118117 118117 4329
+Encoding: 118117 118117 4328
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD66
-Encoding: 118118 118118 4330
+Encoding: 118118 118118 4329
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD67
-Encoding: 118119 118119 4331
+Encoding: 118119 118119 4330
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD68
-Encoding: 118120 118120 4332
+Encoding: 118120 118120 4331
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD69
-Encoding: 118121 118121 4333
+Encoding: 118121 118121 4332
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD6A
-Encoding: 118122 118122 4334
+Encoding: 118122 118122 4333
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD6B
-Encoding: 118123 118123 4335
+Encoding: 118123 118123 4334
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD6C
-Encoding: 118124 118124 4336
+Encoding: 118124 118124 4335
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD6D
-Encoding: 118125 118125 4337
+Encoding: 118125 118125 4336
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD6E
-Encoding: 118126 118126 4338
+Encoding: 118126 118126 4337
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD6F
-Encoding: 118127 118127 4339
+Encoding: 118127 118127 4338
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD70
-Encoding: 118128 118128 4340
+Encoding: 118128 118128 4339
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD71
-Encoding: 118129 118129 4341
+Encoding: 118129 118129 4340
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD72
-Encoding: 118130 118130 4342
+Encoding: 118130 118130 4341
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD73
-Encoding: 118131 118131 4343
+Encoding: 118131 118131 4342
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD74
-Encoding: 118132 118132 4344
+Encoding: 118132 118132 4343
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD75
-Encoding: 118133 118133 4345
+Encoding: 118133 118133 4344
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD76
-Encoding: 118134 118134 4346
+Encoding: 118134 118134 4345
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD77
-Encoding: 118135 118135 4347
+Encoding: 118135 118135 4346
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD78
-Encoding: 118136 118136 4348
+Encoding: 118136 118136 4347
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD79
-Encoding: 118137 118137 4349
+Encoding: 118137 118137 4348
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD7A
-Encoding: 118138 118138 4350
+Encoding: 118138 118138 4349
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD7B
-Encoding: 118139 118139 4351
+Encoding: 118139 118139 4350
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD7C
-Encoding: 118140 118140 4352
+Encoding: 118140 118140 4351
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD7D
-Encoding: 118141 118141 4353
+Encoding: 118141 118141 4352
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD7E
-Encoding: 118142 118142 4354
+Encoding: 118142 118142 4353
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD7F
-Encoding: 118143 118143 4355
+Encoding: 118143 118143 4354
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD80
-Encoding: 118144 118144 4356
+Encoding: 118144 118144 4355
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD81
-Encoding: 118145 118145 4357
+Encoding: 118145 118145 4356
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD82
-Encoding: 118146 118146 4358
+Encoding: 118146 118146 4357
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD83
-Encoding: 118147 118147 4359
+Encoding: 118147 118147 4358
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD84
-Encoding: 118148 118148 4360
+Encoding: 118148 118148 4359
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD85
-Encoding: 118149 118149 4361
+Encoding: 118149 118149 4360
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD86
-Encoding: 118150 118150 4362
+Encoding: 118150 118150 4361
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD87
-Encoding: 118151 118151 4363
+Encoding: 118151 118151 4362
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD88
-Encoding: 118152 118152 4364
+Encoding: 118152 118152 4363
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD89
-Encoding: 118153 118153 4365
+Encoding: 118153 118153 4364
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD8A
-Encoding: 118154 118154 4366
+Encoding: 118154 118154 4365
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD8B
-Encoding: 118155 118155 4367
+Encoding: 118155 118155 4366
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD8C
-Encoding: 118156 118156 4368
+Encoding: 118156 118156 4367
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD8D
-Encoding: 118157 118157 4369
+Encoding: 118157 118157 4368
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD8E
-Encoding: 118158 118158 4370
+Encoding: 118158 118158 4369
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD8F
-Encoding: 118159 118159 4371
+Encoding: 118159 118159 4370
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD90
-Encoding: 118160 118160 4372
+Encoding: 118160 118160 4371
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD91
-Encoding: 118161 118161 4373
+Encoding: 118161 118161 4372
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD92
-Encoding: 118162 118162 4374
+Encoding: 118162 118162 4373
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD93
-Encoding: 118163 118163 4375
+Encoding: 118163 118163 4374
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD94
-Encoding: 118164 118164 4376
+Encoding: 118164 118164 4375
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD95
-Encoding: 118165 118165 4377
+Encoding: 118165 118165 4376
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD96
-Encoding: 118166 118166 4378
+Encoding: 118166 118166 4377
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD97
-Encoding: 118167 118167 4379
+Encoding: 118167 118167 4378
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD98
-Encoding: 118168 118168 4380
+Encoding: 118168 118168 4379
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD99
-Encoding: 118169 118169 4381
+Encoding: 118169 118169 4380
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD9A
-Encoding: 118170 118170 4382
+Encoding: 118170 118170 4381
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD9B
-Encoding: 118171 118171 4383
+Encoding: 118171 118171 4382
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD9C
-Encoding: 118172 118172 4384
+Encoding: 118172 118172 4383
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD9D
-Encoding: 118173 118173 4385
+Encoding: 118173 118173 4384
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD9E
-Encoding: 118174 118174 4386
+Encoding: 118174 118174 4385
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CD9F
-Encoding: 118175 118175 4387
+Encoding: 118175 118175 4386
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA0
-Encoding: 118176 118176 4388
+Encoding: 118176 118176 4387
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA1
-Encoding: 118177 118177 4389
+Encoding: 118177 118177 4388
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA2
-Encoding: 118178 118178 4390
+Encoding: 118178 118178 4389
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA3
-Encoding: 118179 118179 4391
+Encoding: 118179 118179 4390
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA4
-Encoding: 118180 118180 4392
+Encoding: 118180 118180 4391
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA5
-Encoding: 118181 118181 4393
+Encoding: 118181 118181 4392
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA6
-Encoding: 118182 118182 4394
+Encoding: 118182 118182 4393
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA7
-Encoding: 118183 118183 4395
+Encoding: 118183 118183 4394
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA8
-Encoding: 118184 118184 4396
+Encoding: 118184 118184 4395
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDA9
-Encoding: 118185 118185 4397
+Encoding: 118185 118185 4396
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDAA
-Encoding: 118186 118186 4398
+Encoding: 118186 118186 4397
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDAB
-Encoding: 118187 118187 4399
+Encoding: 118187 118187 4398
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDAC
-Encoding: 118188 118188 4400
+Encoding: 118188 118188 4399
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDAD
-Encoding: 118189 118189 4401
+Encoding: 118189 118189 4400
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDAE
-Encoding: 118190 118190 4402
+Encoding: 118190 118190 4401
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDAF
-Encoding: 118191 118191 4403
+Encoding: 118191 118191 4402
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB0
-Encoding: 118192 118192 4404
+Encoding: 118192 118192 4403
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB1
-Encoding: 118193 118193 4405
+Encoding: 118193 118193 4404
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB2
-Encoding: 118194 118194 4406
+Encoding: 118194 118194 4405
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB3
-Encoding: 118195 118195 4407
+Encoding: 118195 118195 4406
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB4
-Encoding: 118196 118196 4408
+Encoding: 118196 118196 4407
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB5
-Encoding: 118197 118197 4409
+Encoding: 118197 118197 4408
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB6
-Encoding: 118198 118198 4410
+Encoding: 118198 118198 4409
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB7
-Encoding: 118199 118199 4411
+Encoding: 118199 118199 4410
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB8
-Encoding: 118200 118200 4412
+Encoding: 118200 118200 4411
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDB9
-Encoding: 118201 118201 4413
+Encoding: 118201 118201 4412
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDBA
-Encoding: 118202 118202 4414
+Encoding: 118202 118202 4413
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDBB
-Encoding: 118203 118203 4415
+Encoding: 118203 118203 4414
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDBC
-Encoding: 118204 118204 4416
+Encoding: 118204 118204 4415
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDBD
-Encoding: 118205 118205 4417
+Encoding: 118205 118205 4416
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDBE
-Encoding: 118206 118206 4418
+Encoding: 118206 118206 4417
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDBF
-Encoding: 118207 118207 4419
+Encoding: 118207 118207 4418
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC0
-Encoding: 118208 118208 4420
+Encoding: 118208 118208 4419
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC1
-Encoding: 118209 118209 4421
+Encoding: 118209 118209 4420
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC2
-Encoding: 118210 118210 4422
+Encoding: 118210 118210 4421
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC3
-Encoding: 118211 118211 4423
+Encoding: 118211 118211 4422
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC4
-Encoding: 118212 118212 4424
+Encoding: 118212 118212 4423
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC5
-Encoding: 118213 118213 4425
+Encoding: 118213 118213 4424
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC6
-Encoding: 118214 118214 4426
+Encoding: 118214 118214 4425
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC7
-Encoding: 118215 118215 4427
+Encoding: 118215 118215 4426
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC8
-Encoding: 118216 118216 4428
+Encoding: 118216 118216 4427
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDC9
-Encoding: 118217 118217 4429
+Encoding: 118217 118217 4428
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDCA
-Encoding: 118218 118218 4430
+Encoding: 118218 118218 4429
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDCB
-Encoding: 118219 118219 4431
+Encoding: 118219 118219 4430
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDCC
-Encoding: 118220 118220 4432
+Encoding: 118220 118220 4431
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDCD
-Encoding: 118221 118221 4433
+Encoding: 118221 118221 4432
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDCE
-Encoding: 118222 118222 4434
+Encoding: 118222 118222 4433
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDCF
-Encoding: 118223 118223 4435
+Encoding: 118223 118223 4434
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD0
-Encoding: 118224 118224 4436
+Encoding: 118224 118224 4435
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD1
-Encoding: 118225 118225 4437
+Encoding: 118225 118225 4436
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD2
-Encoding: 118226 118226 4438
+Encoding: 118226 118226 4437
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD3
-Encoding: 118227 118227 4439
+Encoding: 118227 118227 4438
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD4
-Encoding: 118228 118228 4440
+Encoding: 118228 118228 4439
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD5
-Encoding: 118229 118229 4441
+Encoding: 118229 118229 4440
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD6
-Encoding: 118230 118230 4442
+Encoding: 118230 118230 4441
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD7
-Encoding: 118231 118231 4443
+Encoding: 118231 118231 4442
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD8
-Encoding: 118232 118232 4444
+Encoding: 118232 118232 4443
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDD9
-Encoding: 118233 118233 4445
+Encoding: 118233 118233 4444
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDDA
-Encoding: 118234 118234 4446
+Encoding: 118234 118234 4445
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDDB
-Encoding: 118235 118235 4447
+Encoding: 118235 118235 4446
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDDC
-Encoding: 118236 118236 4448
+Encoding: 118236 118236 4447
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDDD
-Encoding: 118237 118237 4449
+Encoding: 118237 118237 4448
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDDE
-Encoding: 118238 118238 4450
+Encoding: 118238 118238 4449
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDDF
-Encoding: 118239 118239 4451
+Encoding: 118239 118239 4450
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE0
-Encoding: 118240 118240 4452
+Encoding: 118240 118240 4451
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE1
-Encoding: 118241 118241 4453
+Encoding: 118241 118241 4452
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE2
-Encoding: 118242 118242 4454
+Encoding: 118242 118242 4453
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE3
-Encoding: 118243 118243 4455
+Encoding: 118243 118243 4454
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE4
-Encoding: 118244 118244 4456
+Encoding: 118244 118244 4455
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE5
-Encoding: 118245 118245 4457
+Encoding: 118245 118245 4456
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC05
-Encoding: 117765 117765 4458
+Encoding: 117765 117765 4457
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC06
-Encoding: 117766 117766 4459
+Encoding: 117766 117766 4458
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC07
-Encoding: 117767 117767 4460
+Encoding: 117767 117767 4459
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC08
-Encoding: 117768 117768 4461
+Encoding: 117768 117768 4460
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC04
-Encoding: 117764 117764 4462
+Encoding: 117764 117764 4461
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC03
-Encoding: 117763 117763 4463
+Encoding: 117763 117763 4462
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC02
-Encoding: 117762 117762 4464
+Encoding: 117762 117762 4463
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC01
-Encoding: 117761 117761 4465
+Encoding: 117761 117761 4464
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC00
-Encoding: 117760 117760 4466
+Encoding: 117760 117760 4465
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC09
-Encoding: 117769 117769 4467
+Encoding: 117769 117769 4466
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC0A
-Encoding: 117770 117770 4468
+Encoding: 117770 117770 4467
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC0B
-Encoding: 117771 117771 4469
+Encoding: 117771 117771 4468
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC0C
-Encoding: 117772 117772 4470
+Encoding: 117772 117772 4469
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC0D
-Encoding: 117773 117773 4471
+Encoding: 117773 117773 4470
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC0E
-Encoding: 117774 117774 4472
+Encoding: 117774 117774 4471
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC0F
-Encoding: 117775 117775 4473
+Encoding: 117775 117775 4472
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC10
-Encoding: 117776 117776 4474
+Encoding: 117776 117776 4473
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC11
-Encoding: 117777 117777 4475
+Encoding: 117777 117777 4474
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC12
-Encoding: 117778 117778 4476
+Encoding: 117778 117778 4475
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC13
-Encoding: 117779 117779 4477
+Encoding: 117779 117779 4476
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC14
-Encoding: 117780 117780 4478
+Encoding: 117780 117780 4477
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC15
-Encoding: 117781 117781 4479
+Encoding: 117781 117781 4478
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC16
-Encoding: 117782 117782 4480
+Encoding: 117782 117782 4479
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC17
-Encoding: 117783 117783 4481
+Encoding: 117783 117783 4480
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC18
-Encoding: 117784 117784 4482
+Encoding: 117784 117784 4481
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC19
-Encoding: 117785 117785 4483
+Encoding: 117785 117785 4482
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC1A
-Encoding: 117786 117786 4484
+Encoding: 117786 117786 4483
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC1B
-Encoding: 117787 117787 4485
+Encoding: 117787 117787 4484
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC1C
-Encoding: 117788 117788 4486
+Encoding: 117788 117788 4485
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC1D
-Encoding: 117789 117789 4487
+Encoding: 117789 117789 4486
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC1E
-Encoding: 117790 117790 4488
+Encoding: 117790 117790 4487
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC1F
-Encoding: 117791 117791 4489
+Encoding: 117791 117791 4488
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC20
-Encoding: 117792 117792 4490
+Encoding: 117792 117792 4489
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2654
-Encoding: 9812 9812 4491
+Encoding: 9812 9812 4490
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2655
-Encoding: 9813 9813 4492
+Encoding: 9813 9813 4491
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2656
-Encoding: 9814 9814 4493
+Encoding: 9814 9814 4492
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2657
-Encoding: 9815 9815 4494
+Encoding: 9815 9815 4493
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2658
-Encoding: 9816 9816 4495
+Encoding: 9816 9816 4494
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2659
-Encoding: 9817 9817 4496
+Encoding: 9817 9817 4495
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni265A
-Encoding: 9818 9818 4497
+Encoding: 9818 9818 4496
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni265B
-Encoding: 9819 9819 4498
+Encoding: 9819 9819 4497
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni265C
-Encoding: 9820 9820 4499
+Encoding: 9820 9820 4498
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni265D
-Encoding: 9821 9821 4500
+Encoding: 9821 9821 4499
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni265E
-Encoding: 9822 9822 4501
+Encoding: 9822 9822 4500
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni265F
-Encoding: 9823 9823 4502
+Encoding: 9823 9823 4501
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCBA
-Encoding: 117946 117946 4503
+Encoding: 117946 117946 4502
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCBB
-Encoding: 117947 117947 4504
+Encoding: 117947 117947 4503
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCBC
-Encoding: 117948 117948 4505
+Encoding: 117948 117948 4504
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCBD
-Encoding: 117949 117949 4506
+Encoding: 117949 117949 4505
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCBE
-Encoding: 117950 117950 4507
+Encoding: 117950 117950 4506
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCBF
-Encoding: 117951 117951 4508
+Encoding: 117951 117951 4507
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC0
-Encoding: 117952 117952 4509
+Encoding: 117952 117952 4508
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC1
-Encoding: 117953 117953 4510
+Encoding: 117953 117953 4509
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC2
-Encoding: 117954 117954 4511
+Encoding: 117954 117954 4510
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC3
-Encoding: 117955 117955 4512
+Encoding: 117955 117955 4511
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCD2
-Encoding: 117970 117970 4513
+Encoding: 117970 117970 4512
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC4
-Encoding: 117956 117956 4514
+Encoding: 117956 117956 4513
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC5
-Encoding: 117957 117957 4515
+Encoding: 117957 117957 4514
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC6
-Encoding: 117958 117958 4516
+Encoding: 117958 117958 4515
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC7
-Encoding: 117959 117959 4517
+Encoding: 117959 117959 4516
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC8
-Encoding: 117960 117960 4518
+Encoding: 117960 117960 4517
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCC9
-Encoding: 117961 117961 4519
+Encoding: 117961 117961 4518
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCCA
-Encoding: 117962 117962 4520
+Encoding: 117962 117962 4519
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCCB
-Encoding: 117963 117963 4521
+Encoding: 117963 117963 4520
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCCC
-Encoding: 117964 117964 4522
+Encoding: 117964 117964 4521
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCCD
-Encoding: 117965 117965 4523
+Encoding: 117965 117965 4522
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCCE
-Encoding: 117966 117966 4524
+Encoding: 117966 117966 4523
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCCF
-Encoding: 117967 117967 4525
+Encoding: 117967 117967 4524
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCD0
-Encoding: 117968 117968 4526
+Encoding: 117968 117968 4525
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCD1
-Encoding: 117969 117969 4527
+Encoding: 117969 117969 4526
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCD3
-Encoding: 117971 117971 4528
+Encoding: 117971 117971 4527
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCD4
-Encoding: 117972 117972 4529
+Encoding: 117972 117972 4528
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCD5
-Encoding: 117973 117973 4530
+Encoding: 117973 117973 4529
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEB0
-Encoding: 118448 118448 4531
+Encoding: 118448 118448 4530
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEB1
-Encoding: 118449 118449 4532
+Encoding: 118449 118449 4531
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEB2
-Encoding: 118450 118450 4533
+Encoding: 118450 118450 4532
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CEB3
-Encoding: 118451 118451 4534
+Encoding: 118451 118451 4533
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC69
-Encoding: 117865 117865 4535
+Encoding: 117865 117865 4534
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC6A
-Encoding: 117866 117866 4536
+Encoding: 117866 117866 4535
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC6B
-Encoding: 117867 117867 4537
+Encoding: 117867 117867 4536
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC6C
-Encoding: 117868 117868 4538
+Encoding: 117868 117868 4537
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC6D
-Encoding: 117869 117869 4539
+Encoding: 117869 117869 4538
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC6E
-Encoding: 117870 117870 4540
+Encoding: 117870 117870 4539
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC63
-Encoding: 117859 117859 4541
+Encoding: 117859 117859 4540
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC61
-Encoding: 117857 117857 4542
+Encoding: 117857 117857 4541
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC60
-Encoding: 117856 117856 4543
+Encoding: 117856 117856 4542
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC62
-Encoding: 117858 117858 4544
+Encoding: 117858 117858 4543
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC64
-Encoding: 117860 117860 4545
+Encoding: 117860 117860 4544
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC57
-Encoding: 117847 117847 4546
+Encoding: 117847 117847 4545
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC59
-Encoding: 117849 117849 4547
+Encoding: 117849 117849 4546
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC56
-Encoding: 117846 117846 4548
+Encoding: 117846 117846 4547
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC58
-Encoding: 117848 117848 4549
+Encoding: 117848 117848 4548
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC65
-Encoding: 117861 117861 4550
+Encoding: 117861 117861 4549
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC67
-Encoding: 117863 117863 4551
+Encoding: 117863 117863 4550
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC66
-Encoding: 117862 117862 4552
+Encoding: 117862 117862 4551
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC68
-Encoding: 117864 117864 4553
+Encoding: 117864 117864 4552
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC70
-Encoding: 117872 117872 4554
+Encoding: 117872 117872 4553
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC71
-Encoding: 117873 117873 4555
+Encoding: 117873 117873 4554
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC72
-Encoding: 117874 117874 4556
+Encoding: 117874 117874 4555
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC73
-Encoding: 117875 117875 4557
+Encoding: 117875 117875 4556
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC74
-Encoding: 117876 117876 4558
+Encoding: 117876 117876 4557
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC75
-Encoding: 117877 117877 4559
+Encoding: 117877 117877 4558
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC76
-Encoding: 117878 117878 4560
+Encoding: 117878 117878 4559
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC77
-Encoding: 117879 117879 4561
+Encoding: 117879 117879 4560
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC78
-Encoding: 117880 117880 4562
+Encoding: 117880 117880 4561
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC7A
-Encoding: 117882 117882 4563
+Encoding: 117882 117882 4562
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC79
-Encoding: 117881 117881 4564
+Encoding: 117881 117881 4563
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC7B
-Encoding: 117883 117883 4565
+Encoding: 117883 117883 4564
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC7C
-Encoding: 117884 117884 4566
+Encoding: 117884 117884 4565
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC7D
-Encoding: 117885 117885 4567
+Encoding: 117885 117885 4566
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC7E
-Encoding: 117886 117886 4568
+Encoding: 117886 117886 4567
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC7F
-Encoding: 117887 117887 4569
+Encoding: 117887 117887 4568
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC80
-Encoding: 117888 117888 4570
+Encoding: 117888 117888 4569
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC81
-Encoding: 117889 117889 4571
+Encoding: 117889 117889 4570
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC82
-Encoding: 117890 117890 4572
+Encoding: 117890 117890 4571
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC83
-Encoding: 117891 117891 4573
+Encoding: 117891 117891 4572
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC84
-Encoding: 117892 117892 4574
+Encoding: 117892 117892 4573
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC85
-Encoding: 117893 117893 4575
+Encoding: 117893 117893 4574
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC86
-Encoding: 117894 117894 4576
+Encoding: 117894 117894 4575
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC87
-Encoding: 117895 117895 4577
+Encoding: 117895 117895 4576
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC88
-Encoding: 117896 117896 4578
+Encoding: 117896 117896 4577
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC89
-Encoding: 117897 117897 4579
+Encoding: 117897 117897 4578
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC8A
-Encoding: 117898 117898 4580
+Encoding: 117898 117898 4579
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC8B
-Encoding: 117899 117899 4581
+Encoding: 117899 117899 4580
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC8C
-Encoding: 117900 117900 4582
+Encoding: 117900 117900 4581
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC8D
-Encoding: 117901 117901 4583
+Encoding: 117901 117901 4582
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC8E
-Encoding: 117902 117902 4584
+Encoding: 117902 117902 4583
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC8F
-Encoding: 117903 117903 4585
+Encoding: 117903 117903 4584
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC90
-Encoding: 117904 117904 4586
+Encoding: 117904 117904 4585
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC91
-Encoding: 117905 117905 4587
+Encoding: 117905 117905 4586
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC92
-Encoding: 117906 117906 4588
+Encoding: 117906 117906 4587
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC93
-Encoding: 117907 117907 4589
+Encoding: 117907 117907 4588
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC94
-Encoding: 117908 117908 4590
+Encoding: 117908 117908 4589
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC95
-Encoding: 117909 117909 4591
+Encoding: 117909 117909 4590
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC96
-Encoding: 117910 117910 4592
+Encoding: 117910 117910 4591
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC97
-Encoding: 117911 117911 4593
+Encoding: 117911 117911 4592
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC98
-Encoding: 117912 117912 4594
+Encoding: 117912 117912 4593
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC99
-Encoding: 117913 117913 4595
+Encoding: 117913 117913 4594
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC9A
-Encoding: 117914 117914 4596
+Encoding: 117914 117914 4595
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC9B
-Encoding: 117915 117915 4597
+Encoding: 117915 117915 4596
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC9C
-Encoding: 117916 117916 4598
+Encoding: 117916 117916 4597
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC9D
-Encoding: 117917 117917 4599
+Encoding: 117917 117917 4598
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC9E
-Encoding: 117918 117918 4600
+Encoding: 117918 117918 4599
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC9F
-Encoding: 117919 117919 4601
+Encoding: 117919 117919 4600
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC6F
-Encoding: 117871 117871 4602
+Encoding: 117871 117871 4601
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC48
-Encoding: 117832 117832 4603
+Encoding: 117832 117832 4602
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC49
-Encoding: 117833 117833 4604
+Encoding: 117833 117833 4603
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC4A
-Encoding: 117834 117834 4605
+Encoding: 117834 117834 4604
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC4B
-Encoding: 117835 117835 4606
+Encoding: 117835 117835 4605
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC4C
-Encoding: 117836 117836 4607
+Encoding: 117836 117836 4606
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC4D
-Encoding: 117837 117837 4608
+Encoding: 117837 117837 4607
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC4E
-Encoding: 117838 117838 4609
+Encoding: 117838 117838 4608
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC4F
-Encoding: 117839 117839 4610
+Encoding: 117839 117839 4609
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC50
-Encoding: 117840 117840 4611
+Encoding: 117840 117840 4610
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC51
-Encoding: 117841 117841 4612
+Encoding: 117841 117841 4611
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC52
-Encoding: 117842 117842 4613
+Encoding: 117842 117842 4612
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC53
-Encoding: 117843 117843 4614
+Encoding: 117843 117843 4613
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC54
-Encoding: 117844 117844 4615
+Encoding: 117844 117844 4614
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC55
-Encoding: 117845 117845 4616
+Encoding: 117845 117845 4615
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B24
-Encoding: 11044 11044 4617
+Encoding: 11044 11044 4616
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF5
-Encoding: 118261 118261 4618
+Encoding: 118261 118261 4617
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2708
-Encoding: 9992 9992 4619
+Encoding: 9992 9992 4618
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F6E7
-Encoding: 128743 128743 4620
+Encoding: 128743 128743 4619
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF8
-Encoding: 118264 118264 4621
+Encoding: 118264 118264 4620
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF9
-Encoding: 118265 118265 4622
+Encoding: 118265 118265 4621
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDFA
-Encoding: 118266 118266 4623
+Encoding: 118266 118266 4622
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDFB
-Encoding: 118267 118267 4624
+Encoding: 118267 118267 4623
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDFC
-Encoding: 118268 118268 4625
+Encoding: 118268 118268 4624
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDFD
-Encoding: 118269 118269 4626
+Encoding: 118269 118269 4625
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDFE
-Encoding: 118270 118270 4627
+Encoding: 118270 118270 4626
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDFF
-Encoding: 118271 118271 4628
+Encoding: 118271 118271 4627
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC5A
-Encoding: 117850 117850 4629
+Encoding: 117850 117850 4628
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC5D
-Encoding: 117853 117853 4630
+Encoding: 117853 117853 4629
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC5C
-Encoding: 117852 117852 4631
+Encoding: 117852 117852 4630
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC5E
-Encoding: 117854 117854 4632
+Encoding: 117854 117854 4631
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC5F
-Encoding: 117855 117855 4633
+Encoding: 117855 117855 4632
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CC5B
-Encoding: 117851 117851 4634
+Encoding: 117851 117851 4633
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA0
-Encoding: 117920 117920 4635
+Encoding: 117920 117920 4634
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA1
-Encoding: 117921 117921 4636
+Encoding: 117921 117921 4635
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA2
-Encoding: 117922 117922 4637
+Encoding: 117922 117922 4636
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA3
-Encoding: 117923 117923 4638
+Encoding: 117923 117923 4637
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA4
-Encoding: 117924 117924 4639
+Encoding: 117924 117924 4638
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA5
-Encoding: 117925 117925 4640
+Encoding: 117925 117925 4639
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA6
-Encoding: 117926 117926 4641
+Encoding: 117926 117926 4640
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA7
-Encoding: 117927 117927 4642
+Encoding: 117927 117927 4641
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA8
-Encoding: 117928 117928 4643
+Encoding: 117928 117928 4642
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCA9
-Encoding: 117929 117929 4644
+Encoding: 117929 117929 4643
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCAA
-Encoding: 117930 117930 4645
+Encoding: 117930 117930 4644
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCAB
-Encoding: 117931 117931 4646
+Encoding: 117931 117931 4645
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCAC
-Encoding: 117932 117932 4647
+Encoding: 117932 117932 4646
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCAD
-Encoding: 117933 117933 4648
+Encoding: 117933 117933 4647
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCAE
-Encoding: 117934 117934 4649
+Encoding: 117934 117934 4648
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCAF
-Encoding: 117935 117935 4650
+Encoding: 117935 117935 4649
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB0
-Encoding: 117936 117936 4651
+Encoding: 117936 117936 4650
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB1
-Encoding: 117937 117937 4652
+Encoding: 117937 117937 4651
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB2
-Encoding: 117938 117938 4653
+Encoding: 117938 117938 4652
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB3
-Encoding: 117939 117939 4654
+Encoding: 117939 117939 4653
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB4
-Encoding: 117940 117940 4655
+Encoding: 117940 117940 4654
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB5
-Encoding: 117941 117941 4656
+Encoding: 117941 117941 4655
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB6
-Encoding: 117942 117942 4657
+Encoding: 117942 117942 4656
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB7
-Encoding: 117943 117943 4658
+Encoding: 117943 117943 4657
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB8
-Encoding: 117944 117944 4659
+Encoding: 117944 117944 4658
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CCB9
-Encoding: 117945 117945 4660
+Encoding: 117945 117945 4659
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF6
-Encoding: 118262 118262 4661
+Encoding: 118262 118262 4660
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF7
-Encoding: 118263 118263 4662
+Encoding: 118263 118263 4661
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF0
-Encoding: 118256 118256 4663
+Encoding: 118256 118256 4662
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF1
-Encoding: 118257 118257 4664
+Encoding: 118257 118257 4663
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF3
-Encoding: 118259 118259 4665
+Encoding: 118259 118259 4664
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF2
-Encoding: 118258 118258 4666
+Encoding: 118258 118258 4665
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDF4
-Encoding: 118260 118260 4667
+Encoding: 118260 118260 4666
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE6
-Encoding: 118246 118246 4668
+Encoding: 118246 118246 4667
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE7
-Encoding: 118247 118247 4669
+Encoding: 118247 118247 4668
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE8
-Encoding: 118248 118248 4670
+Encoding: 118248 118248 4669
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDEC
-Encoding: 118252 118252 4671
+Encoding: 118252 118252 4670
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDE9
-Encoding: 118249 118249 4672
+Encoding: 118249 118249 4671
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDED
-Encoding: 118253 118253 4673
+Encoding: 118253 118253 4672
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDEA
-Encoding: 118250 118250 4674
+Encoding: 118250 118250 4673
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDEE
-Encoding: 118254 118254 4675
+Encoding: 118254 118254 4674
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDEB
-Encoding: 118251 118251 4676
+Encoding: 118251 118251 4675
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1CDEF
-Encoding: 118255 118255 4677
+Encoding: 118255 118255 4676
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: invbullet
-Encoding: 9688 9688 4678
+Encoding: 9688 9688 4677
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: invcircle
-Encoding: 9689 9689 4679
+Encoding: 9689 9689 4678
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: sun
-Encoding: 9788 9788 4680
+Encoding: 9788 9788 4679
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: filledrect
-Encoding: 9644 9644 4681
+Encoding: 9644 9644 4680
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: arrowupdnbse
-Encoding: 8616 8616 4682
+Encoding: 8616 8616 4681
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: peseta
-Encoding: 8359 8359 4683
+Encoding: 8359 8359 4682
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: revlogicalnot
-Encoding: 8976 8976 4684
+Encoding: 8976 8976 4683
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: triaglf
-Encoding: 9668 9668 4685
+Encoding: 9668 9668 4684
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: triagrt
-Encoding: 9658 9658 4686
+Encoding: 9658 9658 4685
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2243
-Encoding: 8771 8771 4687
+Encoding: 8771 8771 4686
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2244
-Encoding: 8772 8772 4688
+Encoding: 8772 8772 4687
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2628
-Encoding: 9768 9768 4689
+Encoding: 9768 9768 4688
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A0
-Encoding: 127136 127136 4690
+Encoding: 127136 127136 4689
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A1
-Encoding: 127137 127137 4691
+Encoding: 127137 127137 4690
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A2
-Encoding: 127138 127138 4692
+Encoding: 127138 127138 4691
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A3
-Encoding: 127139 127139 4693
+Encoding: 127139 127139 4692
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A4
-Encoding: 127140 127140 4694
+Encoding: 127140 127140 4693
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A5
-Encoding: 127141 127141 4695
+Encoding: 127141 127141 4694
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A6
-Encoding: 127142 127142 4696
+Encoding: 127142 127142 4695
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A7
-Encoding: 127143 127143 4697
+Encoding: 127143 127143 4696
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A8
-Encoding: 127144 127144 4698
+Encoding: 127144 127144 4697
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0A9
-Encoding: 127145 127145 4699
+Encoding: 127145 127145 4698
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0AA
-Encoding: 127146 127146 4700
+Encoding: 127146 127146 4699
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0AB
-Encoding: 127147 127147 4701
+Encoding: 127147 127147 4700
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0AC
-Encoding: 127148 127148 4702
+Encoding: 127148 127148 4701
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0AD
-Encoding: 127149 127149 4703
+Encoding: 127149 127149 4702
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0AE
-Encoding: 127150 127150 4704
+Encoding: 127150 127150 4703
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B1
-Encoding: 127153 127153 4705
+Encoding: 127153 127153 4704
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B2
-Encoding: 127154 127154 4706
+Encoding: 127154 127154 4705
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B3
-Encoding: 127155 127155 4707
+Encoding: 127155 127155 4706
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B4
-Encoding: 127156 127156 4708
+Encoding: 127156 127156 4707
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B5
-Encoding: 127157 127157 4709
+Encoding: 127157 127157 4708
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B6
-Encoding: 127158 127158 4710
+Encoding: 127158 127158 4709
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B7
-Encoding: 127159 127159 4711
+Encoding: 127159 127159 4710
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B8
-Encoding: 127160 127160 4712
+Encoding: 127160 127160 4711
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0B9
-Encoding: 127161 127161 4713
+Encoding: 127161 127161 4712
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0BA
-Encoding: 127162 127162 4714
+Encoding: 127162 127162 4713
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0BB
-Encoding: 127163 127163 4715
+Encoding: 127163 127163 4714
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0BC
-Encoding: 127164 127164 4716
+Encoding: 127164 127164 4715
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0BD
-Encoding: 127165 127165 4717
+Encoding: 127165 127165 4716
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0BE
-Encoding: 127166 127166 4718
+Encoding: 127166 127166 4717
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0BF
-Encoding: 127167 127167 4719
+Encoding: 127167 127167 4718
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C1
-Encoding: 127169 127169 4720
+Encoding: 127169 127169 4719
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C2
-Encoding: 127170 127170 4721
+Encoding: 127170 127170 4720
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C3
-Encoding: 127171 127171 4722
+Encoding: 127171 127171 4721
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C4
-Encoding: 127172 127172 4723
+Encoding: 127172 127172 4722
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C5
-Encoding: 127173 127173 4724
+Encoding: 127173 127173 4723
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C6
-Encoding: 127174 127174 4725
+Encoding: 127174 127174 4724
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C7
-Encoding: 127175 127175 4726
+Encoding: 127175 127175 4725
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C8
-Encoding: 127176 127176 4727
+Encoding: 127176 127176 4726
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0C9
-Encoding: 127177 127177 4728
+Encoding: 127177 127177 4727
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0CA
-Encoding: 127178 127178 4729
+Encoding: 127178 127178 4728
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0CB
-Encoding: 127179 127179 4730
+Encoding: 127179 127179 4729
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0CC
-Encoding: 127180 127180 4731
+Encoding: 127180 127180 4730
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0CD
-Encoding: 127181 127181 4732
+Encoding: 127181 127181 4731
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0CE
-Encoding: 127182 127182 4733
+Encoding: 127182 127182 4732
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0CF
-Encoding: 127183 127183 4734
+Encoding: 127183 127183 4733
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D1
-Encoding: 127185 127185 4735
+Encoding: 127185 127185 4734
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D2
-Encoding: 127186 127186 4736
+Encoding: 127186 127186 4735
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D3
-Encoding: 127187 127187 4737
+Encoding: 127187 127187 4736
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D4
-Encoding: 127188 127188 4738
+Encoding: 127188 127188 4737
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D5
-Encoding: 127189 127189 4739
+Encoding: 127189 127189 4738
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D6
-Encoding: 127190 127190 4740
+Encoding: 127190 127190 4739
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D7
-Encoding: 127191 127191 4741
+Encoding: 127191 127191 4740
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D8
-Encoding: 127192 127192 4742
+Encoding: 127192 127192 4741
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0D9
-Encoding: 127193 127193 4743
+Encoding: 127193 127193 4742
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0DA
-Encoding: 127194 127194 4744
+Encoding: 127194 127194 4743
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0DB
-Encoding: 127195 127195 4745
+Encoding: 127195 127195 4744
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0DC
-Encoding: 127196 127196 4746
+Encoding: 127196 127196 4745
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0DD
-Encoding: 127197 127197 4747
+Encoding: 127197 127197 4746
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0DE
-Encoding: 127198 127198 4748
+Encoding: 127198 127198 4747
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F0DF
-Encoding: 127199 127199 4749
+Encoding: 127199 127199 4748
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni210E
-Encoding: 8462 8462 4750
+Encoding: 8462 8462 4749
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni210F
-Encoding: 8463 8463 4751
+Encoding: 8463 8463 4750
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni212F
-Encoding: 8495 8495 4752
+Encoding: 8495 8495 4751
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2166
-Encoding: 8550 8550 4753
+Encoding: 8550 8550 4752
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2167
-Encoding: 8551 8551 4754
+Encoding: 8551 8551 4753
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni216B
-Encoding: 8555 8555 4755
+Encoding: 8555 8555 4754
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni216C
-Encoding: 8556 8556 4756
+Encoding: 8556 8556 4755
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni216D
-Encoding: 8557 8557 4757
+Encoding: 8557 8557 4756
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni216E
-Encoding: 8558 8558 4758
+Encoding: 8558 8558 4757
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni216F
-Encoding: 8559 8559 4759
+Encoding: 8559 8559 4758
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni217C
-Encoding: 8572 8572 4760
+Encoding: 8572 8572 4759
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni217D
-Encoding: 8573 8573 4761
+Encoding: 8573 8573 4760
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni217E
-Encoding: 8574 8574 4762
+Encoding: 8574 8574 4761
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni217F
-Encoding: 8575 8575 4763
+Encoding: 8575 8575 4762
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2150
-Encoding: 8528 8528 4764
+Encoding: 8528 8528 4763
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2151
-Encoding: 8529 8529 4765
+Encoding: 8529 8529 4764
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2189
-Encoding: 8585 8585 4766
+Encoding: 8585 8585 4765
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2152
-Encoding: 8530 8530 4767
+Encoding: 8530 8530 4766
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: onethird
-Encoding: 8531 8531 4768
+Encoding: 8531 8531 4767
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: twothirds
-Encoding: 8532 8532 4769
+Encoding: 8532 8532 4768
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2155
-Encoding: 8533 8533 4770
+Encoding: 8533 8533 4769
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2156
-Encoding: 8534 8534 4771
+Encoding: 8534 8534 4770
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2157
-Encoding: 8535 8535 4772
+Encoding: 8535 8535 4771
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2158
-Encoding: 8536 8536 4773
+Encoding: 8536 8536 4772
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2159
-Encoding: 8537 8537 4774
+Encoding: 8537 8537 4773
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni215F
-Encoding: 8543 8543 4775
+Encoding: 8543 8543 4774
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni215A
-Encoding: 8538 8538 4776
+Encoding: 8538 8538 4775
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: oneeighth
-Encoding: 8539 8539 4777
+Encoding: 8539 8539 4776
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: threeeighths
-Encoding: 8540 8540 4778
+Encoding: 8540 8540 4777
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: fiveeighths
-Encoding: 8541 8541 4779
+Encoding: 8541 8541 4778
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: seveneighths
-Encoding: 8542 8542 4780
+Encoding: 8542 8542 4779
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2180
-Encoding: 8576 8576 4781
+Encoding: 8576 8576 4780
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2181
-Encoding: 8577 8577 4782
+Encoding: 8577 8577 4781
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2183
-Encoding: 8579 8579 4783
+Encoding: 8579 8579 4782
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2184
-Encoding: 8580 8580 4784
+Encoding: 8580 8580 4783
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni218A
-Encoding: 8586 8586 4785
+Encoding: 8586 8586 4784
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni218B
-Encoding: 8587 8587 4786
+Encoding: 8587 8587 4785
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: Omega
-Encoding: 8486 8486 4787
+Encoding: 8486 8486 4786
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2127
-Encoding: 8487 8487 4788
+Encoding: 8487 8487 4787
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2103
-Encoding: 8451 8451 4789
+Encoding: 8451 8451 4788
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2109
-Encoding: 8457 8457 4790
+Encoding: 8457 8457 4789
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4A3
-Encoding: 128163 128163 4791
+Encoding: 128163 128163 4790
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F3AE
-Encoding: 127918 127918 4792
+Encoding: 127918 127918 4791
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4BE
-Encoding: 128190 128190 4793
+Encoding: 128190 128190 4792
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4BF
-Encoding: 128191 128191 4794
+Encoding: 128191 128191 4793
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C0
-Encoding: 128192 128192 4795
+Encoding: 128192 128192 4794
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4A4
-Encoding: 128164 128164 4796
+Encoding: 128164 128164 4795
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C1
-Encoding: 128193 128193 4797
+Encoding: 128193 128193 4796
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C2
-Encoding: 128194 128194 4798
+Encoding: 128194 128194 4797
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F499
-Encoding: 128153 128153 4799
+Encoding: 128153 128153 4798
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F49A
-Encoding: 128154 128154 4800
+Encoding: 128154 128154 4799
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F49B
-Encoding: 128155 128155 4801
+Encoding: 128155 128155 4800
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F49C
-Encoding: 128156 128156 4802
+Encoding: 128156 128156 4801
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F496
-Encoding: 128150 128150 4803
+Encoding: 128150 128150 4802
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F497
-Encoding: 128151 128151 4804
+Encoding: 128151 128151 4803
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F494
-Encoding: 128148 128148 4805
+Encoding: 128148 128148 4804
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F48C
-Encoding: 128140 128140 4806
+Encoding: 128140 128140 4805
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F90D
-Encoding: 129293 129293 4807
+Encoding: 129293 129293 4806
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F90E
-Encoding: 129294 129294 4808
+Encoding: 129294 129294 4807
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F9E1
-Encoding: 129505 129505 4809
+Encoding: 129505 129505 4808
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F49D
-Encoding: 128157 128157 4810
+Encoding: 128157 128157 4809
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F493
-Encoding: 128147 128147 4811
+Encoding: 128147 128147 4810
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F495
-Encoding: 128149 128149 4812
+Encoding: 128149 128149 4811
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F498
-Encoding: 128152 128152 4813
+Encoding: 128152 128152 4812
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F49E
-Encoding: 128158 128158 4814
+Encoding: 128158 128158 4813
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5A4
-Encoding: 128420 128420 4815
+Encoding: 128420 128420 4814
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F394
-Encoding: 127892 127892 4816
+Encoding: 127892 127892 4815
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4BD
-Encoding: 128189 128189 4817
+Encoding: 128189 128189 4816
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FA75
-Encoding: 129653 129653 4818
+Encoding: 129653 129653 4817
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FA76
-Encoding: 129654 129654 4819
+Encoding: 129654 129654 4818
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FA77
-Encoding: 129655 129655 4820
+Encoding: 129655 129655 4819
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F582
-Encoding: 128386 128386 4821
+Encoding: 128386 128386 4820
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F583
-Encoding: 128387 128387 4822
+Encoding: 128387 128387 4821
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2709
-Encoding: 9993 9993 4823
+Encoding: 9993 9993 4822
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni231B
-Encoding: 8987 8987 4824
+Encoding: 8987 8987 4823
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFFC
-Encoding: 65532 65532 4825
+Encoding: 65532 65532 4824
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFFD
-Encoding: 65533 65533 4826
+Encoding: 65533 65533 4825
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F550
-Encoding: 128336 128336 4827
+Encoding: 128336 128336 4826
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F551
-Encoding: 128337 128337 4828
+Encoding: 128337 128337 4827
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F552
-Encoding: 128338 128338 4829
+Encoding: 128338 128338 4828
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F553
-Encoding: 128339 128339 4830
+Encoding: 128339 128339 4829
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F554
-Encoding: 128340 128340 4831
+Encoding: 128340 128340 4830
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F555
-Encoding: 128341 128341 4832
+Encoding: 128341 128341 4831
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F556
-Encoding: 128342 128342 4833
+Encoding: 128342 128342 4832
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F557
-Encoding: 128343 128343 4834
+Encoding: 128343 128343 4833
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F558
-Encoding: 128344 128344 4835
+Encoding: 128344 128344 4834
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F559
-Encoding: 128345 128345 4836
+Encoding: 128345 128345 4835
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F55A
-Encoding: 128346 128346 4837
+Encoding: 128346 128346 4836
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F55B
-Encoding: 128347 128347 4838
+Encoding: 128347 128347 4837
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F55C
-Encoding: 128348 128348 4839
+Encoding: 128348 128348 4838
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F55D
-Encoding: 128349 128349 4840
+Encoding: 128349 128349 4839
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F55E
-Encoding: 128350 128350 4841
+Encoding: 128350 128350 4840
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F55F
-Encoding: 128351 128351 4842
+Encoding: 128351 128351 4841
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F560
-Encoding: 128352 128352 4843
+Encoding: 128352 128352 4842
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F561
-Encoding: 128353 128353 4844
+Encoding: 128353 128353 4843
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F562
-Encoding: 128354 128354 4845
+Encoding: 128354 128354 4844
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F563
-Encoding: 128355 128355 4846
+Encoding: 128355 128355 4845
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F564
-Encoding: 128356 128356 4847
+Encoding: 128356 128356 4846
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F565
-Encoding: 128357 128357 4848
+Encoding: 128357 128357 4847
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F566
-Encoding: 128358 128358 4849
+Encoding: 128358 128358 4848
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F567
-Encoding: 128359 128359 4850
+Encoding: 128359 128359 4849
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2605
-Encoding: 9733 9733 4851
+Encoding: 9733 9733 4850
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2606
-Encoding: 9734 9734 4852
+Encoding: 9734 9734 4851
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2460
-Encoding: 9312 9312 4853
+Encoding: 9312 9312 4852
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2461
-Encoding: 9313 9313 4854
+Encoding: 9313 9313 4853
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2462
-Encoding: 9314 9314 4855
+Encoding: 9314 9314 4854
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2463
-Encoding: 9315 9315 4856
+Encoding: 9315 9315 4855
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2464
-Encoding: 9316 9316 4857
+Encoding: 9316 9316 4856
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2465
-Encoding: 9317 9317 4858
+Encoding: 9317 9317 4857
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2466
-Encoding: 9318 9318 4859
+Encoding: 9318 9318 4858
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2467
-Encoding: 9319 9319 4860
+Encoding: 9319 9319 4859
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2468
-Encoding: 9320 9320 4861
+Encoding: 9320 9320 4860
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2469
-Encoding: 9321 9321 4862
+Encoding: 9321 9321 4861
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni246A
-Encoding: 9322 9322 4863
+Encoding: 9322 9322 4862
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni246B
-Encoding: 9323 9323 4864
+Encoding: 9323 9323 4863
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni246C
-Encoding: 9324 9324 4865
+Encoding: 9324 9324 4864
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni246D
-Encoding: 9325 9325 4866
+Encoding: 9325 9325 4865
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni246E
-Encoding: 9326 9326 4867
+Encoding: 9326 9326 4866
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni246F
-Encoding: 9327 9327 4868
+Encoding: 9327 9327 4867
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2470
-Encoding: 9328 9328 4869
+Encoding: 9328 9328 4868
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2471
-Encoding: 9329 9329 4870
+Encoding: 9329 9329 4869
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2472
-Encoding: 9330 9330 4871
+Encoding: 9330 9330 4870
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2473
-Encoding: 9331 9331 4872
+Encoding: 9331 9331 4871
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24EA
-Encoding: 9450 9450 4873
+Encoding: 9450 9450 4872
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24FE
-Encoding: 9470 9470 4874
+Encoding: 9470 9470 4873
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F5
-Encoding: 9461 9461 4875
+Encoding: 9461 9461 4874
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F6
-Encoding: 9462 9462 4876
+Encoding: 9462 9462 4875
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F7
-Encoding: 9463 9463 4877
+Encoding: 9463 9463 4876
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F8
-Encoding: 9464 9464 4878
+Encoding: 9464 9464 4877
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F9
-Encoding: 9465 9465 4879
+Encoding: 9465 9465 4878
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24FA
-Encoding: 9466 9466 4880
+Encoding: 9466 9466 4879
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24FB
-Encoding: 9467 9467 4881
+Encoding: 9467 9467 4880
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24FC
-Encoding: 9468 9468 4882
+Encoding: 9468 9468 4881
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24FD
-Encoding: 9469 9469 4883
+Encoding: 9469 9469 4882
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F4
-Encoding: 9460 9460 4884
+Encoding: 9460 9460 4883
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F3
-Encoding: 9459 9459 4885
+Encoding: 9459 9459 4884
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F2
-Encoding: 9458 9458 4886
+Encoding: 9458 9458 4885
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F1
-Encoding: 9457 9457 4887
+Encoding: 9457 9457 4886
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24F0
-Encoding: 9456 9456 4888
+Encoding: 9456 9456 4887
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24EF
-Encoding: 9455 9455 4889
+Encoding: 9455 9455 4888
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24EE
-Encoding: 9454 9454 4890
+Encoding: 9454 9454 4889
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24ED
-Encoding: 9453 9453 4891
+Encoding: 9453 9453 4890
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24EC
-Encoding: 9452 9452 4892
+Encoding: 9452 9452 4891
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24EB
-Encoding: 9451 9451 4893
+Encoding: 9451 9451 4892
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24FF
-Encoding: 9471 9471 4894
+Encoding: 9471 9471 4893
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2776
-Encoding: 10102 10102 4895
+Encoding: 10102 10102 4894
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2777
-Encoding: 10103 10103 4896
+Encoding: 10103 10103 4895
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2778
-Encoding: 10104 10104 4897
+Encoding: 10104 10104 4896
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2779
-Encoding: 10105 10105 4898
+Encoding: 10105 10105 4897
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni277A
-Encoding: 10106 10106 4899
+Encoding: 10106 10106 4898
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni277B
-Encoding: 10107 10107 4900
+Encoding: 10107 10107 4899
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni277C
-Encoding: 10108 10108 4901
+Encoding: 10108 10108 4900
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni277D
-Encoding: 10109 10109 4902
+Encoding: 10109 10109 4901
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni277E
-Encoding: 10110 10110 4903
+Encoding: 10110 10110 4902
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni277F
-Encoding: 10111 10111 4904
+Encoding: 10111 10111 4903
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni278A
-Encoding: 10122 10122 4905
+Encoding: 10122 10122 4904
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni278B
-Encoding: 10123 10123 4906
+Encoding: 10123 10123 4905
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni278C
-Encoding: 10124 10124 4907
+Encoding: 10124 10124 4906
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni278D
-Encoding: 10125 10125 4908
+Encoding: 10125 10125 4907
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni278E
-Encoding: 10126 10126 4909
+Encoding: 10126 10126 4908
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni278F
-Encoding: 10127 10127 4910
+Encoding: 10127 10127 4909
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2790
-Encoding: 10128 10128 4911
+Encoding: 10128 10128 4910
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2791
-Encoding: 10129 10129 4912
+Encoding: 10129 10129 4911
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2792
-Encoding: 10130 10130 4913
+Encoding: 10130 10130 4912
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2793
-Encoding: 10131 10131 4914
+Encoding: 10131 10131 4913
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2780
-Encoding: 10112 10112 4915
+Encoding: 10112 10112 4914
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2781
-Encoding: 10113 10113 4916
+Encoding: 10113 10113 4915
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2782
-Encoding: 10114 10114 4917
+Encoding: 10114 10114 4916
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2783
-Encoding: 10115 10115 4918
+Encoding: 10115 10115 4917
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2784
-Encoding: 10116 10116 4919
+Encoding: 10116 10116 4918
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2785
-Encoding: 10117 10117 4920
+Encoding: 10117 10117 4919
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2786
-Encoding: 10118 10118 4921
+Encoding: 10118 10118 4920
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2787
-Encoding: 10119 10119 4922
+Encoding: 10119 10119 4921
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2788
-Encoding: 10120 10120 4923
+Encoding: 10120 10120 4922
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2789
-Encoding: 10121 10121 4924
+Encoding: 10121 10121 4923
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3251
-Encoding: 12881 12881 4925
+Encoding: 12881 12881 4924
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3252
-Encoding: 12882 12882 4926
+Encoding: 12882 12882 4925
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3253
-Encoding: 12883 12883 4927
+Encoding: 12883 12883 4926
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3254
-Encoding: 12884 12884 4928
+Encoding: 12884 12884 4927
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3255
-Encoding: 12885 12885 4929
+Encoding: 12885 12885 4928
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3256
-Encoding: 12886 12886 4930
+Encoding: 12886 12886 4929
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3257
-Encoding: 12887 12887 4931
+Encoding: 12887 12887 4930
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3258
-Encoding: 12888 12888 4932
+Encoding: 12888 12888 4931
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3259
-Encoding: 12889 12889 4933
+Encoding: 12889 12889 4932
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni325A
-Encoding: 12890 12890 4934
+Encoding: 12890 12890 4933
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni325B
-Encoding: 12891 12891 4935
+Encoding: 12891 12891 4934
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni325C
-Encoding: 12892 12892 4936
+Encoding: 12892 12892 4935
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni325D
-Encoding: 12893 12893 4937
+Encoding: 12893 12893 4936
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni325E
-Encoding: 12894 12894 4938
+Encoding: 12894 12894 4937
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni325F
-Encoding: 12895 12895 4939
+Encoding: 12895 12895 4938
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B1
-Encoding: 12977 12977 4940
+Encoding: 12977 12977 4939
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B2
-Encoding: 12978 12978 4941
+Encoding: 12978 12978 4940
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B3
-Encoding: 12979 12979 4942
+Encoding: 12979 12979 4941
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B4
-Encoding: 12980 12980 4943
+Encoding: 12980 12980 4942
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B5
-Encoding: 12981 12981 4944
+Encoding: 12981 12981 4943
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B6
-Encoding: 12982 12982 4945
+Encoding: 12982 12982 4944
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B7
-Encoding: 12983 12983 4946
+Encoding: 12983 12983 4945
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B8
-Encoding: 12984 12984 4947
+Encoding: 12984 12984 4946
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32B9
-Encoding: 12985 12985 4948
+Encoding: 12985 12985 4947
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32BA
-Encoding: 12986 12986 4949
+Encoding: 12986 12986 4948
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32BB
-Encoding: 12987 12987 4950
+Encoding: 12987 12987 4949
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32BC
-Encoding: 12988 12988 4951
+Encoding: 12988 12988 4950
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32BD
-Encoding: 12989 12989 4952
+Encoding: 12989 12989 4951
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32BE
-Encoding: 12990 12990 4953
+Encoding: 12990 12990 4952
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32BF
-Encoding: 12991 12991 4954
+Encoding: 12991 12991 4953
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32A4
-Encoding: 12964 12964 4955
+Encoding: 12964 12964 4954
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32A5
-Encoding: 12965 12965 4956
+Encoding: 12965 12965 4955
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32A6
-Encoding: 12966 12966 4957
+Encoding: 12966 12966 4956
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32A7
-Encoding: 12967 12967 4958
+Encoding: 12967 12967 4957
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32A8
-Encoding: 12968 12968 4959
+Encoding: 12968 12968 4958
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32A3
-Encoding: 12963 12963 4960
+Encoding: 12963 12963 4959
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3280
-Encoding: 12928 12928 4961
+Encoding: 12928 12928 4960
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3281
-Encoding: 12929 12929 4962
+Encoding: 12929 12929 4961
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3282
-Encoding: 12930 12930 4963
+Encoding: 12930 12930 4962
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3283
-Encoding: 12931 12931 4964
+Encoding: 12931 12931 4963
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3284
-Encoding: 12932 12932 4965
+Encoding: 12932 12932 4964
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3285
-Encoding: 12933 12933 4966
+Encoding: 12933 12933 4965
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3286
-Encoding: 12934 12934 4967
+Encoding: 12934 12934 4966
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3287
-Encoding: 12935 12935 4968
+Encoding: 12935 12935 4967
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3288
-Encoding: 12936 12936 4969
+Encoding: 12936 12936 4968
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3289
-Encoding: 12937 12937 4970
+Encoding: 12937 12937 4969
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni328A
-Encoding: 12938 12938 4971
+Encoding: 12938 12938 4970
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni328B
-Encoding: 12939 12939 4972
+Encoding: 12939 12939 4971
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni328C
-Encoding: 12940 12940 4973
+Encoding: 12940 12940 4972
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni328D
-Encoding: 12941 12941 4974
+Encoding: 12941 12941 4973
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni328E
-Encoding: 12942 12942 4975
+Encoding: 12942 12942 4974
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni328F
-Encoding: 12943 12943 4976
+Encoding: 12943 12943 4975
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3290
-Encoding: 12944 12944 4977
+Encoding: 12944 12944 4976
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D0
-Encoding: 13008 13008 4978
+Encoding: 13008 13008 4977
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D1
-Encoding: 13009 13009 4979
+Encoding: 13009 13009 4978
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D2
-Encoding: 13010 13010 4980
+Encoding: 13010 13010 4979
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D3
-Encoding: 13011 13011 4981
+Encoding: 13011 13011 4980
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D4
-Encoding: 13012 13012 4982
+Encoding: 13012 13012 4981
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D5
-Encoding: 13013 13013 4983
+Encoding: 13013 13013 4982
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D6
-Encoding: 13014 13014 4984
+Encoding: 13014 13014 4983
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D7
-Encoding: 13015 13015 4985
+Encoding: 13015 13015 4984
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D8
-Encoding: 13016 13016 4986
+Encoding: 13016 13016 4985
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32D9
-Encoding: 13017 13017 4987
+Encoding: 13017 13017 4986
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32DA
-Encoding: 13018 13018 4988
+Encoding: 13018 13018 4987
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32DB
-Encoding: 13019 13019 4989
+Encoding: 13019 13019 4988
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32DC
-Encoding: 13020 13020 4990
+Encoding: 13020 13020 4989
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32DD
-Encoding: 13021 13021 4991
+Encoding: 13021 13021 4990
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32DE
-Encoding: 13022 13022 4992
+Encoding: 13022 13022 4991
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32DF
-Encoding: 13023 13023 4993
+Encoding: 13023 13023 4992
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E0
-Encoding: 13024 13024 4994
+Encoding: 13024 13024 4993
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E1
-Encoding: 13025 13025 4995
+Encoding: 13025 13025 4994
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E2
-Encoding: 13026 13026 4996
+Encoding: 13026 13026 4995
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E3
-Encoding: 13027 13027 4997
+Encoding: 13027 13027 4996
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E4
-Encoding: 13028 13028 4998
+Encoding: 13028 13028 4997
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E5
-Encoding: 13029 13029 4999
+Encoding: 13029 13029 4998
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E6
-Encoding: 13030 13030 5000
+Encoding: 13030 13030 4999
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E7
-Encoding: 13031 13031 5001
+Encoding: 13031 13031 5000
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E8
-Encoding: 13032 13032 5002
+Encoding: 13032 13032 5001
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32E9
-Encoding: 13033 13033 5003
+Encoding: 13033 13033 5002
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32EA
-Encoding: 13034 13034 5004
+Encoding: 13034 13034 5003
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32EB
-Encoding: 13035 13035 5005
+Encoding: 13035 13035 5004
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32EC
-Encoding: 13036 13036 5006
+Encoding: 13036 13036 5005
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32ED
-Encoding: 13037 13037 5007
+Encoding: 13037 13037 5006
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32EE
-Encoding: 13038 13038 5008
+Encoding: 13038 13038 5007
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32EF
-Encoding: 13039 13039 5009
+Encoding: 13039 13039 5008
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F0
-Encoding: 13040 13040 5010
+Encoding: 13040 13040 5009
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F1
-Encoding: 13041 13041 5011
+Encoding: 13041 13041 5010
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F2
-Encoding: 13042 13042 5012
+Encoding: 13042 13042 5011
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F3
-Encoding: 13043 13043 5013
+Encoding: 13043 13043 5012
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F4
-Encoding: 13044 13044 5014
+Encoding: 13044 13044 5013
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F5
-Encoding: 13045 13045 5015
+Encoding: 13045 13045 5014
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F6
-Encoding: 13046 13046 5016
+Encoding: 13046 13046 5015
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F7
-Encoding: 13047 13047 5017
+Encoding: 13047 13047 5016
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F8
-Encoding: 13048 13048 5018
+Encoding: 13048 13048 5017
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32F9
-Encoding: 13049 13049 5019
+Encoding: 13049 13049 5018
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32FA
-Encoding: 13050 13050 5020
+Encoding: 13050 13050 5019
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32FB
-Encoding: 13051 13051 5021
+Encoding: 13051 13051 5020
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32FC
-Encoding: 13052 13052 5022
+Encoding: 13052 13052 5021
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32FD
-Encoding: 13053 13053 5023
+Encoding: 13053 13053 5022
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32FE
-Encoding: 13054 13054 5024
+Encoding: 13054 13054 5023
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B6
-Encoding: 9398 9398 5025
+Encoding: 9398 9398 5024
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B7
-Encoding: 9399 9399 5026
+Encoding: 9399 9399 5025
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B8
-Encoding: 9400 9400 5027
+Encoding: 9400 9400 5026
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B9
-Encoding: 9401 9401 5028
+Encoding: 9401 9401 5027
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24BA
-Encoding: 9402 9402 5029
+Encoding: 9402 9402 5028
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24BB
-Encoding: 9403 9403 5030
+Encoding: 9403 9403 5029
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24BC
-Encoding: 9404 9404 5031
+Encoding: 9404 9404 5030
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24BD
-Encoding: 9405 9405 5032
+Encoding: 9405 9405 5031
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D0
-Encoding: 9424 9424 5033
+Encoding: 9424 9424 5032
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D1
-Encoding: 9425 9425 5034
+Encoding: 9425 9425 5033
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D2
-Encoding: 9426 9426 5035
+Encoding: 9426 9426 5034
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D3
-Encoding: 9427 9427 5036
+Encoding: 9427 9427 5035
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D4
-Encoding: 9428 9428 5037
+Encoding: 9428 9428 5036
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D5
-Encoding: 9429 9429 5038
+Encoding: 9429 9429 5037
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D6
-Encoding: 9430 9430 5039
+Encoding: 9430 9430 5038
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D7
-Encoding: 9431 9431 5040
+Encoding: 9431 9431 5039
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D8
-Encoding: 9432 9432 5041
+Encoding: 9432 9432 5040
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24D9
-Encoding: 9433 9433 5042
+Encoding: 9433 9433 5041
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24DA
-Encoding: 9434 9434 5043
+Encoding: 9434 9434 5042
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24DB
-Encoding: 9435 9435 5044
+Encoding: 9435 9435 5043
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24DC
-Encoding: 9436 9436 5045
+Encoding: 9436 9436 5044
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24DD
-Encoding: 9437 9437 5046
+Encoding: 9437 9437 5045
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24DE
-Encoding: 9438 9438 5047
+Encoding: 9438 9438 5046
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24DF
-Encoding: 9439 9439 5048
+Encoding: 9439 9439 5047
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E0
-Encoding: 9440 9440 5049
+Encoding: 9440 9440 5048
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E1
-Encoding: 9441 9441 5050
+Encoding: 9441 9441 5049
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E2
-Encoding: 9442 9442 5051
+Encoding: 9442 9442 5050
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E3
-Encoding: 9443 9443 5052
+Encoding: 9443 9443 5051
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E4
-Encoding: 9444 9444 5053
+Encoding: 9444 9444 5052
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E5
-Encoding: 9445 9445 5054
+Encoding: 9445 9445 5053
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E6
-Encoding: 9446 9446 5055
+Encoding: 9446 9446 5054
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E7
-Encoding: 9447 9447 5056
+Encoding: 9447 9447 5055
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E8
-Encoding: 9448 9448 5057
+Encoding: 9448 9448 5056
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24E9
-Encoding: 9449 9449 5058
+Encoding: 9449 9449 5057
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24BE
-Encoding: 9406 9406 5059
+Encoding: 9406 9406 5058
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24BF
-Encoding: 9407 9407 5060
+Encoding: 9407 9407 5059
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C0
-Encoding: 9408 9408 5061
+Encoding: 9408 9408 5060
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C1
-Encoding: 9409 9409 5062
+Encoding: 9409 9409 5061
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C2
-Encoding: 9410 9410 5063
+Encoding: 9410 9410 5062
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C3
-Encoding: 9411 9411 5064
+Encoding: 9411 9411 5063
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C4
-Encoding: 9412 9412 5065
+Encoding: 9412 9412 5064
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C5
-Encoding: 9413 9413 5066
+Encoding: 9413 9413 5065
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C6
-Encoding: 9414 9414 5067
+Encoding: 9414 9414 5066
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C7
-Encoding: 9415 9415 5068
+Encoding: 9415 9415 5067
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C8
-Encoding: 9416 9416 5069
+Encoding: 9416 9416 5068
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24C9
-Encoding: 9417 9417 5070
+Encoding: 9417 9417 5069
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24CA
-Encoding: 9418 9418 5071
+Encoding: 9418 9418 5070
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24CB
-Encoding: 9419 9419 5072
+Encoding: 9419 9419 5071
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24CC
-Encoding: 9420 9420 5073
+Encoding: 9420 9420 5072
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24CD
-Encoding: 9421 9421 5074
+Encoding: 9421 9421 5073
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24CE
-Encoding: 9422 9422 5075
+Encoding: 9422 9422 5074
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24CF
-Encoding: 9423 9423 5076
+Encoding: 9423 9423 5075
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni037E
-Encoding: 894 894 5077
+Encoding: 894 894 5076
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: tonos
-Encoding: 900 900 5078
+Encoding: 900 900 5077
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: dieresistonos
-Encoding: 901 901 5079
+Encoding: 901 901 5078
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: anoteleia
-Encoding: 903 903 5080
+Encoding: 903 903 5079
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: franc
-Encoding: 8355 8355 5081
+Encoding: 8355 8355 5080
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: lozenge
-Encoding: 9674 9674 5082
+Encoding: 9674 9674 5081
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: f_l
-Encoding: 64258 64258 5083
+Encoding: 64258 64258 5082
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25EF
-Encoding: 9711 9711 5084
+Encoding: 9711 9711 5083
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F3B1
-Encoding: 127921 127921 5085
+Encoding: 127921 127921 5084
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F004
-Encoding: 126980 126980 5086
+Encoding: 126980 126980 5085
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4AE
-Encoding: 128174 128174 5087
+Encoding: 128174 128174 5086
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4AF
-Encoding: 128175 128175 5088
+Encoding: 128175 128175 5087
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4BB
-Encoding: 128187 128187 5089
+Encoding: 128187 128187 5088
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C5
-Encoding: 128197 128197 5090
+Encoding: 128197 128197 5089
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C6
-Encoding: 128198 128198 5091
+Encoding: 128198 128198 5090
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4E7
-Encoding: 128231 128231 5092
+Encoding: 128231 128231 5091
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5A9
-Encoding: 128425 128425 5093
+Encoding: 128425 128425 5092
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5AA
-Encoding: 128426 128426 5094
+Encoding: 128426 128426 5093
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5AB
-Encoding: 128427 128427 5095
+Encoding: 128427 128427 5094
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5AC
-Encoding: 128428 128428 5096
+Encoding: 128428 128428 5095
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5AD
-Encoding: 128429 128429 5097
+Encoding: 128429 128429 5096
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5B3
-Encoding: 128435 128435 5098
+Encoding: 128435 128435 5097
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F5B8
-Encoding: 128440 128440 5099
+Encoding: 128440 128440 5098
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F47E
-Encoding: 128126 128126 5100
+Encoding: 128126 128126 5099
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F338
-Encoding: 127800 127800 5101
+Encoding: 127800 127800 5100
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F427
-Encoding: 128039 128039 5102
+Encoding: 128039 128039 5101
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D306
-Encoding: 119558 119558 5103
+Encoding: 119558 119558 5102
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D307
-Encoding: 119559 119559 5104
+Encoding: 119559 119559 5103
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D308
-Encoding: 119560 119560 5105
+Encoding: 119560 119560 5104
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D309
-Encoding: 119561 119561 5106
+Encoding: 119561 119561 5105
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D30A
-Encoding: 119562 119562 5107
+Encoding: 119562 119562 5106
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D30B
-Encoding: 119563 119563 5108
+Encoding: 119563 119563 5107
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D30C
-Encoding: 119564 119564 5109
+Encoding: 119564 119564 5108
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D30D
-Encoding: 119565 119565 5110
+Encoding: 119565 119565 5109
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D30E
-Encoding: 119566 119566 5111
+Encoding: 119566 119566 5110
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D30F
-Encoding: 119567 119567 5112
+Encoding: 119567 119567 5111
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D310
-Encoding: 119568 119568 5113
+Encoding: 119568 119568 5112
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D311
-Encoding: 119569 119569 5114
+Encoding: 119569 119569 5113
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D312
-Encoding: 119570 119570 5115
+Encoding: 119570 119570 5114
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D313
-Encoding: 119571 119571 5116
+Encoding: 119571 119571 5115
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D314
-Encoding: 119572 119572 5117
+Encoding: 119572 119572 5116
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D315
-Encoding: 119573 119573 5118
+Encoding: 119573 119573 5117
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D316
-Encoding: 119574 119574 5119
+Encoding: 119574 119574 5118
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D317
-Encoding: 119575 119575 5120
+Encoding: 119575 119575 5119
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D318
-Encoding: 119576 119576 5121
+Encoding: 119576 119576 5120
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D319
-Encoding: 119577 119577 5122
+Encoding: 119577 119577 5121
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D31A
-Encoding: 119578 119578 5123
+Encoding: 119578 119578 5122
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D31B
-Encoding: 119579 119579 5124
+Encoding: 119579 119579 5123
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D31C
-Encoding: 119580 119580 5125
+Encoding: 119580 119580 5124
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D31D
-Encoding: 119581 119581 5126
+Encoding: 119581 119581 5125
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D31E
-Encoding: 119582 119582 5127
+Encoding: 119582 119582 5126
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D31F
-Encoding: 119583 119583 5128
+Encoding: 119583 119583 5127
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D356
-Encoding: 119638 119638 5129
+Encoding: 119638 119638 5128
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D355
-Encoding: 119637 119637 5130
+Encoding: 119637 119637 5129
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D354
-Encoding: 119636 119636 5131
+Encoding: 119636 119636 5130
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D353
-Encoding: 119635 119635 5132
+Encoding: 119635 119635 5131
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D352
-Encoding: 119634 119634 5133
+Encoding: 119634 119634 5132
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D351
-Encoding: 119633 119633 5134
+Encoding: 119633 119633 5133
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D350
-Encoding: 119632 119632 5135
+Encoding: 119632 119632 5134
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D320
-Encoding: 119584 119584 5136
+Encoding: 119584 119584 5135
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D321
-Encoding: 119585 119585 5137
+Encoding: 119585 119585 5136
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D322
-Encoding: 119586 119586 5138
+Encoding: 119586 119586 5137
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D323
-Encoding: 119587 119587 5139
+Encoding: 119587 119587 5138
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D324
-Encoding: 119588 119588 5140
+Encoding: 119588 119588 5139
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D325
-Encoding: 119589 119589 5141
+Encoding: 119589 119589 5140
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D326
-Encoding: 119590 119590 5142
+Encoding: 119590 119590 5141
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D327
-Encoding: 119591 119591 5143
+Encoding: 119591 119591 5142
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D328
-Encoding: 119592 119592 5144
+Encoding: 119592 119592 5143
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D329
-Encoding: 119593 119593 5145
+Encoding: 119593 119593 5144
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D32A
-Encoding: 119594 119594 5146
+Encoding: 119594 119594 5145
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D32B
-Encoding: 119595 119595 5147
+Encoding: 119595 119595 5146
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D32C
-Encoding: 119596 119596 5148
+Encoding: 119596 119596 5147
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D32D
-Encoding: 119597 119597 5149
+Encoding: 119597 119597 5148
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D32E
-Encoding: 119598 119598 5150
+Encoding: 119598 119598 5149
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D32F
-Encoding: 119599 119599 5151
+Encoding: 119599 119599 5150
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D330
-Encoding: 119600 119600 5152
+Encoding: 119600 119600 5151
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D331
-Encoding: 119601 119601 5153
+Encoding: 119601 119601 5152
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D332
-Encoding: 119602 119602 5154
+Encoding: 119602 119602 5153
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D333
-Encoding: 119603 119603 5155
+Encoding: 119603 119603 5154
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D334
-Encoding: 119604 119604 5156
+Encoding: 119604 119604 5155
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D335
-Encoding: 119605 119605 5157
+Encoding: 119605 119605 5156
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D336
-Encoding: 119606 119606 5158
+Encoding: 119606 119606 5157
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D337
-Encoding: 119607 119607 5159
+Encoding: 119607 119607 5158
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D338
-Encoding: 119608 119608 5160
+Encoding: 119608 119608 5159
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D339
-Encoding: 119609 119609 5161
+Encoding: 119609 119609 5160
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D33A
-Encoding: 119610 119610 5162
+Encoding: 119610 119610 5161
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D33B
-Encoding: 119611 119611 5163
+Encoding: 119611 119611 5162
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D33C
-Encoding: 119612 119612 5164
+Encoding: 119612 119612 5163
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D33D
-Encoding: 119613 119613 5165
+Encoding: 119613 119613 5164
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D33E
-Encoding: 119614 119614 5166
+Encoding: 119614 119614 5165
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D33F
-Encoding: 119615 119615 5167
+Encoding: 119615 119615 5166
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D340
-Encoding: 119616 119616 5168
+Encoding: 119616 119616 5167
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D341
-Encoding: 119617 119617 5169
+Encoding: 119617 119617 5168
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D342
-Encoding: 119618 119618 5170
+Encoding: 119618 119618 5169
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D343
-Encoding: 119619 119619 5171
+Encoding: 119619 119619 5170
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D344
-Encoding: 119620 119620 5172
+Encoding: 119620 119620 5171
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D345
-Encoding: 119621 119621 5173
+Encoding: 119621 119621 5172
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D346
-Encoding: 119622 119622 5174
+Encoding: 119622 119622 5173
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D347
-Encoding: 119623 119623 5175
+Encoding: 119623 119623 5174
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D348
-Encoding: 119624 119624 5176
+Encoding: 119624 119624 5175
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D349
-Encoding: 119625 119625 5177
+Encoding: 119625 119625 5176
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D34A
-Encoding: 119626 119626 5178
+Encoding: 119626 119626 5177
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D34B
-Encoding: 119627 119627 5179
+Encoding: 119627 119627 5178
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D34C
-Encoding: 119628 119628 5180
+Encoding: 119628 119628 5179
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D34D
-Encoding: 119629 119629 5181
+Encoding: 119629 119629 5180
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D34E
-Encoding: 119630 119630 5182
+Encoding: 119630 119630 5181
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1D34F
-Encoding: 119631 119631 5183
+Encoding: 119631 119631 5182
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2474
-Encoding: 9332 9332 5184
+Encoding: 9332 9332 5183
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2475
-Encoding: 9333 9333 5185
+Encoding: 9333 9333 5184
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2476
-Encoding: 9334 9334 5186
+Encoding: 9334 9334 5185
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2477
-Encoding: 9335 9335 5187
+Encoding: 9335 9335 5186
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2478
-Encoding: 9336 9336 5188
+Encoding: 9336 9336 5187
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2479
-Encoding: 9337 9337 5189
+Encoding: 9337 9337 5188
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni247A
-Encoding: 9338 9338 5190
+Encoding: 9338 9338 5189
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni247B
-Encoding: 9339 9339 5191
+Encoding: 9339 9339 5190
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni247C
-Encoding: 9340 9340 5192
+Encoding: 9340 9340 5191
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni247D
-Encoding: 9341 9341 5193
+Encoding: 9341 9341 5192
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni247E
-Encoding: 9342 9342 5194
+Encoding: 9342 9342 5193
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni247F
-Encoding: 9343 9343 5195
+Encoding: 9343 9343 5194
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2480
-Encoding: 9344 9344 5196
+Encoding: 9344 9344 5195
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2481
-Encoding: 9345 9345 5197
+Encoding: 9345 9345 5196
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2482
-Encoding: 9346 9346 5198
+Encoding: 9346 9346 5197
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2483
-Encoding: 9347 9347 5199
+Encoding: 9347 9347 5198
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2484
-Encoding: 9348 9348 5200
+Encoding: 9348 9348 5199
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2485
-Encoding: 9349 9349 5201
+Encoding: 9349 9349 5200
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2486
-Encoding: 9350 9350 5202
+Encoding: 9350 9350 5201
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2487
-Encoding: 9351 9351 5203
+Encoding: 9351 9351 5202
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni249C
-Encoding: 9372 9372 5204
+Encoding: 9372 9372 5203
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni249D
-Encoding: 9373 9373 5205
+Encoding: 9373 9373 5204
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni249E
-Encoding: 9374 9374 5206
+Encoding: 9374 9374 5205
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni249F
-Encoding: 9375 9375 5207
+Encoding: 9375 9375 5206
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A0
-Encoding: 9376 9376 5208
+Encoding: 9376 9376 5207
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A1
-Encoding: 9377 9377 5209
+Encoding: 9377 9377 5208
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A2
-Encoding: 9378 9378 5210
+Encoding: 9378 9378 5209
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A3
-Encoding: 9379 9379 5211
+Encoding: 9379 9379 5210
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A4
-Encoding: 9380 9380 5212
+Encoding: 9380 9380 5211
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A5
-Encoding: 9381 9381 5213
+Encoding: 9381 9381 5212
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A6
-Encoding: 9382 9382 5214
+Encoding: 9382 9382 5213
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A7
-Encoding: 9383 9383 5215
+Encoding: 9383 9383 5214
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A8
-Encoding: 9384 9384 5216
+Encoding: 9384 9384 5215
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24A9
-Encoding: 9385 9385 5217
+Encoding: 9385 9385 5216
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24AA
-Encoding: 9386 9386 5218
+Encoding: 9386 9386 5217
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24AB
-Encoding: 9387 9387 5219
+Encoding: 9387 9387 5218
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24AC
-Encoding: 9388 9388 5220
+Encoding: 9388 9388 5219
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24AD
-Encoding: 9389 9389 5221
+Encoding: 9389 9389 5220
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24AE
-Encoding: 9390 9390 5222
+Encoding: 9390 9390 5221
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24AF
-Encoding: 9391 9391 5223
+Encoding: 9391 9391 5222
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B0
-Encoding: 9392 9392 5224
+Encoding: 9392 9392 5223
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B1
-Encoding: 9393 9393 5225
+Encoding: 9393 9393 5224
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B2
-Encoding: 9394 9394 5226
+Encoding: 9394 9394 5225
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B3
-Encoding: 9395 9395 5227
+Encoding: 9395 9395 5226
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B4
-Encoding: 9396 9396 5228
+Encoding: 9396 9396 5227
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni24B5
-Encoding: 9397 9397 5229
+Encoding: 9397 9397 5228
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2488
-Encoding: 9352 9352 5230
+Encoding: 9352 9352 5229
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2489
-Encoding: 9353 9353 5231
+Encoding: 9353 9353 5230
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni248A
-Encoding: 9354 9354 5232
+Encoding: 9354 9354 5231
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni248B
-Encoding: 9355 9355 5233
+Encoding: 9355 9355 5232
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni248C
-Encoding: 9356 9356 5234
+Encoding: 9356 9356 5233
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni248D
-Encoding: 9357 9357 5235
+Encoding: 9357 9357 5234
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni248E
-Encoding: 9358 9358 5236
+Encoding: 9358 9358 5235
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni248F
-Encoding: 9359 9359 5237
+Encoding: 9359 9359 5236
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2490
-Encoding: 9360 9360 5238
+Encoding: 9360 9360 5237
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2491
-Encoding: 9361 9361 5239
+Encoding: 9361 9361 5238
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2492
-Encoding: 9362 9362 5240
+Encoding: 9362 9362 5239
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2493
-Encoding: 9363 9363 5241
+Encoding: 9363 9363 5240
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2494
-Encoding: 9364 9364 5242
+Encoding: 9364 9364 5241
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2496
-Encoding: 9366 9366 5243
+Encoding: 9366 9366 5242
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2495
-Encoding: 9365 9365 5244
+Encoding: 9365 9365 5243
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2497
-Encoding: 9367 9367 5245
+Encoding: 9367 9367 5244
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2498
-Encoding: 9368 9368 5246
+Encoding: 9368 9368 5245
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2499
-Encoding: 9369 9369 5247
+Encoding: 9369 9369 5246
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni249A
-Encoding: 9370 9370 5248
+Encoding: 9370 9370 5247
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni249B
-Encoding: 9371 9371 5249
+Encoding: 9371 9371 5248
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2307
-Encoding: 8967 8967 5250
+Encoding: 8967 8967 5249
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni237E
-Encoding: 9086 9086 5251
+Encoding: 9086 9086 5250
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: prescription
-Encoding: 8478 8478 5252
+Encoding: 8478 8478 5251
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2100
-Encoding: 8448 8448 5253
+Encoding: 8448 8448 5252
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2101
-Encoding: 8449 8449 5254
+Encoding: 8449 8449 5253
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: afii61248
-Encoding: 8453 8453 5255
+Encoding: 8453 8453 5254
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2106
-Encoding: 8454 8454 5256
+Encoding: 8454 8454 5255
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni222E
-Encoding: 8750 8750 5257
+Encoding: 8750 8750 5256
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni222F
-Encoding: 8751 8751 5258
+Encoding: 8751 8751 5257
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2230
-Encoding: 8752 8752 5259
+Encoding: 8752 8752 5258
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2121
-Encoding: 8481 8481 5260
+Encoding: 8481 8481 5259
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2252
-Encoding: 8786 8786 5261
+Encoding: 8786 8786 5260
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2250
-Encoding: 8784 8784 5262
+Encoding: 8784 8784 5261
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2251
-Encoding: 8785 8785 5263
+Encoding: 8785 8785 5262
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2253
-Encoding: 8787 8787 5264
+Encoding: 8787 8787 5263
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22BF
-Encoding: 8895 8895 5265
+Encoding: 8895 8895 5264
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni212B
-Encoding: 8491 8491 5266
+Encoding: 8491 8491 5265
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni226A
-Encoding: 8810 8810 5267
+Encoding: 8810 8810 5266
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni226B
-Encoding: 8811 8811 5268
+Encoding: 8811 8811 5267
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2263
-Encoding: 8803 8803 5269
+Encoding: 8803 8803 5268
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2266
-Encoding: 8806 8806 5270
+Encoding: 8806 8806 5269
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2267
-Encoding: 8807 8807 5271
+Encoding: 8807 8807 5270
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE0
-Encoding: 65504 65504 5272
+Encoding: 65504 65504 5271
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE1
-Encoding: 65505 65505 5273
+Encoding: 65505 65505 5272
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE2
-Encoding: 65506 65506 5274
+Encoding: 65506 65506 5273
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE3
-Encoding: 65507 65507 5275
+Encoding: 65507 65507 5274
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE4
-Encoding: 65508 65508 5276
+Encoding: 65508 65508 5275
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE5
-Encoding: 65509 65509 5277
+Encoding: 65509 65509 5276
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE6
-Encoding: 65510 65510 5278
+Encoding: 65510 65510 5277
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20A9
-Encoding: 8361 8361 5279
+Encoding: 8361 8361 5278
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3013
-Encoding: 12307 12307 5280
+Encoding: 12307 12307 5279
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni301D
-Encoding: 12317 12317 5281
+Encoding: 12317 12317 5280
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni301E
-Encoding: 12318 12318 5282
+Encoding: 12318 12318 5281
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni301F
-Encoding: 12319 12319 5283
+Encoding: 12319 12319 5282
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3036
-Encoding: 12342 12342 5284
+Encoding: 12342 12342 5283
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3303
-Encoding: 13059 13059 5285
+Encoding: 13059 13059 5284
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni330D
-Encoding: 13069 13069 5286
+Encoding: 13069 13069 5285
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3314
-Encoding: 13076 13076 5287
+Encoding: 13076 13076 5286
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3318
-Encoding: 13080 13080 5288
+Encoding: 13080 13080 5287
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3322
-Encoding: 13090 13090 5289
+Encoding: 13090 13090 5288
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3323
-Encoding: 13091 13091 5290
+Encoding: 13091 13091 5289
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3326
-Encoding: 13094 13094 5291
+Encoding: 13094 13094 5290
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3327
-Encoding: 13095 13095 5292
+Encoding: 13095 13095 5291
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni332B
-Encoding: 13099 13099 5293
+Encoding: 13099 13099 5292
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3336
-Encoding: 13110 13110 5294
+Encoding: 13110 13110 5293
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni333B
-Encoding: 13115 13115 5295
+Encoding: 13115 13115 5294
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3349
-Encoding: 13129 13129 5296
+Encoding: 13129 13129 5295
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni334A
-Encoding: 13130 13130 5297
+Encoding: 13130 13130 5296
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni334D
-Encoding: 13133 13133 5298
+Encoding: 13133 13133 5297
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3351
-Encoding: 13137 13137 5299
+Encoding: 13137 13137 5298
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3357
-Encoding: 13143 13143 5300
+Encoding: 13143 13143 5299
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni303F
-Encoding: 12351 12351 5301
+Encoding: 12351 12351 5300
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni214D
-Encoding: 8525 8525 5302
+Encoding: 8525 8525 5301
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni213B
-Encoding: 8507 8507 5303
+Encoding: 8507 8507 5302
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFEA
-Encoding: 65514 65514 5304
+Encoding: 65514 65514 5303
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFEB
-Encoding: 65515 65515 5305
+Encoding: 65515 65515 5304
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE8
-Encoding: 65512 65512 5306
+Encoding: 65512 65512 5305
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFE9
-Encoding: 65513 65513 5307
+Encoding: 65513 65513 5306
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFEC
-Encoding: 65516 65516 5308
+Encoding: 65516 65516 5307
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFED
-Encoding: 65517 65517 5309
+Encoding: 65517 65517 5308
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uniFFEE
-Encoding: 65518 65518 5310
+Encoding: 65518 65518 5309
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni223D
-Encoding: 8765 8765 5311
+Encoding: 8765 8765 5310
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni338E
-Encoding: 13198 13198 5312
+Encoding: 13198 13198 5311
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni338F
-Encoding: 13199 13199 5313
+Encoding: 13199 13199 5312
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni339C
-Encoding: 13212 13212 5314
+Encoding: 13212 13212 5313
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni339D
-Encoding: 13213 13213 5315
+Encoding: 13213 13213 5314
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni339E
-Encoding: 13214 13214 5316
+Encoding: 13214 13214 5315
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni339F
-Encoding: 13215 13215 5317
+Encoding: 13215 13215 5316
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33A1
-Encoding: 13217 13217 5318
+Encoding: 13217 13217 5317
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33C4
-Encoding: 13252 13252 5319
+Encoding: 13252 13252 5318
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni4EDD
-Encoding: 20189 20189 5320
+Encoding: 20189 20189 5319
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32FF
-Encoding: 13055 13055 5321
+Encoding: 13055 13055 5320
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni337B
-Encoding: 13179 13179 5322
+Encoding: 13179 13179 5321
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni337C
-Encoding: 13180 13180 5323
+Encoding: 13180 13180 5322
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni337D
-Encoding: 13181 13181 5324
+Encoding: 13181 13181 5323
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni337E
-Encoding: 13182 13182 5325
+Encoding: 13182 13182 5324
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2312
-Encoding: 8978 8978 5326
+Encoding: 8978 8978 5325
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3231
-Encoding: 12849 12849 5327
+Encoding: 12849 12849 5326
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3232
-Encoding: 12850 12850 5328
+Encoding: 12850 12850 5327
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3239
-Encoding: 12857 12857 5329
+Encoding: 12857 12857 5328
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33CD
-Encoding: 13261 13261 5330
+Encoding: 13261 13261 5329
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni27CA
-Encoding: 10186 10186 5331
+Encoding: 10186 10186 5330
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: openbullet
-Encoding: 9702 9702 5332
+Encoding: 9702 9702 5331
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F610
-Encoding: 128528 128528 5333
+Encoding: 128528 128528 5332
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F6F8
-Encoding: 128760 128760 5334
+Encoding: 128760 128760 5333
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2299
-Encoding: 8857 8857 5335
+Encoding: 8857 8857 5334
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21A1
-Encoding: 8609 8609 5336
+Encoding: 8609 8609 5335
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni29D6
-Encoding: 10710 10710 5337
+Encoding: 10710 10710 5336
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni237B
-Encoding: 9083 9083 5338
+Encoding: 9083 9083 5337
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni238D
-Encoding: 9101 9101 5339
+Encoding: 9101 9101 5338
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25FB
-Encoding: 9723 9723 5340
+Encoding: 9723 9723 5339
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni25FC
-Encoding: 9724 9724 5341
+Encoding: 9724 9724 5340
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23BE
-Encoding: 9150 9150 5342
+Encoding: 9150 9150 5341
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23BF
-Encoding: 9151 9151 5343
+Encoding: 9151 9151 5342
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C9
-Encoding: 9161 9161 5344
+Encoding: 9161 9161 5343
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23CA
-Encoding: 9162 9162 5345
+Encoding: 9162 9162 5344
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23CB
-Encoding: 9163 9163 5346
+Encoding: 9163 9163 5345
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23CC
-Encoding: 9164 9164 5347
+Encoding: 9164 9164 5346
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F170
-Encoding: 127344 127344 5348
+Encoding: 127344 127344 5347
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F171
-Encoding: 127345 127345 5349
+Encoding: 127345 127345 5348
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F172
-Encoding: 127346 127346 5350
+Encoding: 127346 127346 5349
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F173
-Encoding: 127347 127347 5351
+Encoding: 127347 127347 5350
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F174
-Encoding: 127348 127348 5352
+Encoding: 127348 127348 5351
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F175
-Encoding: 127349 127349 5353
+Encoding: 127349 127349 5352
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F176
-Encoding: 127350 127350 5354
+Encoding: 127350 127350 5353
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F177
-Encoding: 127351 127351 5355
+Encoding: 127351 127351 5354
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F178
-Encoding: 127352 127352 5356
+Encoding: 127352 127352 5355
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F179
-Encoding: 127353 127353 5357
+Encoding: 127353 127353 5356
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F17A
-Encoding: 127354 127354 5358
+Encoding: 127354 127354 5357
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F17B
-Encoding: 127355 127355 5359
+Encoding: 127355 127355 5358
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F17C
-Encoding: 127356 127356 5360
+Encoding: 127356 127356 5359
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F17D
-Encoding: 127357 127357 5361
+Encoding: 127357 127357 5360
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F17E
-Encoding: 127358 127358 5362
+Encoding: 127358 127358 5361
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F17F
-Encoding: 127359 127359 5363
+Encoding: 127359 127359 5362
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F180
-Encoding: 127360 127360 5364
+Encoding: 127360 127360 5363
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F181
-Encoding: 127361 127361 5365
+Encoding: 127361 127361 5364
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F182
-Encoding: 127362 127362 5366
+Encoding: 127362 127362 5365
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F183
-Encoding: 127363 127363 5367
+Encoding: 127363 127363 5366
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F184
-Encoding: 127364 127364 5368
+Encoding: 127364 127364 5367
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F185
-Encoding: 127365 127365 5369
+Encoding: 127365 127365 5368
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F186
-Encoding: 127366 127366 5370
+Encoding: 127366 127366 5369
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F187
-Encoding: 127367 127367 5371
+Encoding: 127367 127367 5370
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F188
-Encoding: 127368 127368 5372
+Encoding: 127368 127368 5371
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F189
-Encoding: 127369 127369 5373
+Encoding: 127369 127369 5372
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F150
-Encoding: 127312 127312 5374
+Encoding: 127312 127312 5373
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F151
-Encoding: 127313 127313 5375
+Encoding: 127313 127313 5374
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F152
-Encoding: 127314 127314 5376
+Encoding: 127314 127314 5375
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F153
-Encoding: 127315 127315 5377
+Encoding: 127315 127315 5376
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F154
-Encoding: 127316 127316 5378
+Encoding: 127316 127316 5377
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F155
-Encoding: 127317 127317 5379
+Encoding: 127317 127317 5378
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F156
-Encoding: 127318 127318 5380
+Encoding: 127318 127318 5379
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F157
-Encoding: 127319 127319 5381
+Encoding: 127319 127319 5380
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F158
-Encoding: 127320 127320 5382
+Encoding: 127320 127320 5381
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F159
-Encoding: 127321 127321 5383
+Encoding: 127321 127321 5382
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F15A
-Encoding: 127322 127322 5384
+Encoding: 127322 127322 5383
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F15B
-Encoding: 127323 127323 5385
+Encoding: 127323 127323 5384
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F15C
-Encoding: 127324 127324 5386
+Encoding: 127324 127324 5385
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F15D
-Encoding: 127325 127325 5387
+Encoding: 127325 127325 5386
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F15E
-Encoding: 127326 127326 5388
+Encoding: 127326 127326 5387
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F15F
-Encoding: 127327 127327 5389
+Encoding: 127327 127327 5388
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F160
-Encoding: 127328 127328 5390
+Encoding: 127328 127328 5389
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F161
-Encoding: 127329 127329 5391
+Encoding: 127329 127329 5390
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F162
-Encoding: 127330 127330 5392
+Encoding: 127330 127330 5391
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F163
-Encoding: 127331 127331 5393
+Encoding: 127331 127331 5392
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F164
-Encoding: 127332 127332 5394
+Encoding: 127332 127332 5393
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F165
-Encoding: 127333 127333 5395
+Encoding: 127333 127333 5394
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F166
-Encoding: 127334 127334 5396
+Encoding: 127334 127334 5395
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F167
-Encoding: 127335 127335 5397
+Encoding: 127335 127335 5396
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F168
-Encoding: 127336 127336 5398
+Encoding: 127336 127336 5397
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F169
-Encoding: 127337 127337 5399
+Encoding: 127337 127337 5398
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F10B
-Encoding: 127243 127243 5400
+Encoding: 127243 127243 5399
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F10C
-Encoding: 127244 127244 5401
+Encoding: 127244 127244 5400
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F10D
-Encoding: 127245 127245 5402
+Encoding: 127245 127245 5401
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F110
-Encoding: 127248 127248 5403
+Encoding: 127248 127248 5402
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F111
-Encoding: 127249 127249 5404
+Encoding: 127249 127249 5403
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F112
-Encoding: 127250 127250 5405
+Encoding: 127250 127250 5404
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F113
-Encoding: 127251 127251 5406
+Encoding: 127251 127251 5405
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F114
-Encoding: 127252 127252 5407
+Encoding: 127252 127252 5406
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F115
-Encoding: 127253 127253 5408
+Encoding: 127253 127253 5407
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F116
-Encoding: 127254 127254 5409
+Encoding: 127254 127254 5408
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F117
-Encoding: 127255 127255 5410
+Encoding: 127255 127255 5409
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F118
-Encoding: 127256 127256 5411
+Encoding: 127256 127256 5410
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F119
-Encoding: 127257 127257 5412
+Encoding: 127257 127257 5411
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F11A
-Encoding: 127258 127258 5413
+Encoding: 127258 127258 5412
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F11B
-Encoding: 127259 127259 5414
+Encoding: 127259 127259 5413
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F11C
-Encoding: 127260 127260 5415
+Encoding: 127260 127260 5414
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F11D
-Encoding: 127261 127261 5416
+Encoding: 127261 127261 5415
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F11E
-Encoding: 127262 127262 5417
+Encoding: 127262 127262 5416
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F11F
-Encoding: 127263 127263 5418
+Encoding: 127263 127263 5417
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F120
-Encoding: 127264 127264 5419
+Encoding: 127264 127264 5418
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F121
-Encoding: 127265 127265 5420
+Encoding: 127265 127265 5419
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F122
-Encoding: 127266 127266 5421
+Encoding: 127266 127266 5420
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F123
-Encoding: 127267 127267 5422
+Encoding: 127267 127267 5421
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F124
-Encoding: 127268 127268 5423
+Encoding: 127268 127268 5422
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F125
-Encoding: 127269 127269 5424
+Encoding: 127269 127269 5423
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F126
-Encoding: 127270 127270 5425
+Encoding: 127270 127270 5424
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F127
-Encoding: 127271 127271 5426
+Encoding: 127271 127271 5425
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F128
-Encoding: 127272 127272 5427
+Encoding: 127272 127272 5426
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F129
-Encoding: 127273 127273 5428
+Encoding: 127273 127273 5427
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32CB
-Encoding: 13003 13003 5429
+Encoding: 13003 13003 5428
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C0
-Encoding: 12992 12992 5430
+Encoding: 12992 12992 5429
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C1
-Encoding: 12993 12993 5431
+Encoding: 12993 12993 5430
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C2
-Encoding: 12994 12994 5432
+Encoding: 12994 12994 5431
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C3
-Encoding: 12995 12995 5433
+Encoding: 12995 12995 5432
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C4
-Encoding: 12996 12996 5434
+Encoding: 12996 12996 5433
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C5
-Encoding: 12997 12997 5435
+Encoding: 12997 12997 5434
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C6
-Encoding: 12998 12998 5436
+Encoding: 12998 12998 5435
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C7
-Encoding: 12999 12999 5437
+Encoding: 12999 12999 5436
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C8
-Encoding: 13000 13000 5438
+Encoding: 13000 13000 5437
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32C9
-Encoding: 13001 13001 5439
+Encoding: 13001 13001 5438
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni32CA
-Encoding: 13002 13002 5440
+Encoding: 13002 13002 5439
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3359
-Encoding: 13145 13145 5441
+Encoding: 13145 13145 5440
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni335A
-Encoding: 13146 13146 5442
+Encoding: 13146 13146 5441
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3358
-Encoding: 13144 13144 5443
+Encoding: 13144 13144 5442
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni335B
-Encoding: 13147 13147 5444
+Encoding: 13147 13147 5443
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni335C
-Encoding: 13148 13148 5445
+Encoding: 13148 13148 5444
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni335D
-Encoding: 13149 13149 5446
+Encoding: 13149 13149 5445
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni335E
-Encoding: 13150 13150 5447
+Encoding: 13150 13150 5446
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni335F
-Encoding: 13151 13151 5448
+Encoding: 13151 13151 5447
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3360
-Encoding: 13152 13152 5449
+Encoding: 13152 13152 5448
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3361
-Encoding: 13153 13153 5450
+Encoding: 13153 13153 5449
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3362
-Encoding: 13154 13154 5451
+Encoding: 13154 13154 5450
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3363
-Encoding: 13155 13155 5452
+Encoding: 13155 13155 5451
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3364
-Encoding: 13156 13156 5453
+Encoding: 13156 13156 5452
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3365
-Encoding: 13157 13157 5454
+Encoding: 13157 13157 5453
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3366
-Encoding: 13158 13158 5455
+Encoding: 13158 13158 5454
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3367
-Encoding: 13159 13159 5456
+Encoding: 13159 13159 5455
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3368
-Encoding: 13160 13160 5457
+Encoding: 13160 13160 5456
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3369
-Encoding: 13161 13161 5458
+Encoding: 13161 13161 5457
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni336A
-Encoding: 13162 13162 5459
+Encoding: 13162 13162 5458
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni336B
-Encoding: 13163 13163 5460
+Encoding: 13163 13163 5459
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni336C
-Encoding: 13164 13164 5461
+Encoding: 13164 13164 5460
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni336D
-Encoding: 13165 13165 5462
+Encoding: 13165 13165 5461
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni336E
-Encoding: 13166 13166 5463
+Encoding: 13166 13166 5462
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni336F
-Encoding: 13167 13167 5464
+Encoding: 13167 13167 5463
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3370
-Encoding: 13168 13168 5465
+Encoding: 13168 13168 5464
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E0
-Encoding: 13280 13280 5466
+Encoding: 13280 13280 5465
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E1
-Encoding: 13281 13281 5467
+Encoding: 13281 13281 5466
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E2
-Encoding: 13282 13282 5468
+Encoding: 13282 13282 5467
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E3
-Encoding: 13283 13283 5469
+Encoding: 13283 13283 5468
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E4
-Encoding: 13284 13284 5470
+Encoding: 13284 13284 5469
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E5
-Encoding: 13285 13285 5471
+Encoding: 13285 13285 5470
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E6
-Encoding: 13286 13286 5472
+Encoding: 13286 13286 5471
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E7
-Encoding: 13287 13287 5473
+Encoding: 13287 13287 5472
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E8
-Encoding: 13288 13288 5474
+Encoding: 13288 13288 5473
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33E9
-Encoding: 13289 13289 5475
+Encoding: 13289 13289 5474
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33EA
-Encoding: 13290 13290 5476
+Encoding: 13290 13290 5475
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33EB
-Encoding: 13291 13291 5477
+Encoding: 13291 13291 5476
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33EC
-Encoding: 13292 13292 5478
+Encoding: 13292 13292 5477
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33ED
-Encoding: 13293 13293 5479
+Encoding: 13293 13293 5478
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33EE
-Encoding: 13294 13294 5480
+Encoding: 13294 13294 5479
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33EF
-Encoding: 13295 13295 5481
+Encoding: 13295 13295 5480
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F0
-Encoding: 13296 13296 5482
+Encoding: 13296 13296 5481
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F1
-Encoding: 13297 13297 5483
+Encoding: 13297 13297 5482
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F2
-Encoding: 13298 13298 5484
+Encoding: 13298 13298 5483
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F3
-Encoding: 13299 13299 5485
+Encoding: 13299 13299 5484
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F4
-Encoding: 13300 13300 5486
+Encoding: 13300 13300 5485
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F5
-Encoding: 13301 13301 5487
+Encoding: 13301 13301 5486
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F6
-Encoding: 13302 13302 5488
+Encoding: 13302 13302 5487
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F7
-Encoding: 13303 13303 5489
+Encoding: 13303 13303 5488
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F8
-Encoding: 13304 13304 5490
+Encoding: 13304 13304 5489
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33F9
-Encoding: 13305 13305 5491
+Encoding: 13305 13305 5490
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33FA
-Encoding: 13306 13306 5492
+Encoding: 13306 13306 5491
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33FB
-Encoding: 13307 13307 5493
+Encoding: 13307 13307 5492
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33FC
-Encoding: 13308 13308 5494
+Encoding: 13308 13308 5493
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33FD
-Encoding: 13309 13309 5495
+Encoding: 13309 13309 5494
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni33FE
-Encoding: 13310 13310 5496
+Encoding: 13310 13310 5495
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3037
-Encoding: 12343 12343 5497
+Encoding: 12343 12343 5496
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3220
-Encoding: 12832 12832 5498
+Encoding: 12832 12832 5497
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3221
-Encoding: 12833 12833 5499
+Encoding: 12833 12833 5498
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3222
-Encoding: 12834 12834 5500
+Encoding: 12834 12834 5499
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3223
-Encoding: 12835 12835 5501
+Encoding: 12835 12835 5500
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3224
-Encoding: 12836 12836 5502
+Encoding: 12836 12836 5501
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3225
-Encoding: 12837 12837 5503
+Encoding: 12837 12837 5502
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3226
-Encoding: 12838 12838 5504
+Encoding: 12838 12838 5503
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3227
-Encoding: 12839 12839 5505
+Encoding: 12839 12839 5504
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3228
-Encoding: 12840 12840 5506
+Encoding: 12840 12840 5505
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3229
-Encoding: 12841 12841 5507
+Encoding: 12841 12841 5506
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni322A
-Encoding: 12842 12842 5508
+Encoding: 12842 12842 5507
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni322B
-Encoding: 12843 12843 5509
+Encoding: 12843 12843 5508
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni322C
-Encoding: 12844 12844 5510
+Encoding: 12844 12844 5509
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni322D
-Encoding: 12845 12845 5511
+Encoding: 12845 12845 5510
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni322E
-Encoding: 12846 12846 5512
+Encoding: 12846 12846 5511
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni322F
-Encoding: 12847 12847 5513
+Encoding: 12847 12847 5512
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni3230
-Encoding: 12848 12848 5514
+Encoding: 12848 12848 5513
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2047
-Encoding: 8263 8263 5515
+Encoding: 8263 8263 5514
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2048
-Encoding: 8264 8264 5516
+Encoding: 8264 8264 5515
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2049
-Encoding: 8265 8265 5517
+Encoding: 8265 8265 5516
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20A0
-Encoding: 8352 8352 5518
+Encoding: 8352 8352 5517
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2242
-Encoding: 8770 8770 5519
+Encoding: 8770 8770 5518
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2246
-Encoding: 8774 8774 5520
+Encoding: 8774 8774 5519
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2247
-Encoding: 8775 8775 5521
+Encoding: 8775 8775 5520
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni224A
-Encoding: 8778 8778 5522
+Encoding: 8778 8778 5521
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni224B
-Encoding: 8779 8779 5523
+Encoding: 8779 8779 5522
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni224C
-Encoding: 8780 8780 5524
+Encoding: 8780 8780 5523
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2241
-Encoding: 8769 8769 5525
+Encoding: 8769 8769 5524
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: similar
-Encoding: 8764 8764 5526
+Encoding: 8764 8764 5525
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni223B
-Encoding: 8763 8763 5527
+Encoding: 8763 8763 5526
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni229A
-Encoding: 8858 8858 5528
+Encoding: 8858 8858 5527
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni29FA
-Encoding: 10746 10746 5529
+Encoding: 10746 10746 5528
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4B2
-Encoding: 128178 128178 5530
+Encoding: 128178 128178 5529
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni219F
-Encoding: 8607 8607 5531
+Encoding: 8607 8607 5530
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22CD
-Encoding: 8909 8909 5532
+Encoding: 8909 8909 5531
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni223F
-Encoding: 8767 8767 5533
+Encoding: 8767 8767 5532
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2238
-Encoding: 8760 8760 5534
+Encoding: 8760 8760 5533
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2239
-Encoding: 8761 8761 5535
+Encoding: 8761 8761 5534
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2231
-Encoding: 8753 8753 5536
+Encoding: 8753 8753 5535
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2232
-Encoding: 8754 8754 5537
+Encoding: 8754 8754 5536
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2233
-Encoding: 8755 8755 5538
+Encoding: 8755 8755 5537
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2240
-Encoding: 8768 8768 5539
+Encoding: 8768 8768 5538
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni224E
-Encoding: 8782 8782 5540
+Encoding: 8782 8782 5539
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni224F
-Encoding: 8783 8783 5541
+Encoding: 8783 8783 5540
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2268
-Encoding: 8808 8808 5542
+Encoding: 8808 8808 5541
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2269
-Encoding: 8809 8809 5543
+Encoding: 8809 8809 5542
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni226D
-Encoding: 8813 8813 5544
+Encoding: 8813 8813 5543
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni226C
-Encoding: 8812 8812 5545
+Encoding: 8812 8812 5544
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C1
-Encoding: 9153 9153 5546
+Encoding: 9153 9153 5545
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C2
-Encoding: 9154 9154 5547
+Encoding: 9154 9154 5546
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C0
-Encoding: 9152 9152 5548
+Encoding: 9152 9152 5547
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C3
-Encoding: 9155 9155 5549
+Encoding: 9155 9155 5548
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C4
-Encoding: 9156 9156 5550
+Encoding: 9156 9156 5549
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C5
-Encoding: 9157 9157 5551
+Encoding: 9157 9157 5550
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C6
-Encoding: 9158 9158 5552
+Encoding: 9158 9158 5551
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C7
-Encoding: 9159 9159 5553
+Encoding: 9159 9159 5552
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23C8
-Encoding: 9160 9160 5554
+Encoding: 9160 9160 5553
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2117
-Encoding: 8471 8471 5555
+Encoding: 8471 8471 5554
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni226E
-Encoding: 8814 8814 5556
+Encoding: 8814 8814 5555
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni226F
-Encoding: 8815 8815 5557
+Encoding: 8815 8815 5556
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2270
-Encoding: 8816 8816 5558
+Encoding: 8816 8816 5557
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2271
-Encoding: 8817 8817 5559
+Encoding: 8817 8817 5558
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2272
-Encoding: 8818 8818 5560
+Encoding: 8818 8818 5559
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2273
-Encoding: 8819 8819 5561
+Encoding: 8819 8819 5560
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2274
-Encoding: 8820 8820 5562
+Encoding: 8820 8820 5561
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2275
-Encoding: 8821 8821 5563
+Encoding: 8821 8821 5562
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2276
-Encoding: 8822 8822 5564
+Encoding: 8822 8822 5563
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2277
-Encoding: 8823 8823 5565
+Encoding: 8823 8823 5564
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2278
-Encoding: 8824 8824 5566
+Encoding: 8824 8824 5565
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2279
-Encoding: 8825 8825 5567
+Encoding: 8825 8825 5566
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni227A
-Encoding: 8826 8826 5568
+Encoding: 8826 8826 5567
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni227B
-Encoding: 8827 8827 5569
+Encoding: 8827 8827 5568
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni227C
-Encoding: 8828 8828 5570
+Encoding: 8828 8828 5569
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni227D
-Encoding: 8829 8829 5571
+Encoding: 8829 8829 5570
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni227E
-Encoding: 8830 8830 5572
+Encoding: 8830 8830 5571
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni227F
-Encoding: 8831 8831 5573
+Encoding: 8831 8831 5572
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2280
-Encoding: 8832 8832 5574
+Encoding: 8832 8832 5573
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2281
-Encoding: 8833 8833 5575
+Encoding: 8833 8833 5574
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E0
-Encoding: 8928 8928 5576
+Encoding: 8928 8928 5575
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E1
-Encoding: 8929 8929 5577
+Encoding: 8929 8929 5576
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22DE
-Encoding: 8926 8926 5578
+Encoding: 8926 8926 5577
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22DF
-Encoding: 8927 8927 5579
+Encoding: 8927 8927 5578
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22DC
-Encoding: 8924 8924 5580
+Encoding: 8924 8924 5579
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22DD
-Encoding: 8925 8925 5581
+Encoding: 8925 8925 5580
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni231A
-Encoding: 8986 8986 5582
+Encoding: 8986 8986 5581
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F513
-Encoding: 128275 128275 5583
+Encoding: 128275 128275 5582
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4E8
-Encoding: 128232 128232 5584
+Encoding: 128232 128232 5583
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4E5
-Encoding: 128229 128229 5585
+Encoding: 128229 128229 5584
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4E4
-Encoding: 128228 128228 5586
+Encoding: 128228 128228 5585
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F480
-Encoding: 128128 128128 5587
+Encoding: 128128 128128 5586
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F47B
-Encoding: 128123 128123 5588
+Encoding: 128123 128123 5587
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1FA9F
-Encoding: 129695 129695 5589
+Encoding: 129695 129695 5588
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F34E
-Encoding: 127822 127822 5590
+Encoding: 127822 127822 5589
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F34F
-Encoding: 127823 127823 5591
+Encoding: 127823 127823 5590
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F916
-Encoding: 129302 129302 5592
+Encoding: 129302 129302 5591
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4CB
-Encoding: 128203 128203 5593
+Encoding: 128203 128203 5592
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4DC
-Encoding: 128220 128220 5594
+Encoding: 128220 128220 5593
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C3
-Encoding: 128195 128195 5595
+Encoding: 128195 128195 5594
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4C7
-Encoding: 128199 128199 5596
+Encoding: 128199 128199 5595
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4DE
-Encoding: 128222 128222 5597
+Encoding: 128222 128222 5596
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4E0
-Encoding: 128224 128224 5598
+Encoding: 128224 128224 5597
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4F0
-Encoding: 128240 128240 5599
+Encoding: 128240 128240 5598
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F4B0
-Encoding: 128176 128176 5600
+Encoding: 128176 128176 5599
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22CF
-Encoding: 8911 8911 5601
+Encoding: 8911 8911 5600
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22CE
-Encoding: 8910 8910 5602
+Encoding: 8910 8910 5601
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D5
-Encoding: 8917 8917 5603
+Encoding: 8917 8917 5602
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D6
-Encoding: 8918 8918 5604
+Encoding: 8918 8918 5603
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E2
-Encoding: 8930 8930 5605
+Encoding: 8930 8930 5604
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E3
-Encoding: 8931 8931 5606
+Encoding: 8931 8931 5605
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E4
-Encoding: 8932 8932 5607
+Encoding: 8932 8932 5606
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E5
-Encoding: 8933 8933 5608
+Encoding: 8933 8933 5607
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E6
-Encoding: 8934 8934 5609
+Encoding: 8934 8934 5608
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E7
-Encoding: 8935 8935 5610
+Encoding: 8935 8935 5609
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E8
-Encoding: 8936 8936 5611
+Encoding: 8936 8936 5610
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22E9
-Encoding: 8937 8937 5612
+Encoding: 8937 8937 5611
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22EA
-Encoding: 8938 8938 5613
+Encoding: 8938 8938 5612
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22EB
-Encoding: 8939 8939 5614
+Encoding: 8939 8939 5613
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22EC
-Encoding: 8940 8940 5615
+Encoding: 8940 8940 5614
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22ED
-Encoding: 8941 8941 5616
+Encoding: 8941 8941 5615
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22DA
-Encoding: 8922 8922 5617
+Encoding: 8922 8922 5616
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22DB
-Encoding: 8923 8923 5618
+Encoding: 8923 8923 5617
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22BE
-Encoding: 8894 8894 5619
+Encoding: 8894 8894 5618
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D7
-Encoding: 8919 8919 5620
+Encoding: 8919 8919 5619
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D8
-Encoding: 8920 8920 5621
+Encoding: 8920 8920 5620
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D9
-Encoding: 8921 8921 5622
+Encoding: 8921 8921 5621
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22BC
-Encoding: 8892 8892 5623
+Encoding: 8892 8892 5622
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22BD
-Encoding: 8893 8893 5624
+Encoding: 8893 8893 5623
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22BB
-Encoding: 8891 8891 5625
+Encoding: 8891 8891 5624
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22C9
-Encoding: 8905 8905 5626
+Encoding: 8905 8905 5625
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22CA
-Encoding: 8906 8906 5627
+Encoding: 8906 8906 5626
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22CB
-Encoding: 8907 8907 5628
+Encoding: 8907 8907 5627
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22CC
-Encoding: 8908 8908 5629
+Encoding: 8908 8908 5628
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22C7
-Encoding: 8903 8903 5630
+Encoding: 8903 8903 5629
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23F0
-Encoding: 9200 9200 5631
+Encoding: 9200 9200 5630
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni238C
-Encoding: 9100 9100 5632
+Encoding: 9100 9100 5631
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23FD
-Encoding: 9213 9213 5633
+Encoding: 9213 9213 5632
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23FE
-Encoding: 9214 9214 5634
+Encoding: 9214 9214 5633
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2042
-Encoding: 8258 8258 5635
+Encoding: 8258 8258 5634
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2051
-Encoding: 8273 8273 5636
+Encoding: 8273 8273 5635
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: colonmonetary
-Encoding: 8353 8353 5637
+Encoding: 8353 8353 5636
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20A2
-Encoding: 8354 8354 5638
+Encoding: 8354 8354 5637
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20A5
-Encoding: 8357 8357 5639
+Encoding: 8357 8357 5638
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20A6
-Encoding: 8358 8358 5640
+Encoding: 8358 8358 5639
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20A8
-Encoding: 8360 8360 5641
+Encoding: 8360 8360 5640
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: dong
-Encoding: 8363 8363 5642
+Encoding: 8363 8363 5641
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20AD
-Encoding: 8365 8365 5643
+Encoding: 8365 8365 5642
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20AE
-Encoding: 8366 8366 5644
+Encoding: 8366 8366 5643
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20AF
-Encoding: 8367 8367 5645
+Encoding: 8367 8367 5644
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B0
-Encoding: 8368 8368 5646
+Encoding: 8368 8368 5645
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B1
-Encoding: 8369 8369 5647
+Encoding: 8369 8369 5646
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2102
-Encoding: 8450 8450 5648
+Encoding: 8450 8450 5647
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2104
-Encoding: 8452 8452 5649
+Encoding: 8452 8452 5648
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2107
-Encoding: 8455 8455 5650
+Encoding: 8455 8455 5649
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2108
-Encoding: 8456 8456 5651
+Encoding: 8456 8456 5650
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni210A
-Encoding: 8458 8458 5652
+Encoding: 8458 8458 5651
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni210B
-Encoding: 8459 8459 5653
+Encoding: 8459 8459 5652
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni210C
-Encoding: 8460 8460 5654
+Encoding: 8460 8460 5653
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni210D
-Encoding: 8461 8461 5655
+Encoding: 8461 8461 5654
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2110
-Encoding: 8464 8464 5656
+Encoding: 8464 8464 5655
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: Ifraktur
-Encoding: 8465 8465 5657
+Encoding: 8465 8465 5656
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2112
-Encoding: 8466 8466 5658
+Encoding: 8466 8466 5657
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: afii61289
-Encoding: 8467 8467 5659
+Encoding: 8467 8467 5658
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2114
-Encoding: 8468 8468 5660
+Encoding: 8468 8468 5659
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2115
-Encoding: 8469 8469 5661
+Encoding: 8469 8469 5660
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2119
-Encoding: 8473 8473 5662
+Encoding: 8473 8473 5661
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni211A
-Encoding: 8474 8474 5663
+Encoding: 8474 8474 5662
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni211D
-Encoding: 8477 8477 5664
+Encoding: 8477 8477 5663
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2124
-Encoding: 8484 8484 5665
+Encoding: 8484 8484 5664
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2120
-Encoding: 8480 8480 5666
+Encoding: 8480 8480 5665
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2182
-Encoding: 8578 8578 5667
+Encoding: 8578 8578 5666
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: estimated
-Encoding: 8494 8494 5668
+Encoding: 8494 8494 5667
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2132
-Encoding: 8498 8498 5669
+Encoding: 8498 8498 5668
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni214E
-Encoding: 8526 8526 5670
+Encoding: 8526 8526 5669
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21D6
-Encoding: 8662 8662 5671
+Encoding: 8662 8662 5670
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21D7
-Encoding: 8663 8663 5672
+Encoding: 8663 8663 5671
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21D8
-Encoding: 8664 8664 5673
+Encoding: 8664 8664 5672
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21D9
-Encoding: 8665 8665 5674
+Encoding: 8665 8665 5673
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21DE
-Encoding: 8670 8670 5675
+Encoding: 8670 8670 5674
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21DF
-Encoding: 8671 8671 5676
+Encoding: 8671 8671 5675
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21E4
-Encoding: 8676 8676 5677
+Encoding: 8676 8676 5676
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21E5
-Encoding: 8677 8677 5678
+Encoding: 8677 8677 5677
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21E6
-Encoding: 8678 8678 5679
+Encoding: 8678 8678 5678
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21E7
-Encoding: 8679 8679 5680
+Encoding: 8679 8679 5679
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21E8
-Encoding: 8680 8680 5681
+Encoding: 8680 8680 5680
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21E9
-Encoding: 8681 8681 5682
+Encoding: 8681 8681 5681
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21EA
-Encoding: 8682 8682 5683
+Encoding: 8682 8682 5682
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni219E
-Encoding: 8606 8606 5684
+Encoding: 8606 8606 5683
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21A0
-Encoding: 8608 8608 5685
+Encoding: 8608 8608 5684
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2305
-Encoding: 8965 8965 5686
+Encoding: 8965 8965 5685
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2306
-Encoding: 8966 8966 5687
+Encoding: 8966 8966 5686
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni219C
-Encoding: 8604 8604 5688
+Encoding: 8604 8604 5687
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni219D
-Encoding: 8605 8605 5689
+Encoding: 8605 8605 5688
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21AE
-Encoding: 8622 8622 5690
+Encoding: 8622 8622 5689
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21C4
-Encoding: 8644 8644 5691
+Encoding: 8644 8644 5690
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21C6
-Encoding: 8646 8646 5692
+Encoding: 8646 8646 5691
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21C7
-Encoding: 8647 8647 5693
+Encoding: 8647 8647 5692
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21C9
-Encoding: 8649 8649 5694
+Encoding: 8649 8649 5693
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21C5
-Encoding: 8645 8645 5695
+Encoding: 8645 8645 5694
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21C8
-Encoding: 8648 8648 5696
+Encoding: 8648 8648 5695
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21CA
-Encoding: 8650 8650 5697
+Encoding: 8650 8650 5696
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21CD
-Encoding: 8653 8653 5698
+Encoding: 8653 8653 5697
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21CF
-Encoding: 8655 8655 5699
+Encoding: 8655 8655 5698
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21CE
-Encoding: 8654 8654 5700
+Encoding: 8654 8654 5699
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21DA
-Encoding: 8666 8666 5701
+Encoding: 8666 8666 5700
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21DB
-Encoding: 8667 8667 5702
+Encoding: 8667 8667 5701
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21EB
-Encoding: 8683 8683 5703
+Encoding: 8683 8683 5702
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21EC
-Encoding: 8684 8684 5704
+Encoding: 8684 8684 5703
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21EE
-Encoding: 8686 8686 5705
+Encoding: 8686 8686 5704
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21ED
-Encoding: 8685 8685 5706
+Encoding: 8685 8685 5705
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21F0
-Encoding: 8688 8688 5707
+Encoding: 8688 8688 5706
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21F3
-Encoding: 8691 8691 5708
+Encoding: 8691 8691 5707
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21F5
-Encoding: 8693 8693 5709
+Encoding: 8693 8693 5708
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21F6
-Encoding: 8694 8694 5710
+Encoding: 8694 8694 5709
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2607
-Encoding: 9735 9735 5711
+Encoding: 9735 9735 5710
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2608
-Encoding: 9736 9736 5712
+Encoding: 9736 9736 5711
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25A4
-Encoding: 9636 9636 5713
+Encoding: 9636 9636 5712
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25A5
-Encoding: 9637 9637 5714
+Encoding: 9637 9637 5713
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25A7
-Encoding: 9639 9639 5715
+Encoding: 9639 9639 5714
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25A6
-Encoding: 9638 9638 5716
+Encoding: 9638 9638 5715
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25A8
-Encoding: 9640 9640 5717
+Encoding: 9640 9640 5716
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25A9
-Encoding: 9641 9641 5718
+Encoding: 9641 9641 5717
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E7
-Encoding: 9703 9703 5719
+Encoding: 9703 9703 5718
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E8
-Encoding: 9704 9704 5720
+Encoding: 9704 9704 5719
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E9
-Encoding: 9705 9705 5721
+Encoding: 9705 9705 5720
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25EA
-Encoding: 9706 9706 5722
+Encoding: 9706 9706 5721
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25AD
-Encoding: 9645 9645 5723
+Encoding: 9645 9645 5722
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25D6
-Encoding: 9686 9686 5724
+Encoding: 9686 9686 5723
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25D7
-Encoding: 9687 9687 5725
+Encoding: 9687 9687 5724
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25CD
-Encoding: 9677 9677 5726
+Encoding: 9677 9677 5725
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25CC
-Encoding: 9676 9676 5727
+Encoding: 9676 9676 5726
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E0
-Encoding: 9696 9696 5728
+Encoding: 9696 9696 5727
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25E1
-Encoding: 9697 9697 5729
+Encoding: 9697 9697 5728
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25DC
-Encoding: 9692 9692 5730
+Encoding: 9692 9692 5729
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25DD
-Encoding: 9693 9693 5731
+Encoding: 9693 9693 5730
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25DE
-Encoding: 9694 9694 5732
+Encoding: 9694 9694 5731
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25DF
-Encoding: 9695 9695 5733
+Encoding: 9695 9695 5732
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25EC
-Encoding: 9708 9708 5734
+Encoding: 9708 9708 5733
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25ED
-Encoding: 9709 9709 5735
+Encoding: 9709 9709 5734
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25EE
-Encoding: 9710 9710 5736
+Encoding: 9710 9710 5735
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25DA
-Encoding: 9690 9690 5737
+Encoding: 9690 9690 5736
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25DB
-Encoding: 9691 9691 5738
+Encoding: 9691 9691 5737
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25F8
-Encoding: 9720 9720 5739
+Encoding: 9720 9720 5738
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25F9
-Encoding: 9721 9721 5740
+Encoding: 9721 9721 5739
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25FA
-Encoding: 9722 9722 5741
+Encoding: 9722 9722 5740
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B7
-Encoding: 9655 9655 5742
+Encoding: 9655 9655 5741
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25BB
-Encoding: 9659 9659 5743
+Encoding: 9659 9659 5742
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25C1
-Encoding: 9665 9665 5744
+Encoding: 9665 9665 5743
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25C5
-Encoding: 9669 9669 5745
+Encoding: 9669 9669 5744
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B4
-Encoding: 9652 9652 5746
+Encoding: 9652 9652 5745
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B5
-Encoding: 9653 9653 5747
+Encoding: 9653 9653 5746
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25BE
-Encoding: 9662 9662 5748
+Encoding: 9662 9662 5747
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25BF
-Encoding: 9663 9663 5749
+Encoding: 9663 9663 5748
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B8
-Encoding: 9656 9656 5750
+Encoding: 9656 9656 5749
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B9
-Encoding: 9657 9657 5751
+Encoding: 9657 9657 5750
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25C2
-Encoding: 9666 9666 5752
+Encoding: 9666 9666 5751
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25C3
-Encoding: 9667 9667 5753
+Encoding: 9667 9667 5752
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2686
-Encoding: 9862 9862 5754
+Encoding: 9862 9862 5753
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2688
-Encoding: 9864 9864 5755
+Encoding: 9864 9864 5754
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2689
-Encoding: 9865 9865 5756
+Encoding: 9865 9865 5755
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni21EF
-Encoding: 8687 8687 5757
+Encoding: 8687 8687 5756
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B15
-Encoding: 11029 11029 5758
+Encoding: 11029 11029 5757
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B14
-Encoding: 11028 11028 5759
+Encoding: 11028 11028 5758
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B13
-Encoding: 11027 11027 5760
+Encoding: 11027 11027 5759
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B12
-Encoding: 11026 11026 5761
+Encoding: 11026 11026 5760
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B1A
-Encoding: 11034 11034 5762
+Encoding: 11034 11034 5761
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B31
-Encoding: 11057 11057 5763
+Encoding: 11057 11057 5762
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BB8
-Encoding: 11192 11192 5764
+Encoding: 11192 11192 5763
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2985
-Encoding: 10629 10629 5765
+Encoding: 10629 10629 5764
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2986
-Encoding: 10630 10630 5766
+Encoding: 10630 10630 5765
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2620
-Encoding: 9760 9760 5767
+Encoding: 9760 9760 5766
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2622
-Encoding: 9762 9762 5768
+Encoding: 9762 9762 5767
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2623
-Encoding: 9763 9763 5769
+Encoding: 9763 9763 5768
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2625
-Encoding: 9765 9765 5770
+Encoding: 9765 9765 5769
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2626
-Encoding: 9766 9766 5771
+Encoding: 9766 9766 5770
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2627
-Encoding: 9767 9767 5772
+Encoding: 9767 9767 5771
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2629
-Encoding: 9769 9769 5773
+Encoding: 9769 9769 5772
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2624
-Encoding: 9764 9764 5774
+Encoding: 9764 9764 5773
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni262A
-Encoding: 9770 9770 5775
+Encoding: 9770 9770 5774
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni262B
-Encoding: 9771 9771 5776
+Encoding: 9771 9771 5775
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni262C
-Encoding: 9772 9772 5777
+Encoding: 9772 9772 5776
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni262D
-Encoding: 9773 9773 5778
+Encoding: 9773 9773 5777
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni262E
-Encoding: 9774 9774 5779
+Encoding: 9774 9774 5778
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni262F
-Encoding: 9775 9775 5780
+Encoding: 9775 9775 5779
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni263D
-Encoding: 9789 9789 5781
+Encoding: 9789 9789 5780
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni263E
-Encoding: 9790 9790 5782
+Encoding: 9790 9790 5781
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2621
-Encoding: 9761 9761 5783
+Encoding: 9761 9761 5782
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni0E3F
-Encoding: 3647 3647 5784
+Encoding: 3647 3647 5783
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2031
-Encoding: 8241 8241 5785
+Encoding: 8241 8241 5784
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni212A
-Encoding: 8490 8490 5786
+Encoding: 8490 8490 5785
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni260F
-Encoding: 9743 9743 5787
+Encoding: 9743 9743 5786
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni260E
-Encoding: 9742 9742 5788
+Encoding: 9742 9742 5787
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2616
-Encoding: 9750 9750 5789
+Encoding: 9750 9750 5788
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2617
-Encoding: 9751 9751 5790
+Encoding: 9751 9751 5789
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2668
-Encoding: 9832 9832 5791
+Encoding: 9832 9832 5790
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2720
-Encoding: 10016 10016 5792
+Encoding: 10016 10016 5791
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25AE
-Encoding: 9646 9646 5793
+Encoding: 9646 9646 5792
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25AF
-Encoding: 9647 9647 5794
+Encoding: 9647 9647 5793
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B0
-Encoding: 9648 9648 5795
+Encoding: 9648 9648 5794
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25B1
-Encoding: 9649 9649 5796
+Encoding: 9649 9649 5795
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2613
-Encoding: 9747 9747 5797
+Encoding: 9747 9747 5796
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22B0
-Encoding: 8880 8880 5798
+Encoding: 8880 8880 5797
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22B1
-Encoding: 8881 8881 5799
+Encoding: 8881 8881 5798
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22B9
-Encoding: 8889 8889 5800
+Encoding: 8889 8889 5799
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22BA
-Encoding: 8890 8890 5801
+Encoding: 8890 8890 5800
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D0
-Encoding: 8912 8912 5802
+Encoding: 8912 8912 5801
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D1
-Encoding: 8913 8913 5803
+Encoding: 8913 8913 5802
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D2
-Encoding: 8914 8914 5804
+Encoding: 8914 8914 5803
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D3
-Encoding: 8915 8915 5805
+Encoding: 8915 8915 5804
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni22D4
-Encoding: 8916 8916 5806
+Encoding: 8916 8916 5805
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni271D
-Encoding: 10013 10013 5807
+Encoding: 10013 10013 5806
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni271E
-Encoding: 10014 10014 5808
+Encoding: 10014 10014 5807
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni271F
-Encoding: 10015 10015 5809
+Encoding: 10015 10015 5808
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2721
-Encoding: 10017 10017 5810
+Encoding: 10017 10017 5809
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2722
-Encoding: 10018 10018 5811
+Encoding: 10018 10018 5810
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2723
-Encoding: 10019 10019 5812
+Encoding: 10019 10019 5811
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2724
-Encoding: 10020 10020 5813
+Encoding: 10020 10020 5812
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2725
-Encoding: 10021 10021 5814
+Encoding: 10021 10021 5813
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2727
-Encoding: 10023 10023 5815
+Encoding: 10023 10023 5814
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni272B
-Encoding: 10027 10027 5816
+Encoding: 10027 10027 5815
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni272C
-Encoding: 10028 10028 5817
+Encoding: 10028 10028 5816
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni272F
-Encoding: 10031 10031 5818
+Encoding: 10031 10031 5817
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2729
-Encoding: 10025 10025 5819
+Encoding: 10025 10025 5818
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2730
-Encoding: 10032 10032 5820
+Encoding: 10032 10032 5819
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni272A
-Encoding: 10026 10026 5821
+Encoding: 10026 10026 5820
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2731
-Encoding: 10033 10033 5822
+Encoding: 10033 10033 5821
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2732
-Encoding: 10034 10034 5823
+Encoding: 10034 10034 5822
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2733
-Encoding: 10035 10035 5824
+Encoding: 10035 10035 5823
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2734
-Encoding: 10036 10036 5825
+Encoding: 10036 10036 5824
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2735
-Encoding: 10037 10037 5826
+Encoding: 10037 10037 5825
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2756
-Encoding: 10070 10070 5827
+Encoding: 10070 10070 5826
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B16
-Encoding: 11030 11030 5828
+Encoding: 11030 11030 5827
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B17
-Encoding: 11031 11031 5829
+Encoding: 11031 11031 5828
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B18
-Encoding: 11032 11032 5830
+Encoding: 11032 11032 5829
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B19
-Encoding: 11033 11033 5831
+Encoding: 11033 11033 5830
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BCA
-Encoding: 11210 11210 5832
+Encoding: 11210 11210 5831
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BCB
-Encoding: 11211 11211 5833
+Encoding: 11211 11211 5832
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2619
-Encoding: 9753 9753 5834
+Encoding: 9753 9753 5833
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2767
-Encoding: 10087 10087 5835
+Encoding: 10087 10087 5834
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2766
-Encoding: 10086 10086 5836
+Encoding: 10086 10086 5835
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2765
-Encoding: 10085 10085 5837
+Encoding: 10085 10085 5836
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2763
-Encoding: 10083 10083 5838
+Encoding: 10083 10083 5837
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2762
-Encoding: 10082 10082 5839
+Encoding: 10082 10082 5838
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2754
-Encoding: 10068 10068 5840
+Encoding: 10068 10068 5839
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2755
-Encoding: 10069 10069 5841
+Encoding: 10069 10069 5840
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2757
-Encoding: 10071 10071 5842
+Encoding: 10071 10071 5841
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2A2F
-Encoding: 10799 10799 5843
+Encoding: 10799 10799 5842
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23AF
-Encoding: 9135 9135 5844
+Encoding: 9135 9135 5843
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2C6D
-Encoding: 11373 11373 5845
+Encoding: 11373 11373 5844
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2C62
-Encoding: 11362 11362 5846
+Encoding: 11362 11362 5845
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni0245
-Encoding: 581 581 5847
+Encoding: 581 581 5846
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni023D
-Encoding: 573 573 5848
+Encoding: 573 573 5847
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni023E
-Encoding: 574 574 5849
+Encoding: 574 574 5848
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni023B
-Encoding: 571 571 5850
+Encoding: 571 571 5849
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni023A
-Encoding: 570 570 5851
+Encoding: 570 570 5850
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni023C
-Encoding: 572 572 5852
+Encoding: 572 572 5851
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni0243
-Encoding: 579 579 5853
+Encoding: 579 579 5852
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni02B8
-Encoding: 696 696 5854
+Encoding: 696 696 5853
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni1DBB
-Encoding: 7611 7611 5855
+Encoding: 7611 7611 5854
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni1DBF
-Encoding: 7615 7615 5856
+Encoding: 7615 7615 5855
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B2
-Encoding: 8370 8370 5857
+Encoding: 8370 8370 5856
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B4
-Encoding: 8372 8372 5858
+Encoding: 8372 8372 5857
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B5
-Encoding: 8373 8373 5859
+Encoding: 8373 8373 5858
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B8
-Encoding: 8376 8376 5860
+Encoding: 8376 8376 5859
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20B9
-Encoding: 8377 8377 5861
+Encoding: 8377 8377 5860
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20BA
-Encoding: 8378 8378 5862
+Encoding: 8378 8378 5861
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20BC
-Encoding: 8380 8380 5863
+Encoding: 8380 8380 5862
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni20BE
-Encoding: 8382 8382 5864
+Encoding: 8382 8382 5863
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni0237
-Encoding: 567 567 5865
+Encoding: 567 567 5864
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2A09
-Encoding: 10761 10761 5866
+Encoding: 10761 10761 5865
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni03CF
-Encoding: 975 975 5867
+Encoding: 975 975 5866
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni03D7
-Encoding: 983 983 5868
+Encoding: 983 983 5867
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2770
-Encoding: 10096 10096 5869
+Encoding: 10096 10096 5868
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2771
-Encoding: 10097 10097 5870
+Encoding: 10097 10097 5869
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2774
-Encoding: 10100 10100 5871
+Encoding: 10100 10100 5870
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2775
-Encoding: 10101 10101 5872
+Encoding: 10101 10101 5871
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2772
-Encoding: 10098 10098 5873
+Encoding: 10098 10098 5872
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2773
-Encoding: 10099 10099 5874
+Encoding: 10099 10099 5873
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2618
-Encoding: 9752 9752 5875
+Encoding: 9752 9752 5874
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F340
-Encoding: 127808 127808 5876
+Encoding: 127808 127808 5875
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni0374
-Encoding: 884 884 5877
+Encoding: 884 884 5876
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni0375
-Encoding: 885 885 5878
+Encoding: 885 885 5877
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni2B1D
-Encoding: 11037 11037 5879
+Encoding: 11037 11037 5878
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B1E
-Encoding: 11038 11038 5880
+Encoding: 11038 11038 5879
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25FD
-Encoding: 9725 9725 5881
+Encoding: 9725 9725 5880
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B1B
-Encoding: 11035 11035 5882
+Encoding: 11035 11035 5881
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B1C
-Encoding: 11036 11036 5883
+Encoding: 11036 11036 5882
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni25FE
-Encoding: 9726 9726 5884
+Encoding: 9726 9726 5883
 Width: 1890
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B1F
-Encoding: 11039 11039 5885
+Encoding: 11039 11039 5884
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B20
-Encoding: 11040 11040 5886
+Encoding: 11040 11040 5885
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B21
-Encoding: 11041 11041 5887
+Encoding: 11041 11041 5886
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B23
-Encoding: 11043 11043 5888
+Encoding: 11043 11043 5887
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B25
-Encoding: 11045 11045 5889
+Encoding: 11045 11045 5888
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B26
-Encoding: 11046 11046 5890
+Encoding: 11046 11046 5889
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B27
-Encoding: 11047 11047 5891
+Encoding: 11047 11047 5890
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B28
-Encoding: 11048 11048 5892
+Encoding: 11048 11048 5891
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B29
-Encoding: 11049 11049 5893
+Encoding: 11049 11049 5892
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B2A
-Encoding: 11050 11050 5894
+Encoding: 11050 11050 5893
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B2B
-Encoding: 11051 11051 5895
+Encoding: 11051 11051 5894
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B2C
-Encoding: 11052 11052 5896
+Encoding: 11052 11052 5895
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B2D
-Encoding: 11053 11053 5897
+Encoding: 11053 11053 5896
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B2E
-Encoding: 11054 11054 5898
+Encoding: 11054 11054 5897
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B2F
-Encoding: 11055 11055 5899
+Encoding: 11055 11055 5898
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BC5
-Encoding: 11205 11205 5900
+Encoding: 11205 11205 5899
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BC6
-Encoding: 11206 11206 5901
+Encoding: 11206 11206 5900
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BC7
-Encoding: 11207 11207 5902
+Encoding: 11207 11207 5901
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2BC8
-Encoding: 11208 11208 5903
+Encoding: 11208 11208 5902
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2028
-Encoding: 8232 8232 5904
+Encoding: 8232 8232 5903
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B53
-Encoding: 11091 11091 5905
+Encoding: 11091 11091 5904
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B54
-Encoding: 11092 11092 5906
+Encoding: 11092 11092 5905
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B51
-Encoding: 11089 11089 5907
+Encoding: 11089 11089 5906
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B52
-Encoding: 11090 11090 5908
+Encoding: 11090 11090 5907
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B84
-Encoding: 11140 11140 5909
+Encoding: 11140 11140 5908
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B85
-Encoding: 11141 11141 5910
+Encoding: 11141 11141 5909
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B86
-Encoding: 11142 11142 5911
+Encoding: 11142 11142 5910
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2B87
-Encoding: 11143 11143 5912
+Encoding: 11143 11143 5911
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni26C9
-Encoding: 9929 9929 5913
+Encoding: 9929 9929 5912
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni26CA
-Encoding: 9930 9930 5914
+Encoding: 9930 9930 5913
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2123
-Encoding: 8483 8483 5915
+Encoding: 8483 8483 5914
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2128
-Encoding: 8488 8488 5916
+Encoding: 8488 8488 5915
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2125
-Encoding: 8485 8485 5917
+Encoding: 8485 8485 5916
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: Rfraktur
-Encoding: 8476 8476 5918
+Encoding: 8476 8476 5917
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni212D
-Encoding: 8493 8493 5919
+Encoding: 8493 8493 5918
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: weierstrass
-Encoding: 8472 8472 5920
+Encoding: 8472 8472 5919
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni211B
-Encoding: 8475 8475 5921
+Encoding: 8475 8475 5920
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni211F
-Encoding: 8479 8479 5922
+Encoding: 8479 8479 5921
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2129
-Encoding: 8489 8489 5923
+Encoding: 8489 8489 5922
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni212C
-Encoding: 8492 8492 5924
+Encoding: 8492 8492 5923
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2131
-Encoding: 8497 8497 5925
+Encoding: 8497 8497 5924
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2133
-Encoding: 8499 8499 5926
+Encoding: 8499 8499 5925
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2134
-Encoding: 8500 8500 5927
+Encoding: 8500 8500 5926
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2139
-Encoding: 8505 8505 5928
+Encoding: 8505 8505 5927
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni214C
-Encoding: 8524 8524 5929
+Encoding: 8524 8524 5928
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni214B
-Encoding: 8523 8523 5930
+Encoding: 8523 8523 5929
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni214A
-Encoding: 8522 8522 5931
+Encoding: 8522 8522 5930
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2144
-Encoding: 8516 8516 5932
+Encoding: 8516 8516 5931
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2143
-Encoding: 8515 8515 5933
+Encoding: 8515 8515 5932
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2142
-Encoding: 8514 8514 5934
+Encoding: 8514 8514 5933
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni2141
-Encoding: 8513 8513 5935
+Encoding: 8513 8513 5934
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni214F
-Encoding: 8527 8527 5936
+Encoding: 8527 8527 5935
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1E6
-Encoding: 127462 127462 5937
+Encoding: 127462 127462 5936
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1E7
-Encoding: 127463 127463 5938
+Encoding: 127463 127463 5937
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1E8
-Encoding: 127464 127464 5939
+Encoding: 127464 127464 5938
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1E9
-Encoding: 127465 127465 5940
+Encoding: 127465 127465 5939
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1EA
-Encoding: 127466 127466 5941
+Encoding: 127466 127466 5940
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1EB
-Encoding: 127467 127467 5942
+Encoding: 127467 127467 5941
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1EC
-Encoding: 127468 127468 5943
+Encoding: 127468 127468 5942
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1ED
-Encoding: 127469 127469 5944
+Encoding: 127469 127469 5943
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1EE
-Encoding: 127470 127470 5945
+Encoding: 127470 127470 5944
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1EF
-Encoding: 127471 127471 5946
+Encoding: 127471 127471 5945
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F0
-Encoding: 127472 127472 5947
+Encoding: 127472 127472 5946
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F1
-Encoding: 127473 127473 5948
+Encoding: 127473 127473 5947
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F2
-Encoding: 127474 127474 5949
+Encoding: 127474 127474 5948
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F3
-Encoding: 127475 127475 5950
+Encoding: 127475 127475 5949
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F4
-Encoding: 127476 127476 5951
+Encoding: 127476 127476 5950
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F5
-Encoding: 127477 127477 5952
+Encoding: 127477 127477 5951
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F6
-Encoding: 127478 127478 5953
+Encoding: 127478 127478 5952
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F7
-Encoding: 127479 127479 5954
+Encoding: 127479 127479 5953
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F8
-Encoding: 127480 127480 5955
+Encoding: 127480 127480 5954
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1F9
-Encoding: 127481 127481 5956
+Encoding: 127481 127481 5955
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1FA
-Encoding: 127482 127482 5957
+Encoding: 127482 127482 5956
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1FB
-Encoding: 127483 127483 5958
+Encoding: 127483 127483 5957
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1FC
-Encoding: 127484 127484 5959
+Encoding: 127484 127484 5958
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1FD
-Encoding: 127485 127485 5960
+Encoding: 127485 127485 5959
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1FE
-Encoding: 127486 127486 5961
+Encoding: 127486 127486 5960
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: u1F1FF
-Encoding: 127487 127487 5962
+Encoding: 127487 127487 5961
 Width: 1024
 Flags: W
 LayerCount: 2
 EndChar
 
 StartChar: uni23A4
-Encoding: 9124 9124 5963
+Encoding: 9124 9124 5962
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A3
-Encoding: 9123 9123 5964
+Encoding: 9123 9123 5963
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A6
-Encoding: 9126 9126 5965
+Encoding: 9126 9126 5964
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A5
-Encoding: 9125 9125 5966
+Encoding: 9125 9125 5965
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A2
-Encoding: 9122 9122 5967
+Encoding: 9122 9122 5966
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A1
-Encoding: 9121 9121 5968
+Encoding: 9121 9121 5967
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni239F
-Encoding: 9119 9119 5969
+Encoding: 9119 9119 5968
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni239C
-Encoding: 9116 9116 5970
+Encoding: 9116 9116 5969
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23AA
-Encoding: 9130 9130 5971
+Encoding: 9130 9130 5970
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23AE
-Encoding: 9134 9134 5972
+Encoding: 9134 9134 5971
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni239B
-Encoding: 9115 9115 5973
+Encoding: 9115 9115 5972
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni239D
-Encoding: 9117 9117 5974
+Encoding: 9117 9117 5973
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni239E
-Encoding: 9118 9118 5975
+Encoding: 9118 9118 5974
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A0
-Encoding: 9120 9120 5976
+Encoding: 9120 9120 5975
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A7
-Encoding: 9127 9127 5977
+Encoding: 9127 9127 5976
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A9
-Encoding: 9129 9129 5978
+Encoding: 9129 9129 5977
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23AB
-Encoding: 9131 9131 5979
+Encoding: 9131 9131 5978
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23AD
-Encoding: 9133 9133 5980
+Encoding: 9133 9133 5979
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23A8
-Encoding: 9128 9128 5981
+Encoding: 9128 9128 5980
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni23AC
-Encoding: 9132 9132 5982
+Encoding: 9132 9132 5981
 Width: 1024
 Flags: HW
 LayerCount: 2
@@ -56289,66 +56278,66 @@ BDFChar: 3245 12362 12 2 10 0 8
 &HMV,&:b;lIfPR\OFWFCErZ1?
 BDFChar: 3246 12363 12 2 10 0 8
 &-*7Aqu@pk,(Lkf63'=P9E5%m
-BDFChar: 3247 12364 12 2 11 0 8
-&:b<Wqu@pk,(Lkf63'=P9E5%m
+BDFChar: 3247 12364 12 10 11 7 8
+J3X)7
 BDFChar: 3248 12365 12 3 9 0 8
 &:=b4":Tg2IK0?J
-BDFChar: 3249 12366 12 3 11 0 8
-&HI3/#QT;R"98i1J,k*"IK0?J
+BDFChar: 3249 12366 12 10 11 7 8
+J3X)7
 BDFChar: 3250 12367 12 3 7 0 8
 #S8+DJ3Y4g#QOi)
-BDFChar: 3251 12368 12 3 8 0 8
-#S87PJ3Y4g#QOi)
+BDFChar: 3251 12368 12 7 8 5 6
+5_&h7
 BDFChar: 3252 12369 12 2 9 0 8
 JqAT8JqAT+9E5%m
-BDFChar: 3253 12370 12 2 11 0 8
-Jq/G<JcLi3JcLB&JcLB&9E5%m
+BDFChar: 3253 12370 12 10 11 7 8
+J3X)7
 BDFChar: 3254 12371 12 2 9 0 7
 IK9KM5_+E7
-BDFChar: 3255 12372 12 2 11 0 8
-!.]M`!<<0$!!#7aJ,k-#IK0?J
+BDFChar: 3255 12372 12 10 11 7 8
+J3X)7
 BDFChar: 3256 12373 12 3 9 0 8
 &.j9r":Tg2IK0?J
-BDFChar: 3257 12374 12 3 11 0 8
-&HEAmIK0WR"98i1J,k*"IK0?J
+BDFChar: 3257 12374 12 10 11 7 8
+J3X)7
 BDFChar: 3258 12375 12 3 9 0 8
 J:N0#J:`B)HiO-H
-BDFChar: 3259 12376 12 3 9 0 8
-J<6FSJ:`B)HiO-H
+BDFChar: 3259 12376 12 5 6 6 7
+5_&h7
 BDFChar: 3260 12377 12 2 8 0 8
 #lY)h84Y]G&-)\1
-BDFChar: 3261 12378 12 2 11 0 8
-#_;n>#QQga8,u0\2uj3a&-)\1
+BDFChar: 3261 12378 12 10 11 7 8
+J3X)7
 BDFChar: 3262 12379 12 2 9 0 7
 +sR%2+s8!M
-BDFChar: 3263 12380 12 2 11 0 8
-!.Z7Y+oqWC+oiee+93Ma*rl9@
+BDFChar: 3263 12380 12 10 11 7 8
+J3X)7
 BDFChar: 3264 12381 12 3 9 0 8
 p^eQq#S8+&)uos=
-BDFChar: 3265 12382 12 3 10 0 8
-q@Oit#S8+&)uos=
+BDFChar: 3265 12382 12 9 10 7 8
+J3X)7
 BDFChar: 3266 12383 12 2 10 0 8
 +93Maqu@i>-\+G^8,u0\7t:R>
-BDFChar: 3267 12384 12 2 10 0 8
-+FkU8qu@i>-\+G^8,u0\7t:R>
+BDFChar: 3267 12384 12 9 10 7 8
+5_&h7
 BDFChar: 3268 12385 12 3 9 0 8
 &.na^=C_I749,?]
-BDFChar: 3269 12386 12 3 10 0 8
-&eY$a=C_I749,?]
+BDFChar: 3269 12386 12 9 10 7 8
+J3X)7
 BDFChar: 3270 12387 12 3 9 0 4
 4Mh.&2uipY
 BDFChar: 3271 12388 12 2 10 0 6
 56/KL!.Y'"!.Y(M*WQ0?
-BDFChar: 3272 12389 12 2 11 0 8
-!.Y&756/KL!.Y'"!.Y(M*WQ0?
+BDFChar: 3272 12389 12 10 11 7 8
+J3X)7
 BDFChar: 3273 12390 12 2 9 0 7
 rrN</&.fB_
-BDFChar: 3274 12391 12 2 10 0 7
-rr<*#"FpdY&-*7A&-*1?
+BDFChar: 3274 12391 12 9 10 4 5
+5_&h7
 BDFChar: 3275 12392 12 3 8 0 8
 J4(ds+@&1W49,?]
-BDFChar: 3276 12393 12 3 10 0 9
-!eE`f&0O5'5Wf#H
+BDFChar: 3276 12393 12 9 10 8 9
+J3X)7
 BDFChar: 3277 12394 12 2 10 0 8
 +93Pbq#DOf6i_l?)uq;c)#sX:
 BDFChar: 3278 12395 12 2 10 0 8
@@ -56361,34 +56350,34 @@ BDFChar: 3281 12398 12 2 10 0 6
 4oe.SLk(;3OFUa>"onW'
 BDFChar: 3282 12399 12 2 9 0 8
 KS5qMKS5;I9`P.n
-BDFChar: 3283 12400 12 2 10 0 8
-KE-Z*ScFFoK`Hc+Mu]"@9`P.n
-BDFChar: 3284 12401 12 2 11 0 8
-KE-Z*ScFFoKg:<AMu]"@9`P.n
-BDFChar: 3285 12412 12 2 10 0 8
-ScFEDScFFoK`Hc+Mu]"@9`P.n
-BDFChar: 3286 12413 12 2 11 0 8
-ScFEDScFFoKg:<AMu]"@9`P.n
+BDFChar: 3283 12400 12 9 10 4 5
+5_&h7
+BDFChar: 3284 12401 12 9 11 3 5
+5bL@B
+BDFChar: 3285 12412 12 9 10 4 5
+5_&h7
+BDFChar: 3286 12413 12 9 11 3 5
+5bL@B
 BDFChar: 3287 12411 12 2 9 0 8
 SqN\gKS5;I9`P.n
 BDFChar: 3288 12402 12 2 10 0 8
 huFl"63)W<K)gLRJcJ1=2uipY
-BDFChar: 3289 12403 12 2 11 0 8
-i'8E863)W<K)gLRJcJ1=2uipY
+BDFChar: 3289 12403 12 10 11 7 8
+5_&h7
 BDFChar: 3290 12405 12 2 10 0 8
 (]X[=#QPD9#QOu-70&!kR",/:
-BDFChar: 3291 12404 12 2 11 0 9
-!.a#n+FlcYK)gN(Jq/FQ6i]1H
-BDFChar: 3292 12406 12 2 10 0 8
-(]X[=#lkNe#QOu-70&!kR",/:
+BDFChar: 3291 12404 12 9 11 7 9
+5bL@B
+BDFChar: 3292 12406 12 9 10 5 6
+J3X)7
 BDFChar: 3293 12408 12 2 10 1 6
 &-+*Y6i_f=!<<+M
-BDFChar: 3294 12407 12 2 10 0 8
-(]X[=#lkTg#lk).70&!kR",/:
-BDFChar: 3295 12409 12 2 10 1 7
-!<<`4-icX8JcGfO!.Y%L
-BDFChar: 3296 12410 12 2 10 1 7
-!<<a_.0)a9JcGfO!.Y%L
+BDFChar: 3294 12407 12 8 10 4 6
+5bL@B
+BDFChar: 3295 12409 12 8 9 6 7
+5_&h7
+BDFChar: 3296 12410 12 8 10 5 7
+5bL@B
 BDFChar: 3297 12414 12 4 10 0 8
 &H34PrXa%9AcMf2
 BDFChar: 3298 12415 12 2 10 0 8
@@ -56433,8 +56422,8 @@ BDFChar: 3317 12434 12 2 9 0 8
 +S[';#S\C(*rl9@
 BDFChar: 3318 12435 12 2 9 0 8
 &.fs,5]B8NL&_2R
-BDFChar: 3319 12436 12 2 10 0 8
-I"24t4934u!<<-#!<<0$49,?]
+BDFChar: 3319 12436 12 9 10 7 8
+5_&h7
 BDFChar: 3320 12437 12 3 10 0 7
 +<^G*,t(.'
 BDFChar: 3321 12438 12 3 9 0 6
@@ -56445,8 +56434,8 @@ BDFChar: 3323 12444 12 1 3 6 8
 5bL@B
 BDFChar: 3324 12445 12 4 7 0 5
 J3Y4g0YdYg
-BDFChar: 3325 12446 12 4 8 0 6
-#`q:o&2:m"
+BDFChar: 3325 12446 12 7 8 5 6
+5_&h7
 BDFChar: 3326 12447 12 3 9 0 8
 #RDI_4<d*YS,`Nh
 BDFChar: 3327 12448 12 3 9 3 5
@@ -56473,66 +56462,66 @@ BDFChar: 3337 12458 12 2 9 0 8
 !WrB+$5+OL$ig8-
 BDFChar: 3338 12459 12 3 9 0 8
 +<^Y-+sK??MuWhX
-BDFChar: 3339 12460 12 3 11 0 8
-+TNX8rW",B+oiee63'=PMuWhX
+BDFChar: 3339 12460 12 10 11 7 8
+J3X)7
 BDFChar: 3340 12461 12 3 9 0 8
 +?\Qn&0C<H#QOi)
-BDFChar: 3341 12462 12 3 11 0 8
-+TOWThuF;g&-*aOn,N^o#QOi)
+BDFChar: 3341 12462 12 10 11 7 8
+J3X)7
 BDFChar: 3342 12463 12 2 9 0 8
 +?r/C!<N<20E;(Q
-BDFChar: 3343 12464 12 2 11 0 8
-+Fl[A5lcH9!<<0$!WWW/0E;(Q
+BDFChar: 3343 12464 12 10 11 7 8
+J3X)7
 BDFChar: 3344 12465 12 2 9 0 8
 +?rDQ#RCtQ+92BA
-BDFChar: 3345 12466 12 2 11 0 8
-+Fl[A8-"GG#QP,1&-*7A+92BA
+BDFChar: 3345 12466 12 10 11 7 8
+J3X)7
 BDFChar: 3346 12467 12 3 9 0 6
 rW3-&!Wr?$
-BDFChar: 3347 12468 12 3 11 0 8
-!<<+MrW!!"!WW9%!WW9%rVuou
+BDFChar: 3347 12468 12 10 11 7 8
+J3X)7
 BDFChar: 3348 12469 12 2 10 0 8
 +oiees*u9n+oiee!WW?'(]XO9
-BDFChar: 3349 12470 12 2 11 0 8
-,(Lk&s*u9n+oiee!WW?'(]XO9
+BDFChar: 3349 12470 12 10 11 7 8
+J3X)7
 BDFChar: 3350 12471 12 2 9 0 7
 ?kEFU+p&0l
-BDFChar: 3351 12472 12 2 11 0 8
-!.\HB&HDh3_#PYZ!WWW/Du]k<
+BDFChar: 3351 12472 12 10 11 7 8
+J3X)7
 BDFChar: 3352 12473 12 3 9 0 7
 rW3-(#S8E(
-BDFChar: 3353 12474 12 3 11 0 8
-!<E+L!WW9%"98]-&-+*Y`W,u=
+BDFChar: 3353 12474 12 10 11 7 8
+J3X)7
 BDFChar: 3354 12475 12 2 10 0 8
 +93Ma0*(MB+oikg+93O7*rl9@
-BDFChar: 3355 12476 12 2 11 0 8
-+FkS"0*(MB+oikg+93O7*rl9@
+BDFChar: 3355 12476 12 10 11 7 8
+J3X)7
 BDFChar: 3356 12477 12 3 9 0 6
 Jq?;l";p%s
-BDFChar: 3357 12478 12 3 11 0 8
-!<<+MJcLB&63%,g"998=huE`W
+BDFChar: 3357 12478 12 10 11 7 8
+J3X)7
 BDFChar: 3358 12479 12 2 9 0 8
 +?r/C+VG+j1&q:S
-BDFChar: 3359 12480 12 2 11 0 8
-+Fl[A5lcH9+TN,T$31J71&q:S
+BDFChar: 3359 12480 12 10 11 7 8
+J3X)7
 BDFChar: 3360 12481 12 2 9 0 8
 #'^CZrs/l90E;(Q
-BDFChar: 3361 12482 12 2 11 0 8
-#(Uq`#QP,1rr<<)#QP,10E;(Q
+BDFChar: 3361 12482 12 9 10 6 7
+5_&h7
 BDFChar: 3362 12483 12 3 9 0 6
 +JP#e";kMH
 BDFChar: 3363 12484 12 2 9 0 7
 &.sbM637R7
-BDFChar: 3364 12485 12 2 11 0 8
-!.YVG&HIXfJH/":!WWW/Du]k<
+BDFChar: 3364 12485 12 10 11 7 8
+J3X)7
 BDFChar: 3365 12486 12 2 9 0 8
 IK0BJ#RC\A0E;(Q
-BDFChar: 3366 12487 12 2 11 0 8
-IXhD`!!*$!#QP,1#QP,10E;(Q
+BDFChar: 3366 12487 12 10 11 7 8
+J3X)7
 BDFChar: 3367 12488 12 5 9 0 8
 J:N1.R"0^;J,fQL
-BDFChar: 3368 12489 12 4 9 0 8
-6qBR^9L(j.5QCca
+BDFChar: 3368 12489 12 8 9 7 8
+5_&h7
 BDFChar: 3369 12490 12 2 9 0 8
 #RC_9#RC\A0E;(Q
 BDFChar: 3370 12491 12 2 10 0 7
@@ -56545,34 +56534,34 @@ BDFChar: 3373 12494 12 3 9 0 7
 !WiE)"9]S"
 BDFChar: 3374 12495 12 2 9 0 7
 ,U=QX6:!ng
-BDFChar: 3375 12496 12 2 10 0 7
-,lf3@+oiee63':O5lcH9
-BDFChar: 3376 12497 12 2 11 0 8
-!.Z@\,_.'=+ojq05la1NJH,ZM
+BDFChar: 3375 12496 12 9 10 6 7
+J3X)7
+BDFChar: 3376 12497 12 9 11 6 8
+5bL@B
 BDFChar: 3377 12498 12 3 9 0 8
 J:N<?i.-?.IK0?J
-BDFChar: 3378 12499 12 3 10 0 8
-Jq8TBi.-?.IK0?J
-BDFChar: 3379 12500 12 3 11 0 8
-JH1:PK`IJ?huJ9-J,k*"IK0?J
+BDFChar: 3378 12499 12 9 10 7 8
+J3X)7
+BDFChar: 3379 12500 12 9 11 6 8
+5bL@B
 BDFChar: 3380 12501 12 2 9 0 7
 rrE-$!Wica
-BDFChar: 3381 12502 12 2 11 0 8
-!.b)7!<<-#!<<0$!WWW/0E;(Q
-BDFChar: 3382 12503 12 2 11 0 8
-!.b)7!It1N!<<0$!WWW/0E;(Q
-BDFChar: 3383 12504 12 2 10 1 6
-&-+*Y6i_f=!<<+M
-BDFChar: 3384 12505 12 2 10 1 7
-!<<`4-icX8JcGfO!.Y%L
-BDFChar: 3385 12506 12 2 10 1 8
-!WWB(&ca<[6i_f=!<<+M
+BDFChar: 3381 12502 12 10 11 7 8
+J3X)7
+BDFChar: 3382 12503 12 10 11 6 8
+J3\Vb
+BDFChar: 3383 12504 12 0 0 0 0
+z
+BDFChar: 3384 12505 12 0 0 0 0
+z
+BDFChar: 3385 12506 12 0 0 0 0
+z
 BDFChar: 3386 12507 12 2 10 0 8
 #QP,1s*t@T.KCpu8H9"r0E;(Q
-BDFChar: 3387 12508 12 2 11 0 8
-#_31Gs*t@T.KCpu8H9"r0E;(Q
-BDFChar: 3388 12509 12 2 11 0 8
-#_34Hs*t@T.KCpu8H9"r0E;(Q
+BDFChar: 3387 12508 12 10 11 7 8
+J3X)7
+BDFChar: 3388 12509 12 9 11 7 8
+5bJ)W
 BDFChar: 3389 12510 12 2 9 0 7
 rrE-D&deaC
 BDFChar: 3390 12511 12 3 9 0 7
@@ -56617,28 +56606,28 @@ BDFChar: 3409 12530 12 2 9 0 7
 rrE0#!Wica
 BDFChar: 3410 12531 12 3 9 0 6
 _BK$a";p%s
-BDFChar: 3411 12532 12 2 10 0 8
-&HEAmrr@TMJH,`O!WWW/0E;(Q
+BDFChar: 3411 12532 12 9 10 7 8
+J3X)7
 BDFChar: 3412 12533 12 3 8 0 7
 !$M1b,Xb%V
 BDFChar: 3413 12534 12 3 8 0 6
 5^ZCi&.fra
-BDFChar: 3414 12535 12 2 11 0 8
-!.b)7JH16$!<<0$!WWW/0E;(Q
-BDFChar: 3415 12536 12 2 11 0 8
-!.Y2;IfL_o,QK(irr<0%"98E%
-BDFChar: 3416 12537 12 2 11 0 8
-!.]Pa!<<H,#QP,1#QP,1s*t(L
-BDFChar: 3417 12538 12 2 11 0 8
-!.b)7!<<-#rr<*#!WWW/0E;(Q
+BDFChar: 3414 12535 12 10 11 7 8
+J3X)7
+BDFChar: 3415 12536 12 10 11 7 8
+J3X)7
+BDFChar: 3416 12537 12 10 11 7 8
+J3X)7
+BDFChar: 3417 12538 12 10 11 7 8
+J3X)7
 BDFChar: 3418 12539 12 5 7 3 5
 5i=m-
 BDFChar: 3419 12540 12 2 10 4 4
 s*t(L
 BDFChar: 3420 12541 12 4 7 1 5
 J3Y4g&-)\1
-BDFChar: 3421 12542 12 4 8 1 6
-#`q:o&.egA
+BDFChar: 3421 12542 12 7 8 5 6
+5_&h7
 BDFChar: 3422 12543 12 2 10 -1 7
 s*t*"!.Y'"!.Y'"!.Y'"!.Y%L
 BDFChar: 3423 65281 12 6 6 0 7
@@ -57163,4607 +57152,4666 @@ BDFChar: 3682 37329 12 2 10 0 8
 #QPP=+opGL#QT>S#QQ=Ss*t(L
 BDFChar: 3683 12306 12 2 10 0 8
 s*t(L!!*%L#QP,1#QP,1#QOi)
-BDFChar: 3684 12352 12 1 11 2 4
-P2Q9]dQdd4
-BDFChar: 3685 129792 6 0 2 6 9
-i8EPO
-BDFChar: 3686 129793 6 3 5 6 9
-i8EPO
-BDFChar: 3687 129794 6 0 5 6 9
-r;?Kj
-BDFChar: 3688 129795 6 0 2 1 5
-i8EPOhuE`W
-BDFChar: 3689 129796 6 0 2 1 9
-i8EPOi8EPOhuE`W
-BDFChar: 3690 129797 6 0 5 1 9
-*#oq<i8EPOhuE`W
-BDFChar: 3691 129798 6 0 5 1 9
-r;?Kji8EPOhuE`W
-BDFChar: 3692 129799 6 3 5 1 5
-i8EPOhuE`W
-BDFChar: 3693 129800 6 0 5 1 9
-i8EPO*#oq<)uos=
-BDFChar: 3694 129801 6 3 5 1 9
-i8EPOi8EPOhuE`W
-BDFChar: 3695 129802 6 0 5 1 9
-r;?Kj*#oq<)uos=
-BDFChar: 3696 129803 6 0 5 1 5
-r;?Kjqu?]s
-BDFChar: 3697 129804 6 0 5 1 9
-i8EPOr;?Kjqu?]s
-BDFChar: 3698 129805 6 0 5 1 9
-*#oq<r;?Kjqu?]s
-BDFChar: 3699 129806 6 0 5 1 9
-r;?Kjr;?Kjqu?]s
-BDFChar: 3700 129807 6 0 2 -3 0
-i8EPO
-BDFChar: 3701 129808 6 0 2 -3 9
-i8EPOz!8uenhuE`W
-BDFChar: 3702 129809 6 0 5 -3 9
-*#oq<z!8uenhuE`W
-BDFChar: 3703 129810 6 0 5 -3 9
-r;?Kjz!8uenhuE`W
-BDFChar: 3704 129811 6 0 2 -3 5
-i8EPOi8EPOhuE`W
-BDFChar: 3705 129812 6 0 5 -3 9
-*#oq<i8EPOi8EPOhuE`W
-BDFChar: 3706 129813 6 0 5 -3 9
-r;?Kji8EPOi8EPOhuE`W
-BDFChar: 3707 129814 6 0 5 -3 5
-*#oq<*8oc5huE`W
-BDFChar: 3708 129815 6 0 5 -3 9
-i8EPO*#oq<*8oc5huE`W
-BDFChar: 3709 129816 6 0 5 -3 9
-*#oq<*#oq<*8oc5huE`W
-BDFChar: 3710 129817 6 0 5 -3 9
-r;?Kj*#oq<*8oc5huE`W
-BDFChar: 3711 129818 6 0 5 -3 5
-r;?Kjr8?MkhuE`W
-BDFChar: 3712 129819 6 0 5 -3 9
-i8EPOr;?Kjr8?MkhuE`W
-BDFChar: 3713 129820 6 0 5 -3 9
-*#oq<r;?Kjr8?MkhuE`W
-BDFChar: 3714 129821 6 0 5 -3 9
-r;?Kjr;?Kjr8?MkhuE`W
-BDFChar: 3715 129822 6 3 5 -3 0
-i8EPO
-BDFChar: 3716 129823 6 0 5 -3 9
-i8EPOz!#usu)uos=
-BDFChar: 3717 129824 6 3 5 -3 9
-i8EPOz!8uenhuE`W
-BDFChar: 3718 129825 6 0 5 -3 9
-r;?Kjz!#usu)uos=
-BDFChar: 3719 129826 6 0 5 -3 5
-i8EPOi#E^V)uos=
-BDFChar: 3720 129827 6 0 5 -3 9
-i8EPOi8EPOi#E^V)uos=
-BDFChar: 3721 129828 6 0 5 -3 9
-*#oq<i8EPOi#E^V)uos=
-BDFChar: 3722 129829 6 0 5 -3 9
-r;?Kji8EPOi#E^V)uos=
-BDFChar: 3723 129830 6 3 5 -3 5
-i8EPOi8EPOhuE`W
-BDFChar: 3724 129831 6 0 5 -3 9
-i8EPO*#oq<*#oq<)uos=
-BDFChar: 3725 129832 6 0 5 -3 9
-r;?Kj*#oq<*#oq<)uos=
-BDFChar: 3726 129833 6 0 5 -3 5
-r;?Kjr#?[r)uos=
-BDFChar: 3727 129834 6 0 5 -3 9
-i8EPOr;?Kjr#?[r)uos=
-BDFChar: 3728 129835 6 0 5 -3 9
-*#oq<r;?Kjr#?[r)uos=
-BDFChar: 3729 129836 6 0 5 -3 9
-r;?Kjr;?Kjr#?[r)uos=
-BDFChar: 3730 129837 6 0 5 -3 0
-r;?Kj
-BDFChar: 3731 129838 6 0 5 -3 9
-i8EPOz!;ucmqu?]s
-BDFChar: 3732 129839 6 0 5 -3 9
-*#oq<z!;ucmqu?]s
-BDFChar: 3733 129840 6 0 5 -3 9
-r;?Kjz!;ucmqu?]s
-BDFChar: 3734 129841 6 0 5 -3 5
-i8EPOi;ENNqu?]s
-BDFChar: 3735 129842 6 0 5 -3 9
-i8EPOi8EPOi;ENNqu?]s
-BDFChar: 3736 129843 6 0 5 -3 9
-*#oq<i8EPOi;ENNqu?]s
-BDFChar: 3737 129844 6 0 5 -3 9
-r;?Kji8EPOi;ENNqu?]s
-BDFChar: 3738 129845 6 0 5 -3 5
-*#oq<*;oa4qu?]s
-BDFChar: 3739 129846 6 0 5 -3 9
-i8EPO*#oq<*;oa4qu?]s
-BDFChar: 3740 129847 6 0 5 -3 9
-*#oq<*#oq<*;oa4qu?]s
-BDFChar: 3741 129848 6 0 5 -3 9
-r;?Kj*#oq<*;oa4qu?]s
-BDFChar: 3742 129849 6 0 5 -3 5
-r;?Kjr;?Kjqu?]s
-BDFChar: 3743 129850 6 0 5 -3 9
-i8EPOr;?Kjr;?Kjqu?]s
-BDFChar: 3744 129851 6 0 5 -3 9
-*#oq<r;?Kjr;?Kjqu?]s
-BDFChar: 3745 117793 6 1 2 4 8
-^qdb$^]4?7
-BDFChar: 3746 117794 6 4 5 4 8
-^qdb$^]4?7
-BDFChar: 3747 117795 6 1 5 4 8
-f\"j/fDkmO
-BDFChar: 3748 117796 6 1 2 -2 2
-^qdb$^]4?7
-BDFChar: 3749 117797 6 1 2 -2 8
-^qdb$^];0c^qd_c
-BDFChar: 3750 117798 6 1 5 -2 8
-(`4),(]_@e^qd_c
-BDFChar: 3751 117799 6 1 5 -2 8
-f\"j/fDr_&^qd_c
-BDFChar: 3752 117800 6 4 5 -2 2
-^qdb$^]4?7
-BDFChar: 3753 117801 6 1 5 -2 8
-^qdb$^]52g(`4(i
-BDFChar: 3754 117802 6 4 5 -2 8
-^qdb$^];0c^qd_c
-BDFChar: 3755 117803 6 1 5 -2 8
-f\"j/fDla*(`4(i
-BDFChar: 3756 117804 6 1 5 -2 2
-f\"j/fDkmO
-BDFChar: 3757 117805 6 1 5 -2 8
-^qdb$^]<$>f\"gV
-BDFChar: 3758 117806 6 1 5 -2 8
-(`4),(]`4@f\"gV
-BDFChar: 3759 117807 6 1 5 -2 8
-f\"j/fDsRVf\"gV
-BDFChar: 3760 118353 6 1 2 6 8
-^qd_c
-BDFChar: 3761 118354 6 4 5 6 8
-^qd_c
-BDFChar: 3762 118355 6 1 5 6 8
-f\"gV
-BDFChar: 3763 118356 6 1 2 2 4
-^qd_c
-BDFChar: 3764 118357 6 1 2 2 8
-^qd_c^qd_c
-BDFChar: 3765 118358 6 1 5 2 8
-(`4(i^qd_c
-BDFChar: 3766 118359 6 1 5 2 8
-f\"gV^qd_c
-BDFChar: 3767 118360 6 4 5 2 4
-^qd_c
-BDFChar: 3768 118361 6 1 5 2 8
-^qd_c(`4(i
-BDFChar: 3769 118362 6 4 5 2 8
-^qd_c^qd_c
-BDFChar: 3770 118363 6 1 5 2 8
-f\"gV(`4(i
-BDFChar: 3771 118364 6 1 5 2 4
-f\"gV
-BDFChar: 3772 118365 6 1 5 2 8
-^qd_cf\"gV
-BDFChar: 3773 118366 6 1 5 2 8
-(`4(if\"gV
-BDFChar: 3774 118367 6 1 5 2 8
-f\"gVf\"gV
-BDFChar: 3775 118368 6 1 2 -2 0
-^qd_c
-BDFChar: 3776 118369 6 1 2 -2 8
-^qd_cz^qd_c
-BDFChar: 3777 118370 6 1 5 -2 8
-(`4(iz^qd_c
-BDFChar: 3778 118371 6 1 5 -2 8
-f\"gVz^qd_c
-BDFChar: 3779 118372 6 1 2 -2 4
-^qd_c^qd_c
-BDFChar: 3780 118373 6 1 2 -2 8
-^qd_c^qd_c^qd_c
-BDFChar: 3781 118374 6 1 5 -2 8
-(`4(i^qd_c^qd_c
-BDFChar: 3782 118375 6 1 5 -2 8
-f\"gV^qd_c^qd_c
-BDFChar: 3783 118376 6 1 5 -2 4
-(`4(i^qd_c
-BDFChar: 3784 118377 6 1 5 -2 8
-^qd_c(`4(i^qd_c
-BDFChar: 3785 118378 6 1 5 -2 8
-(`4(i(`4(i^qd_c
-BDFChar: 3786 118379 6 1 5 -2 8
-f\"gV(`4(i^qd_c
-BDFChar: 3787 118380 6 1 5 -2 4
-f\"gV^qd_c
-BDFChar: 3788 118381 6 1 5 -2 8
-^qd_cf\"gV^qd_c
-BDFChar: 3789 118382 6 1 5 -2 8
-(`4(if\"gV^qd_c
-BDFChar: 3790 118383 6 1 5 -2 8
-f\"gVf\"gV^qd_c
-BDFChar: 3791 118384 6 4 5 -2 0
-^qd_c
-BDFChar: 3792 118385 6 1 5 -2 8
-^qd_cz(`4(i
-BDFChar: 3793 118386 6 4 5 -2 8
-^qd_cz^qd_c
-BDFChar: 3794 118387 6 1 5 -2 8
-f\"gVz(`4(i
-BDFChar: 3795 118388 6 1 5 -2 4
-^qd_c(`4(i
-BDFChar: 3796 118389 6 1 5 -2 8
-^qd_c^qd_c(`4(i
-BDFChar: 3797 118390 6 1 5 -2 8
-(`4(i^qd_c(`4(i
-BDFChar: 3798 118391 6 1 5 -2 8
-f\"gV^qd_c(`4(i
-BDFChar: 3799 118392 6 4 5 -2 4
-^qd_c^qd_c
-BDFChar: 3800 118393 6 1 5 -2 8
-^qd_c(`4(i(`4(i
-BDFChar: 3801 118394 6 4 5 -2 8
-^qd_c^qd_c^qd_c
-BDFChar: 3802 118395 6 1 5 -2 8
-f\"gV(`4(i(`4(i
-BDFChar: 3803 118396 6 1 5 -2 4
-f\"gV(`4(i
-BDFChar: 3804 118397 6 1 5 -2 8
-^qd_cf\"gV(`4(i
-BDFChar: 3805 118398 6 1 5 -2 8
-(`4(if\"gV(`4(i
-BDFChar: 3806 118399 6 1 5 -2 8
-f\"gVf\"gV(`4(i
-BDFChar: 3807 118400 6 1 5 -2 0
-f\"gV
-BDFChar: 3808 118401 6 1 5 -2 8
-^qd_czf\"gV
-BDFChar: 3809 118402 6 1 5 -2 8
-(`4(izf\"gV
-BDFChar: 3810 118403 6 1 5 -2 8
-f\"gVzf\"gV
-BDFChar: 3811 118404 6 1 5 -2 4
-^qd_cf\"gV
-BDFChar: 3812 118405 6 1 5 -2 8
-^qd_c^qd_cf\"gV
-BDFChar: 3813 118406 6 1 5 -2 8
-(`4(i^qd_cf\"gV
-BDFChar: 3814 118407 6 1 5 -2 8
-f\"gV^qd_cf\"gV
-BDFChar: 3815 118408 6 1 5 -2 4
-(`4(if\"gV
-BDFChar: 3816 118409 6 1 5 -2 8
-^qd_c(`4(if\"gV
-BDFChar: 3817 118410 6 1 5 -2 8
-(`4(i(`4(if\"gV
-BDFChar: 3818 118411 6 1 5 -2 8
-f\"gV(`4(if\"gV
-BDFChar: 3819 118412 6 1 5 -2 4
-f\"gVf\"gV
-BDFChar: 3820 118413 6 1 5 -2 8
-^qd_cf\"gVf\"gV
-BDFChar: 3821 118414 6 1 5 -2 8
-(`4(if\"gVf\"gV
-BDFChar: 3822 118415 6 1 5 -2 8
-f\"gVf\"gVf\"gV
-BDFChar: 3823 130032 6 1 5 -1 7
-E/9=+!/QGeDu]k<
-BDFChar: 3824 130033 6 5 5 0 6
-J:N.MJ:N.M
-BDFChar: 3825 130034 6 1 5 -1 7
-E!Q^TE.EIhDu]k<
-BDFChar: 3826 130035 6 2 5 -1 7
-i"-G2i"-G2huE`W
-BDFChar: 3827 130036 6 1 5 0 6
-Lkpk+#RC\9
-BDFChar: 3828 130037 6 1 5 -1 7
-E.EIhE!Q^TDu]k<
-BDFChar: 3829 130038 6 1 5 -1 7
-E.EIhE/9=+Du]k<
-BDFChar: 3830 130039 6 1 5 0 7
-E/9=+!!ii9
-BDFChar: 3831 130040 6 1 5 -1 7
-E/9=+E/9=+Du]k<
-BDFChar: 3832 130041 6 1 5 -1 7
-E/9=+E!Q^TDu]k<
-BDFChar: 3833 118000 6 0 5 0 7
-G_EH"PdH*g
-BDFChar: 3834 118001 6 1 4 0 7
-E6s]n:f'u-
-BDFChar: 3835 118002 6 0 5 0 7
-G_EHR-sVH'
-BDFChar: 3836 118003 6 0 5 0 7
-G_G][FS(62
-BDFChar: 3837 118004 6 0 5 0 7
-*$eLjK_,ru
-BDFChar: 3838 118005 6 0 5 0 7
-r.M_=FS(62
-BDFChar: 3839 118006 6 0 5 0 7
-G_ES[['YL2
-BDFChar: 3840 118007 6 0 5 0 7
-r.O\V-n$K'
-BDFChar: 3841 118008 6 0 5 0 7
-G_EGW['YL2
-BDFChar: 3842 118009 6 0 5 0 7
-G_EH2KQMll
-BDFChar: 3843 117974 6 0 5 0 7
-G_EH2KXA,a
-BDFChar: 3844 117975 6 0 5 0 7
-pk6#1['YM]
-BDFChar: 3845 117976 6 0 5 0 7
-G_EH6\?pp6
-BDFChar: 3846 117977 6 0 5 0 7
-pk6#]['YM]
-BDFChar: 3847 117978 6 0 5 0 7
-r.M_=\@dLm
-BDFChar: 3848 117979 6 0 5 0 7
-r.M_=\=fMQ
-BDFChar: 3849 117980 6 0 5 0 7
-I"]/.['YL6
-BDFChar: 3850 117981 6 0 5 0 7
-r3Wha['[4<
-BDFChar: 3851 117982 6 1 5 0 7
-pk[R!:tUU!
-BDFChar: 3852 117983 6 0 5 0 7
-*#')$oX'9r
-BDFChar: 3853 117984 6 0 5 0 7
-r3WPmR&m[m
-BDFChar: 3854 117985 6 0 5 0 7
-i1Qa9TY,sU
-BDFChar: 3855 117986 6 0 5 0 7
-bd<%V['[4<
-BDFChar: 3856 117987 6 0 5 0 7
-gpE<1UnkBa
-BDFChar: 3857 117988 6 0 5 0 7
-G_EH2['YL2
-BDFChar: 3858 117989 6 0 5 0 7
-pk6#]KXd]5
-BDFChar: 3859 117990 6 0 5 0 7
-G_EH2[&fL>
-BDFChar: 3860 117991 6 0 5 0 7
-pk6#]KWMQY
-BDFChar: 3861 117992 6 0 5 0 7
-I"]/"AFtQM
-BDFChar: 3862 117993 6 1 5 0 7
-pk[R!:f'u-
-BDFChar: 3863 117994 6 0 5 0 7
-r3Wi<['YL2
-BDFChar: 3864 117995 6 0 5 0 7
-r3Wi<KLeWf
-BDFChar: 3865 117996 6 0 5 0 7
-r3Wi<KS6_V
-BDFChar: 3866 117997 6 0 5 0 7
-r3Wh%8@5c%
-BDFChar: 3867 117998 6 1 5 0 7
-po(.D:f'u-
-BDFChar: 3868 117999 6 0 5 0 7
-r.O\j:qVJZ
-BDFChar: 3869 129852 6 0 2 -3 0
-J:PGn
-BDFChar: 3870 129853 6 0 4 -3 0
-JAC[L
-BDFChar: 3871 129854 6 0 2 -3 3
-J:N0c^qek.
-BDFChar: 3872 129855 6 0 5 -3 4
-JAAtYnF65N
-BDFChar: 3873 129856 6 0 2 -3 7
-J:N0#JAAt9^u4,N
-BDFChar: 3874 129857 6 0 5 -3 9
-*'AUrr;?Kjr;?Kjqu?]s
-BDFChar: 3875 129858 6 0 5 -3 9
-":RD?r;?Kjr;?Kjqu?]s
-BDFChar: 3876 129859 6 0 5 -3 9
-*'?>GI!g>>r;?Kjqu?]s
-BDFChar: 3877 129860 6 0 5 -3 8
-":P\Y4?S#hr;?Kj
-BDFChar: 3878 129861 6 0 5 -3 9
-*#oq\4?P`RI!g>>qu?]s
-BDFChar: 3879 129862 6 0 5 -3 4
-$lhD-r;?Kj
-BDFChar: 3880 129863 6 3 5 -3 0
-+<Y(M
-BDFChar: 3881 129864 6 1 5 -3 0
-#T.g]
-BDFChar: 3882 129865 6 3 5 -3 3
-+<Ve7?sqmm
-BDFChar: 3883 129866 6 0 5 -3 4
-":P\Y4?S#h
-BDFChar: 3884 129867 6 3 5 -3 7
-+<VdL+CJSb@,TrC
-BDFChar: 3885 129868 6 0 5 -3 9
-i:-O:r;?Kjr;?Kjqu?]s
-BDFChar: 3886 129869 6 0 5 -3 9
-JAC[Lr;?Kjr;?Kjqu?]s
-BDFChar: 3887 129870 6 0 5 -3 9
-i:-7*q"XX^r;?Kjqu?]s
-BDFChar: 3888 129871 6 0 5 -3 8
-JAAtYnF65Nr;?Kj
-BDFChar: 3889 129872 6 0 5 -3 9
-i8EP_nF5rBq"XX^qu?]s
-BDFChar: 3890 129873 6 0 5 -3 4
-^u4_[r;?Kj
-BDFChar: 3891 129874 6 0 5 -3 9
-r;?Kjr;?Kjr-WlS)uos=
-BDFChar: 3892 129875 6 0 5 -3 9
-r;?Kjr;?Kjr-UU8"98E%
-BDFChar: 3893 129876 6 0 5 -3 9
-r;?Kjr;:qiHosMR)uos=
-BDFChar: 3894 129877 6 0 5 -2 9
-r;?Kjr-UUh*"35Y
-BDFChar: 3895 129878 6 0 5 -3 9
-r;:qiI!g<(4?P_G)uos=
-BDFChar: 3896 129879 6 0 2 6 9
-i4skn
-BDFChar: 3897 129880 6 0 4 6 9
-q!c(L
-BDFChar: 3898 129881 6 0 2 3 9
-i5!.DJ:N.M
-BDFChar: 3899 129882 6 0 5 2 9
-r:odNi5!-Y
-BDFChar: 3900 129883 6 0 2 -1 9
-i8EP/^qda9J:N.M
-BDFChar: 3901 129884 6 0 5 2 9
-r;?Kjr:&X[
-BDFChar: 3902 129885 6 0 5 -3 9
-r;?Kjr;?Kjr:p'VhuE`W
-BDFChar: 3903 129886 6 0 5 -3 9
-r;?Kjr;?Kjr:ocsJ,fQL
-BDFChar: 3904 129887 6 0 5 -3 9
-r;?Kjr;??bq!deBhuE`W
-BDFChar: 3905 129888 6 0 5 -2 9
-r;?Kjr:odNi5!-Y
-BDFChar: 3906 129889 6 0 5 -3 9
-r;?Kfq"XXRnF5r*huE`W
-BDFChar: 3907 129890 6 3 5 6 9
-i*[ZM
-BDFChar: 3908 129891 6 1 5 6 9
-pimV]
-BDFChar: 3909 129892 6 3 5 3 9
-i*]r#+<Vd,
-BDFChar: 3910 129893 6 0 5 2 9
-r-UUh*"35Y
-BDFChar: 3911 129894 6 3 5 -1 9
-i8EO$?sm@b+<Vd,
-BDFChar: 3912 129895 6 0 5 2 9
-r;?Kjr&br-
-BDFChar: 3913 129896 6 0 5 -3 9
-r-WlS4<,=\4?S"=qu?]s
-BDFChar: 3914 129897 6 0 5 -3 8
-KS7Rnr;?Kjr;?Kj
-BDFChar: 3915 129898 6 0 5 -3 9
-r:p'VnDN6_nF65Jqu?]s
-BDFChar: 3916 129899 6 0 5 -2 9
-r;?Kjr;?Kjbfk`n
-BDFChar: 3917 129900 6 0 2 -2 8
-J:PGNi8EP/^jpq8
-BDFChar: 3918 129902 6 3 5 -2 8
-+<Y'"i8EO$?m$Ql
-BDFChar: 3919 129901 6 0 5 5 9
-r-3H?0E;(Q
-BDFChar: 3920 129903 6 0 5 -3 1
-0JI`rqu?]s
-BDFChar: 3921 129946 6 0 5 -3 9
-r-3H?0E;(Q0JI`rqu?]s
-BDFChar: 3922 129947 6 0 5 -2 8
-KS7Rnr;?K:b_1WL
-BDFChar: 3923 9698 6 0 5 -3 8
-"9],A*#oq\4FDPS
-BDFChar: 3924 9699 6 0 5 -3 8
-J:PGNi8EP_nG)eV
-BDFChar: 3925 9700 6 0 5 -2 9
-r:p'VnDN6_^qbJN
-BDFChar: 3926 9701 6 0 5 -2 9
-r-WlS4<,=\$k*7A
-BDFChar: 3927 129941 6 0 5 -3 9
-]Y#3ai:Q[6n6cZp]Dqp3
-BDFChar: 3928 129942 6 0 5 -3 9
-o^q&A*5&qs4;blpoDejk
-BDFChar: 3929 129943 6 0 5 -3 6
-r;?Hm!!!#sr;6Np
-BDFChar: 3930 129944 6 0 5 -3 9
-88KQYOP!*?,d`Zc8,rVi
-BDFChar: 3931 129945 6 0 5 -3 9
-8D'$2,]$$(OL-9L8,rVi
-BDFChar: 3932 129932 6 0 2 -3 9
-TKo/8TKo/8TKo/8TE"rl
-BDFChar: 3933 129933 6 3 5 -3 9
-5bLB85bLB85bLB85QCca
-BDFChar: 3934 129934 6 0 5 3 9
-W)T]pW)T\q
-BDFChar: 3935 129935 6 0 6 -3 2
-<2rot<2oou
-BDFChar: 3936 129936 6 0 5 -3 9
-<2`cp<2`cp<2`cp;ucmu
-BDFChar: 3937 129937 6 0 5 -3 9
-r;?Kjr;?Jk<2`cp;ucmu
-BDFChar: 3938 129938 6 0 5 -3 9
-<2`cp<2`dor;?Kjqu?]s
-BDFChar: 3939 129940 6 0 5 -3 9
->eF=S>eF=S>eF=S>Q=a(
-BDFChar: 3940 129948 6 0 4 -1 9
-W)0EhTKo/8J3\Vb
-BDFChar: 3941 129949 6 0 5 -2 9
-W)P/Z-klq$#Qt,1
-BDFChar: 3942 129950 6 0 5 -3 8
-"98Q1'F5C$'IZqZ
-BDFChar: 3943 129951 6 0 4 -3 7
-J3\WMTKo/HW)0Dm
-BDFChar: 3944 130020 6 1 4 3 9
-nF5r:nF5oI
-BDFChar: 3945 130021 6 1 4 -3 2
-nF5r:nF-DX
-BDFChar: 3946 130022 6 0 2 0 6
-i8EPOi8EMn
-BDFChar: 3947 130023 6 3 5 0 6
-i8EPOi8EMn
-BDFChar: 3948 130016 6 0 5 3 9
-KS5#384YE7
-BDFChar: 3949 130017 6 3 5 -3 9
-+@&2BJ:N0#J:KmM+92BA
-BDFChar: 3950 130018 6 0 5 -3 2
-0M"`fKS0=*
-BDFChar: 3951 130019 6 0 2 -3 9
-J3Z@B+<VdL+<Wp7J,fQL
-BDFChar: 3952 130024 6 0 5 3 9
-r;?KjG^(nB
-BDFChar: 3953 130025 6 3 5 -3 9
-+CJU8i8EPOi8A!N+92BA
-BDFChar: 3954 130026 6 0 5 -3 2
-0R.j?r;6Np
-BDFChar: 3955 130027 6 0 2 -3 9
-JAAtYi8EPOi8DDdJ,fQL
-BDFChar: 3956 130028 6 3 5 3 9
-i8EPO?sk)W
-BDFChar: 3957 130029 6 0 2 -3 2
-JAAtYi8=S8
-BDFChar: 3958 130030 6 3 5 -3 2
-+CJU8i8=S8
-BDFChar: 3959 130031 6 0 2 3 9
-i8EPO^qbI#
-BDFChar: 3960 130000 6 0 6 -3 3
-!X&c?+@(GW
-BDFChar: 3961 130001 6 0 6 3 9
-!X&c?+@(GW
-BDFChar: 3962 130002 6 0 6 3 9
-J3Y4g#Qt2/
-BDFChar: 3963 130003 6 0 6 -3 3
-J3Y4g#Qt2/
-BDFChar: 3964 130004 6 0 2 -3 9
-J:N0#5X7S"5Th0l+92BA
-BDFChar: 3965 130005 6 3 5 -3 9
-J:N0#5X7S"5Th0l+92BA
-BDFChar: 3966 130006 6 3 5 -3 9
-+<VdL5X7S"5_+B8J,fQL
-BDFChar: 3967 130007 6 0 2 -3 9
-+<VdL5X7S"5_+B8J,fQL
-BDFChar: 3968 130008 6 0 6 3 9
-Jj`!T-kHpi
-BDFChar: 3969 130009 6 3 6 -3 9
-&0N)\5_+B85X6G7&-)\1
-BDFChar: 3970 130010 6 0 6 -3 3
-&.g6<6puV,
-BDFChar: 3971 130011 6 0 3 -3 9
-J3Z@B+:o(q+<Wp7J,fQL
-BDFChar: 3972 130012 6 0 5 -3 9
-KS5#384Z9B82)_O0E;(Q
-BDFChar: 3973 130013 6 0 6 -3 9
-!X&c?+@(HB+:ne]!WW3#
-BDFChar: 3974 130014 6 0 5 -3 9
-0JG1784Z9B8;)YLKE(uP
-BDFChar: 3975 130015 6 0 6 -3 9
-J3Y4g#Qt23#S8+DJ,fQL
-BDFChar: 3976 129952 6 0 3 3 9
-&0N)\5_+@b
-BDFChar: 3977 129953 6 3 6 3 9
-J3Z@B+:o(a
-BDFChar: 3978 129954 6 0 3 -3 3
-J:KmM+<V3q
-BDFChar: 3979 129955 6 3 6 -3 3
-&.fs,5X9i"
-BDFChar: 3980 129956 6 0 3 -3 9
-&0N)\5_+B85X6G7&-)\1
-BDFChar: 3981 129957 6 3 6 -3 9
-J3Z@B+:o(q+<Wp7J,fQL
-BDFChar: 3982 129958 6 0 6 -3 3
-Jq?BY-n#W,
-BDFChar: 3983 129959 6 0 6 3 9
-&1Aqp7"U!j
-BDFChar: 3984 129960 6 0 6 -3 9
-&0N)\5_+@d"9\u9&-)\1
-BDFChar: 3985 129961 6 0 6 -3 9
-&-rOE"9O1*5X6G7&-)\1
-BDFChar: 3986 129962 6 0 6 -3 9
-&-rOE"9O1,6prFO&-)\1
-BDFChar: 3987 129963 6 0 6 -3 9
-&0N)\5_+H<6prFO&-)\1
-BDFChar: 3988 129964 6 0 6 -3 9
-&1Aqp7"U!l"9\u9&-)\1
-BDFChar: 3989 129965 6 0 6 -3 9
-&1Aqp7"U#@5X6G7&-)\1
-BDFChar: 3990 129966 6 0 6 -3 9
-&1Aqp7"U#B6prFO&-)\1
-BDFChar: 3991 118298 6 2 5 -3 3
-0Q:FX^qd_c
-BDFChar: 3992 118299 6 2 5 -3 4
-nF5q_^qdb$
-BDFChar: 3993 118300 6 2 3 -3 4
-^qdb$^qdb$
-BDFChar: 3994 118301 6 2 5 -3 4
-JAC+4nBetd
-BDFChar: 3995 118302 6 2 5 2 4
-nF5oI
-BDFChar: 3996 118303 6 0 5 2 4
-r;?Hm
-BDFChar: 3997 118304 6 0 5 -3 4
-r;?IH0JG17
-BDFChar: 3998 118305 6 0 5 -3 0
-KZs@=
-BDFChar: 3999 118306 6 0 3 -3 0
-JAC)^
-BDFChar: 4000 118307 6 2 3 -3 -2
-^q]pM
-BDFChar: 4001 118308 6 0 3 -3 3
-^u/U>0JG0\
-BDFChar: 4002 118309 6 0 3 2 4
-nF5oI
-BDFChar: 4003 118310 6 0 3 -3 4
-&28(mn?=T#
-BDFChar: 4004 118311 6 0 3 -3 4
-nF5p$0JG17
-BDFChar: 4005 118312 6 2 5 -3 9
-^qdb$_!pj_^qdb$^]4?7
-BDFChar: 4006 118313 6 2 3 -3 9
-^qdb$^qdb$^qdb$^]4?7
-BDFChar: 4007 118314 6 2 5 -3 9
-i,C@]z!"^i'huE`W
-BDFChar: 4008 118315 6 2 5 6 9
-i,C@]
-BDFChar: 4009 118316 6 2 5 -3 0
-&28(]
-BDFChar: 4010 118317 6 2 3 8 9
-^q]pM
-BDFChar: 4011 118318 6 2 5 -3 9
-^qdbD?uRf=@,Si9^]4?7
-BDFChar: 4012 118319 6 0 5 -1 7
-":Q:FnG!t3"98E%
-BDFChar: 4013 118320 6 2 3 9 9
-^]4?7
-BDFChar: 4014 118321 6 2 3 -3 -3
-^]4?7
-BDFChar: 4015 118322 6 0 5 -1 7
-KZs@=0R3N>KE(uP
-BDFChar: 4016 118323 6 0 5 -3 7
-KZs@=0JG170JG0\
-BDFChar: 4017 118324 6 0 5 -1 7
-":Q:Jr;>KgJ,fQL
-BDFChar: 4018 118325 6 2 5 -3 7
-&25eW?sqp.^qd_c
-BDFChar: 4019 118326 6 0 3 -3 9
-0JG170_"T$0JG170E;(Q
-BDFChar: 4020 118327 6 0 3 -3 9
-0JG2"@,SiY?uReR0E;(Q
-BDFChar: 4021 118328 6 0 3 -3 9
-E8\N^z!._lCDu]k<
-BDFChar: 4022 118329 6 0 3 -3 9
-0JKa#n8L'80JG170E;(Q
-BDFChar: 4023 118330 6 0 5 -3 9
-0JG170`:kH0JG170E;(Q
-BDFChar: 4024 118331 6 0 3 6 9
-E8\N^
-BDFChar: 4025 118332 6 2 3 2 9
-^qdb$^qdb$
-BDFChar: 4026 118333 6 2 5 2 9
-^qdb$_!pj_
-BDFChar: 4027 118334 6 2 5 3 9
-^qdbD?uRe"
-BDFChar: 4028 118335 6 2 5 2 9
-^qe=dnDM*4
-BDFChar: 4029 118336 6 0 5 2 9
-0JG170`:kH
-BDFChar: 4030 118337 6 0 5 3 7
-KZs@=0E;(Q
-BDFChar: 4031 118338 6 0 5 6 9
-Gl5d=
-BDFChar: 4032 118339 6 0 3 3 9
-0JG2"@,Sg#
-BDFChar: 4033 118340 6 0 3 2 9
-0JG170_"T$
-BDFChar: 4034 118341 6 0 4 1 9
-0JG2"i8F)a(]XO9
-BDFChar: 4035 118342 6 0 3 2 9
-0JKa#n8L&m
-BDFChar: 4036 118343 6 2 3 -3 1
-^qdb$^]4?7
-BDFChar: 4037 118344 6 2 3 -3 7
-^qdb$^qdb$^qd_c
-BDFChar: 4038 118345 6 2 3 -1 1
-^qd_c
-BDFChar: 4039 118346 6 2 3 -1 4
-^qdb$^q]pM
-BDFChar: 4040 118347 6 2 3 -1 7
-^qdb$^qdb$^]4?7
-BDFChar: 4041 118348 6 2 3 -1 9
-^qdb$^qdb$^qd_c
-BDFChar: 4042 118349 6 2 3 2 4
-^qd_c
-BDFChar: 4043 118350 6 2 3 2 7
-^qdb$^q]pM
-BDFChar: 4044 118351 6 2 3 5 7
-^qd_c
-BDFChar: 4045 118352 6 2 3 5 9
-^qdb$^]4?7
-BDFChar: 4046 129904 6 1 1 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 4047 129905 6 2 2 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 4048 129906 6 3 3 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 4049 129907 6 3 3 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 4050 129908 6 4 4 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 4051 129909 6 5 5 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 4052 129910 6 0 5 6 7
-r;6Np
-BDFChar: 4053 129911 6 0 5 5 6
-r;6Np
-BDFChar: 4054 129912 6 0 5 3 4
-r;6Np
-BDFChar: 4055 129913 6 0 5 1 2
-r;6Np
-BDFChar: 4056 129914 6 0 5 -1 0
-r;6Np
-BDFChar: 4057 129915 6 0 5 -2 -1
-r;6Np
-BDFChar: 4058 129916 6 0 6 -3 9
-J:N0#J:N0#J:N1LrVuou
-BDFChar: 4059 129917 6 0 6 -3 9
-rr.FuJ:N0#J:N0#J,fQL
-BDFChar: 4060 129918 6 0 6 -3 9
-rr)s#!WiE)!WiE)!WW3#
-BDFChar: 4061 129919 6 0 6 -3 9
-!WiE)!WiE)!WiH&rVuou
-BDFChar: 4062 129920 6 0 6 -3 9
-rr)ltz!!!#urVuou
-BDFChar: 4063 129921 6 0 6 -3 9
-rr)ltrW)otrVurtrVuou
-BDFChar: 4064 129922 6 0 5 7 9
-r;?Hm
-BDFChar: 4065 129923 6 0 5 5 9
-r;?Kjqu?]s
-BDFChar: 4066 129924 6 0 5 2 9
-r;?Kjr;?Kj
-BDFChar: 4067 129925 6 0 5 0 9
-r;?Kjr;?Kjr;6Np
-BDFChar: 4068 129926 6 0 5 -1 9
-r;?Kjr;?Kjr;?Hm
-BDFChar: 4069 129927 6 5 6 -3 9
-^qdb$^qdb$^qdb$^]4?7
-BDFChar: 4070 129928 6 4 6 -3 9
-i8EPOi8EPOi8EPOhuE`W
-BDFChar: 4071 129929 6 3 6 -3 9
-nF5r:nF5r:nF5r:n,NFg
-BDFChar: 4072 129930 6 2 6 -3 9
-q"XXZq"XXZq"XXZp](9o
-BDFChar: 4073 129931 6 1 6 -3 9
-r;?Kjr;?Kjr;?Kjqu?]s
-BDFChar: 4074 129967 6 0 5 1 5
-0JNDY0E;(Q
-BDFChar: 4075 129968 6 1 5 -1 6
-JAC+4pu%5F
-BDFChar: 4076 129985 6 0 5 0 7
-]YMJ(aRm9\
-BDFChar: 4077 129979 6 0 6 -1 7
-GYH>9L<`PA49,?]
-BDFChar: 4078 129980 6 0 6 -3 9
-rr)s#H:ge%H3+0IrVuou
-BDFChar: 4079 129989 6 1 5 0 7
-E,Zrp+<XL:
-BDFChar: 4080 129990 6 1 5 0 7
-E,_ap+<XKW
-BDFChar: 4081 129991 6 1 5 0 7
-E,[4ETHI'%
-BDFChar: 4082 129992 6 1 5 0 7
-E,_Ih-m2?J
-BDFChar: 4083 129993 6 1 5 0 7
-E,Zrp:l+mC
-BDFChar: 4084 129994 6 1 5 0 7
-+AdlMLoAs^
-BDFChar: 4085 129995 6 0 5 1 6
-8@1oYZq(/s
-BDFChar: 4086 129998 6 0 3 -3 9
-nF5r:nF5r:nF5r:n,NFg
-BDFChar: 4087 129999 6 0 1 -3 9
-^qdb$^qdb$^qdb$^]4?7
-BDFChar: 4088 129997 6 2 4 2 6
-5iCSYTE"rl
-BDFChar: 4089 129996 6 3 5 4 7
-i.-@9
-BDFChar: 4090 129976 6 0 6 -3 9
-!WiE93.1]:&eYfY!WW3#
-BDFChar: 4091 129975 6 0 6 -3 9
-!WiuI&eP%i3"c8o!WW3#
-BDFChar: 4092 129974 6 0 6 -3 9
-rr)m?0KAti0H^AprVuou
-BDFChar: 4093 129973 6 0 6 -3 9
-rr)m'(cZt((^L-@rVuou
-BDFChar: 4094 129984 6 0 5 1 6
-bd9o3[*/LM
-BDFChar: 4095 129972 6 0 6 -1 8
-rr2cZg4J2Lrr)lt
-BDFChar: 4096 129969 6 0 6 -1 8
-rr2cjp9r97rr)lt
-BDFChar: 4097 129970 6 1 5 0 7
-(^PAR\/>!+
-BDFChar: 4098 129971 6 0 5 0 7
-J=,6pi%P]N
-BDFChar: 4099 129977 6 1 5 1 6
-E/9$pJG9*E
-BDFChar: 4100 129978 6 0 5 1 5
-p]L^&qu?]s
-BDFChar: 4101 129981 6 0 6 -3 9
-I!iN:f%09?f"/G?HiO-H
-BDFChar: 4102 129982 6 0 6 -3 9
-rr2orrr2inqYKpZmJm4e
-BDFChar: 4103 129983 6 0 6 -3 9
-mdAZW]"3:#]%5I#mJm4e
-BDFChar: 4104 129988 6 0 6 -1 8
-rl2PGp?qAJmf!1d
-BDFChar: 4105 129986 6 0 5 0 7
-r!7t#"S`8l
-BDFChar: 4106 129987 6 0 5 5 7
-p]U?l
-BDFChar: 4107 129200 6 1 4 0 5
-nA(]Y&.egA
-BDFChar: 4108 129201 6 1 4 0 6
-i"-H]TYU$s
-BDFChar: 4109 129203 6 1 5 0 7
-E,]dkE$,/U
-BDFChar: 4110 129204 6 0 6 -1 7
-rr2?BK&5qprVuou
-BDFChar: 4111 129205 6 0 6 -1 7
-rr2?*Wp]<CrVuou
-BDFChar: 4112 129207 6 0 6 -1 7
-rpK4BWlFK+rVuou
-BDFChar: 4113 129206 6 0 6 -1 7
-rr2?ZK(eX3rVuou
-BDFChar: 4114 129208 6 1 5 1 5
-i4u9&+92BA
-BDFChar: 4115 129209 6 1 5 1 5
-3#JSZ+92BA
-BDFChar: 4116 129210 6 1 5 1 5
-+@)kB2uipY
-BDFChar: 4117 129211 6 1 5 1 5
-+:tKehuE`W
-BDFChar: 4118 129202 6 1 5 0 6
-+:rdZTR]9-
-BDFChar: 4119 9255 6 1 5 1 5
-W)0EhVuQet
-BDFChar: 4120 9256 6 1 5 0 6
-:oI3h:oI1j
-BDFChar: 4121 9257 6 0 5 -3 9
-W)T]pW)T]pW)T]pVuQet
-BDFChar: 4122 9217 6 1 4 -2 8
-@":Kb^]72-E)9@2
-BDFChar: 4123 9218 6 1 4 -2 8
-@":Kb^]72-+Abl7
-BDFChar: 4124 9219 6 1 4 -2 8
-i.0a9huHSM+Abl7
-BDFChar: 4125 9220 6 1 4 -2 8
-i.0a9huI^=+<Vd,
-BDFChar: 4126 9221 6 1 4 -3 8
-i.0a9huFlr:f&8G
-BDFChar: 4127 9222 6 1 4 -2 8
-5bR&.TE%eb?r0Z"
-BDFChar: 4128 9223 6 1 4 -2 8
-^nAK9^]6Vb5X98g
-BDFChar: 4129 9232 6 1 4 -2 8
-^n@?n^]6Vb5X98g
-BDFChar: 4130 9233 6 1 4 -2 8
-^n@?n^]5Kb+<YV'
-BDFChar: 4131 9234 6 1 4 -2 8
-^n@?n^]5KR&0Pol
-BDFChar: 4132 9235 6 1 4 -2 8
-^n@?n^]7aR+:qo\
-BDFChar: 4133 9236 6 1 4 -2 8
-^n@?n^]6&bE"EQ\
-BDFChar: 4134 9237 6 1 4 -2 8
-OO14nO8r*R?r0Z"
-BDFChar: 4135 9238 6 1 4 -2 8
-@":Kb^]72-+<Vd,
-BDFChar: 4136 9239 6 1 4 -2 8
-i.0a9huI.]?r152
-BDFChar: 4137 9240 6 1 5 -2 8
-@"<cX?iW`2=@bs_
-BDFChar: 4138 9241 6 1 4 -2 8
-i.0a9huHSmE)9@2
-BDFChar: 4139 9242 6 1 4 -2 8
-@":Kb^]7b=?r152
-BDFChar: 4140 9243 6 1 4 -2 8
-i.0a9huGGr5X7"'
-BDFChar: 4141 9249 6 1 4 -2 8
-^n@?n^]8<r+<Vd,
-BDFChar: 4142 9250 6 1 5 0 7
-:gcQX84Z9j
-BDFChar: 4143 9251 6 1 5 -2 -1
-M"grM
-BDFChar: 4144 9253 6 1 5 0 6
-+@qS:8<=qo
-BDFChar: 4145 9254 6 1 5 0 7
-E/9$0+<UY,
-BDFChar: 4146 118283 6 0 5 -3 9
-$nu's^qdb$^gLP($ig8-
-BDFChar: 4147 118284 6 0 5 -3 9
-^b?TB$k*OQ$lBg8^]4?7
-BDFChar: 4148 118282 6 0 6 -3 9
-Jq?BY-n(716prFO&-)\1
-BDFChar: 4149 118281 6 0 6 -3 9
-&1Aqp7"URM-q$ITJcGcN
-BDFChar: 4150 118285 6 0 5 3 3
-bQ%VC
-BDFChar: 4151 118286 6 2 3 3 3
-^]4?7
-BDFChar: 4152 118287 6 0 5 0 3
-qud-*
-BDFChar: 4153 118291 6 0 3 -3 9
-&.fBan.6-B&.fBa&-)\1
-BDFChar: 4154 118292 6 0 3 -3 9
-n.6-B&.fBan.6-B&-)\1
-BDFChar: 4155 118293 6 0 3 -3 9
-n.6-Bn.6-Bn.6-B&-)\1
-BDFChar: 4156 118294 6 3 6 -3 9
-n:6%>J:N0#J:N0#J,fQL
-BDFChar: 4157 118295 6 3 6 -3 9
-J:N0#J:N0#J:N0#n,NFg
-BDFChar: 4158 118296 6 0 3 -3 9
-n.6-B&.fBa&.fBa&-)\1
-BDFChar: 4159 118297 6 0 3 -3 9
-&.fBa&.fBa&.fBan,NFg
-BDFChar: 4160 118288 6 0 5 0 3
-r"'DN
-BDFChar: 4161 118289 6 0 5 0 3
-r'Wq@
-BDFChar: 4162 118290 6 0 5 0 3
-r)?Wp
-BDFChar: 4163 118280 6 0 5 0 6
-r.ITp0JG0\
-BDFChar: 4164 118279 6 0 2 3 7
-+CO,8+92BA
-BDFChar: 4165 118278 6 1 5 0 6
-E)9C+:f)*2
-BDFChar: 4166 118277 6 0 5 1 6
-r.MGaK_tfM
-BDFChar: 4167 118276 6 0 5 1 3
-KS97'
-BDFChar: 4168 118275 6 0 5 4 6
-r.K_'
-BDFChar: 4169 118274 6 0 5 1 5
-82.DAqu?]s
-BDFChar: 4170 118273 6 0 5 1 6
-KQmIsG_?%s
-BDFChar: 4171 118272 6 0 5 1 6
-KLeX)8;$sC
-BDFChar: 4172 117808 6 2 5 -3 5
-&.fs,5X9jMJ,fQL
-BDFChar: 4173 117809 6 0 5 6 9
-$nsqs
-BDFChar: 4174 117810 6 0 5 6 9
-^b?#s
-BDFChar: 4175 117811 6 0 3 -3 5
-J:KmM+<V4,&-)\1
-BDFChar: 4176 117812 6 0 2 -3 9
-+@&1W5X9jMJ:N0#J,fQL
-BDFChar: 4177 117813 6 0 5 -3 9
-":,P]+@&1WJ:N0#J,fQL
-BDFChar: 4178 117814 6 0 5 -3 9
-J3Y4g&-rOI"9\i1"98E%
-BDFChar: 4179 117815 6 3 5 -3 9
-J3Z@b5X6G7+<VdL+92BA
-BDFChar: 4180 117816 6 0 2 -3 9
-J:N0#J:N/85X7S"+92BA
-BDFChar: 4181 117817 6 0 5 -3 9
-J:N0#J3Z@b+<V4$"98E%
-BDFChar: 4182 117818 6 0 5 -3 9
-"9\i1":,8=&.fsLJ,fQL
-BDFChar: 4183 117819 6 3 5 -3 9
-+<VdL+<Vdl5X7S"J,fQL
-BDFChar: 4184 117820 6 2 5 1 9
-J:N/85Th0\&-)\1
-BDFChar: 4185 117821 6 0 5 -3 0
-J3Yds
-BDFChar: 4186 117822 6 0 5 -3 0
-":-]s
-BDFChar: 4187 117823 6 0 3 1 9
-&.fBq+@&2BJ,fQL
-BDFChar: 4188 117824 6 0 5 -1 8
-qu?`p!!)os!;lfs
-BDFChar: 4189 117825 6 1 4 -3 9
-OH>QcOH>QcOH>QcO8o7\
-BDFChar: 4190 117826 6 0 5 -3 9
-8Gl"Lr('BV84`YL8,rVi
-BDFChar: 4191 117827 6 0 6 -3 9
-Jj_!u-q&YT-kIdpJcGcN
-BDFChar: 4192 117828 6 0 4 -3 9
-W2QYnW2QYnW2QYnVuQet
-BDFChar: 4193 117829 6 0 5 -3 9
-quHWpquHWpquHWpqu?]s
-BDFChar: 4194 117830 6 0 5 -2 9
-,_-.c&:c//6kFks
-BDFChar: 4195 117831 6 0 5 -3 9
-:dbRW&<m/;XFLl#'EA+5
-BDFChar: 4196 118416 6 0 1 7 9
-^qd_c
-BDFChar: 4197 118417 6 1 2 7 9
-^qd_c
-BDFChar: 4198 118418 6 3 4 7 9
-^qd_c
-BDFChar: 4199 118419 6 4 5 7 9
-^qd_c
-BDFChar: 4200 118420 6 0 1 4 6
-^qd_c
-BDFChar: 4201 118421 6 1 2 4 6
-^qd_c
-BDFChar: 4202 118422 6 3 4 4 6
-^qd_c
-BDFChar: 4203 118423 6 4 5 4 6
-^qd_c
-BDFChar: 4204 118424 6 0 1 0 2
-^qd_c
-BDFChar: 4205 118425 6 1 2 0 2
-^qd_c
-BDFChar: 4206 118426 6 3 4 0 2
-^qd_c
-BDFChar: 4207 118427 6 4 5 0 2
-^qd_c
-BDFChar: 4208 118428 6 0 1 -3 -1
-^qd_c
-BDFChar: 4209 118429 6 1 2 -3 -1
-^qd_c
-BDFChar: 4210 118430 6 3 4 -3 -1
-^qd_c
-BDFChar: 4211 118431 6 4 5 -3 -1
-^qd_c
-BDFChar: 4212 118432 6 3 5 -3 -1
-i8EMn
-BDFChar: 4213 118433 6 1 5 -3 -1
-q"XUa
-BDFChar: 4214 118434 6 0 4 -3 -1
-q"XUa
-BDFChar: 4215 118435 6 0 2 -3 -1
-i8EMn
-BDFChar: 4216 118436 6 0 1 -3 2
-^qdb$^q]pM
-BDFChar: 4217 118437 6 0 1 -3 5
-^qdb$^qdb$^]4?7
-BDFChar: 4218 118438 6 0 1 1 9
-^qdb$^qdb$^]4?7
-BDFChar: 4219 118439 6 0 1 4 9
-^qdb$^q]pM
-BDFChar: 4220 118440 6 0 2 7 9
-i8EMn
-BDFChar: 4221 118441 6 0 4 7 9
-q"XUa
-BDFChar: 4222 118442 6 1 5 7 9
-q"XUa
-BDFChar: 4223 118443 6 3 5 7 9
-i8EMn
-BDFChar: 4224 118444 6 4 5 4 9
-^qdb$^q]pM
-BDFChar: 4225 118445 6 4 5 1 9
-^qdb$^qdb$^]4?7
-BDFChar: 4226 118446 6 4 5 -3 5
-^qdb$^qdb$^]4?7
-BDFChar: 4227 118447 6 4 5 -3 2
-^qdb$^q]pM
-BDFChar: 4228 118016 6 0 2 3 6
-i8EPO
-BDFChar: 4229 118017 6 0 5 3 9
-*#osVi8EMn
-BDFChar: 4230 118018 6 0 5 3 9
-r;?KNi8EMn
-BDFChar: 4231 118019 6 3 5 3 6
-i8EPO
-BDFChar: 4232 118020 6 0 5 3 9
-i8EN5*#opu
-BDFChar: 4233 118021 6 0 5 3 9
-r;?I4*#opu
-BDFChar: 4234 118022 6 0 5 3 6
-r;?Kj
-BDFChar: 4235 118023 6 0 5 3 9
-i8EPkr;?Hm
-BDFChar: 4236 118024 6 0 5 3 9
-*#osrr;?Hm
-BDFChar: 4237 118025 6 0 2 0 2
-i8EMn
-BDFChar: 4238 118026 6 0 2 0 9
-i8EMn!!!#Wi8=S8
-BDFChar: 4239 118027 6 0 5 0 9
-*#opu!!!#Wi8=S8
-BDFChar: 4240 118028 6 0 5 0 9
-r;?Hm!!!#Wi8=S8
-BDFChar: 4241 118029 6 0 2 0 9
-i8EPOi8EPOi8=S8
-BDFChar: 4242 118030 6 0 5 0 9
-*#osVi8EPOi8=S8
-BDFChar: 4243 118031 6 0 5 0 9
-r;?KNi8EPOi8=S8
-BDFChar: 4244 118032 6 0 5 0 6
-*#oq<i8EMn
-BDFChar: 4245 118033 6 0 5 0 9
-i8EN5*#osVi8=S8
-BDFChar: 4246 118034 6 0 5 0 9
-*#oq<*#osVi8=S8
-BDFChar: 4247 118035 6 0 5 0 9
-r;?I4*#osVi8=S8
-BDFChar: 4248 118036 6 0 5 0 6
-r;?Kji8EMn
-BDFChar: 4249 118037 6 0 5 0 9
-i8EPkr;?KNi8=S8
-BDFChar: 4250 118038 6 0 5 0 9
-*#osrr;?KNi8=S8
-BDFChar: 4251 118039 6 0 5 0 9
-r;?Kjr;?KNi8=S8
-BDFChar: 4252 118040 6 3 5 0 2
-i8EMn
-BDFChar: 4253 118041 6 0 5 0 9
-i8EMn!!!!=*#nqY
-BDFChar: 4254 118042 6 3 5 0 9
-i8EMn!!!#Wi8=S8
-BDFChar: 4255 118043 6 0 5 0 9
-r;?Hm!!!!=*#nqY
-BDFChar: 4256 118044 6 0 5 0 6
-i8EPO*#opu
-BDFChar: 4257 118045 6 0 5 0 9
-i8EPOi8EN5*#nqY
-BDFChar: 4258 118046 6 0 5 0 9
-*#osVi8EN5*#nqY
-BDFChar: 4259 118047 6 0 5 0 9
-r;?KNi8EN5*#nqY
-BDFChar: 4260 118048 6 0 5 0 9
-i8EN5*#oq<*#nqY
-BDFChar: 4261 118049 6 3 5 0 9
-i8EPOi8EPOi8=S8
-BDFChar: 4262 118050 6 0 5 0 9
-r;?I4*#oq<*#nqY
-BDFChar: 4263 118051 6 0 5 0 6
-r;?Kj*#opu
-BDFChar: 4264 118052 6 0 5 0 9
-i8EPkr;?I4*#nqY
-BDFChar: 4265 118053 6 0 5 0 9
-*#osrr;?I4*#nqY
-BDFChar: 4266 118054 6 0 5 0 9
-r;?Kjr;?I4*#nqY
-BDFChar: 4267 118055 6 0 5 0 2
-r;?Hm
-BDFChar: 4268 118056 6 0 5 0 9
-i8EMn!!!#sr;6Np
-BDFChar: 4269 118057 6 0 5 0 9
-*#opu!!!#sr;6Np
-BDFChar: 4270 118058 6 0 5 0 9
-r;?Hm!!!#sr;6Np
-BDFChar: 4271 118060 6 0 5 0 9
-i8EPOi8EPkr;6Np
-BDFChar: 4272 118059 6 0 5 0 6
-i8EPOr;?Hm
-BDFChar: 4273 118061 6 0 5 0 9
-*#osVi8EPkr;6Np
-BDFChar: 4274 118062 6 0 5 0 9
-r;?KNi8EPkr;6Np
-BDFChar: 4275 118063 6 0 5 0 6
-*#oq<r;?Hm
-BDFChar: 4276 118064 6 0 5 0 9
-i8EN5*#osrr;6Np
-BDFChar: 4277 118065 6 0 5 0 9
-*#oq<*#osrr;6Np
-BDFChar: 4278 118066 6 0 5 0 9
-r;?I4*#osrr;6Np
-BDFChar: 4279 118067 6 0 5 0 6
-r;?Kjr;?Hm
-BDFChar: 4280 118068 6 0 5 0 9
-i8EPkr;?Kjr;6Np
-BDFChar: 4281 118069 6 0 5 0 9
-*#osrr;?Kjr;6Np
-BDFChar: 4282 118070 6 0 2 -3 9
-i8EMnz!!(s8huE`W
-BDFChar: 4283 118071 6 0 5 -3 9
-*#opuz!!(s8huE`W
-BDFChar: 4284 118072 6 0 5 -3 9
-r;?Hmz!!(s8huE`W
-BDFChar: 4285 118073 6 0 2 -3 6
-i8EPO!!!#Wi8=S8
-BDFChar: 4286 118074 6 0 2 -3 9
-i8EPOi8EMn!!(s8huE`W
-BDFChar: 4287 118075 6 0 5 -3 9
-*#osVi8EMn!!(s8huE`W
-BDFChar: 4288 118076 6 0 5 -3 9
-r;?KNi8EMn!!(s8huE`W
-BDFChar: 4289 118077 6 0 5 -3 6
-*#oq<!!!#Wi8=S8
-BDFChar: 4290 118078 6 0 5 -3 9
-i8EN5*#opu!!(s8huE`W
-BDFChar: 4291 118079 6 0 5 -3 9
-*#oq<*#opu!!(s8huE`W
-BDFChar: 4292 118080 6 0 5 -3 9
-r;?I4*#opu!!(s8huE`W
-BDFChar: 4293 118081 6 0 5 -3 6
-r;?Kj!!!#Wi8=S8
-BDFChar: 4294 118082 6 0 5 -3 9
-i8EPkr;?Hm!!(s8huE`W
-BDFChar: 4295 118083 6 0 5 -3 9
-*#osrr;?Hm!!(s8huE`W
-BDFChar: 4296 118084 6 0 5 -3 9
-r;?Kjr;?Hm!!(s8huE`W
-BDFChar: 4297 118085 6 0 2 -3 9
-i8EMn!!!#Wi8EPOhuE`W
-BDFChar: 4298 118086 6 0 5 -3 9
-*#opu!!!#Wi8EPOhuE`W
-BDFChar: 4299 118087 6 0 5 -3 9
-r;?Hm!!!#Wi8EPOhuE`W
-BDFChar: 4300 118088 6 0 2 -3 6
-i8EPOi8EPOi8=S8
-BDFChar: 4301 118089 6 0 5 -3 9
-*#osVi8EPOi8EPOhuE`W
-BDFChar: 4302 118090 6 0 5 -3 9
-r;?KNi8EPOi8EPOhuE`W
-BDFChar: 4303 118091 6 0 5 -3 6
-*#oq<i8EPOi8=S8
-BDFChar: 4304 118092 6 0 5 -3 9
-i8EN5*#osVi8EPOhuE`W
-BDFChar: 4305 118093 6 0 5 -3 9
-r;?I4*#osVi8EPOhuE`W
-BDFChar: 4306 118094 6 0 5 -3 6
-r;?Kji8EPOi8=S8
-BDFChar: 4307 118095 6 0 5 -3 9
-i8EPkr;?KNi8EPOhuE`W
-BDFChar: 4308 118096 6 0 5 -3 9
-*#osrr;?KNi8EPOhuE`W
-BDFChar: 4309 118097 6 0 5 -3 2
-*#osVi8=S8
-BDFChar: 4310 118098 6 0 5 -3 9
-i8EMn!!!!=*$!nphuE`W
-BDFChar: 4311 118099 6 0 5 -3 9
-*#opu!!!!=*$!nphuE`W
-BDFChar: 4312 118100 6 0 5 -3 9
-r;?Hm!!!!=*$!nphuE`W
-BDFChar: 4313 118101 6 0 5 -3 6
-i8EPO*#osVi8=S8
-BDFChar: 4314 118102 6 0 5 -3 9
-i8EPOi8EN5*$!nphuE`W
-BDFChar: 4315 118103 6 0 5 -3 9
-*#osVi8EN5*$!nphuE`W
-BDFChar: 4316 118104 6 0 5 -3 9
-r;?KNi8EN5*$!nphuE`W
-BDFChar: 4317 118105 6 0 5 -3 6
-*#oq<*#osVi8=S8
-BDFChar: 4318 118106 6 0 5 -3 9
-i8EN5*#oq<*$!nphuE`W
-BDFChar: 4319 118107 6 0 5 -3 9
-*#oq<*#oq<*$!nphuE`W
-BDFChar: 4320 118108 6 0 5 -3 9
-r;?I4*#oq<*$!nphuE`W
-BDFChar: 4321 118109 6 0 5 -3 6
-r;?Kj*#osVi8=S8
-BDFChar: 4322 118110 6 0 5 -3 9
-i8EPkr;?I4*$!nphuE`W
-BDFChar: 4323 118111 6 0 5 -3 9
-*#osrr;?I4*$!nphuE`W
-BDFChar: 4324 118112 6 0 5 -3 9
-r;?Kjr;?I4*$!nphuE`W
-BDFChar: 4325 118113 6 0 5 -3 2
-r;?KNi8=S8
-BDFChar: 4326 118114 6 0 5 -3 9
-i8EMn!!!#sr;>L2huE`W
-BDFChar: 4327 118115 6 0 5 -3 9
-*#opu!!!#sr;>L2huE`W
-BDFChar: 4328 118116 6 0 5 -3 9
-r;?Hm!!!#sr;>L2huE`W
-BDFChar: 4329 118117 6 0 5 -3 6
-i8EPOr;?KNi8=S8
-BDFChar: 4330 118118 6 0 5 -3 9
-i8EPOi8EPkr;>L2huE`W
-BDFChar: 4331 118119 6 0 5 -3 9
-*#osVi8EPkr;>L2huE`W
-BDFChar: 4332 118120 6 0 5 -3 9
-r;?KNi8EPkr;>L2huE`W
-BDFChar: 4333 118121 6 0 5 -3 6
-*#oq<r;?KNi8=S8
-BDFChar: 4334 118122 6 0 5 -3 9
-i8EN5*#osrr;>L2huE`W
-BDFChar: 4335 118123 6 0 5 -3 9
-*#oq<*#osrr;>L2huE`W
-BDFChar: 4336 118124 6 0 5 -3 9
-r;?I4*#osrr;>L2huE`W
-BDFChar: 4337 118125 6 0 5 -3 6
-r;?Kjr;?KNi8=S8
-BDFChar: 4338 118126 6 0 5 -3 9
-i8EPkr;?Kjr;>L2huE`W
-BDFChar: 4339 118127 6 0 5 -3 9
-*#osrr;?Kjr;>L2huE`W
-BDFChar: 4340 118128 6 0 5 -3 9
-r;?Kjr;?Kjr;>L2huE`W
-BDFChar: 4341 118129 6 0 5 -3 9
-i8EMnz!!!uY)uos=
-BDFChar: 4342 118130 6 3 5 -3 9
-i8EMnz!!(s8huE`W
-BDFChar: 4343 118131 6 0 5 -3 9
-r;?Hmz!!!uY)uos=
-BDFChar: 4344 118132 6 0 5 -3 6
-i8EPO!!!!=*#nqY
-BDFChar: 4345 118133 6 0 5 -3 9
-i8EPOi8EMn!!!uY)uos=
-BDFChar: 4346 118134 6 0 5 -3 9
-*#osVi8EMn!!!uY)uos=
-BDFChar: 4347 118135 6 0 5 -3 9
-r;?KNi8EMn!!!uY)uos=
-BDFChar: 4348 118136 6 3 5 -3 6
-i8EPO!!!#Wi8=S8
-BDFChar: 4349 118137 6 0 5 -3 9
-i8EN5*#opu!!!uY)uos=
-BDFChar: 4350 118138 6 3 5 -3 9
-i8EPOi8EMn!!(s8huE`W
-BDFChar: 4351 118139 6 0 5 -3 9
-r;?I4*#opu!!!uY)uos=
-BDFChar: 4352 118140 6 0 5 -3 6
-r;?Kj!!!!=*#nqY
-BDFChar: 4353 118141 6 0 5 -3 9
-i8EPkr;?Hm!!!uY)uos=
-BDFChar: 4354 118142 6 0 5 -3 9
-*#osrr;?Hm!!!uY)uos=
-BDFChar: 4355 118143 6 0 5 -3 9
-r;?Kjr;?Hm!!!uY)uos=
-BDFChar: 4356 118144 6 0 5 -3 2
-i8EN5*#nqY
-BDFChar: 4357 118145 6 0 5 -3 9
-i8EMn!!!#Wi8>Rp)uos=
-BDFChar: 4358 118146 6 0 5 -3 9
-*#opu!!!#Wi8>Rp)uos=
-BDFChar: 4359 118147 6 0 5 -3 9
-r;?Hm!!!#Wi8>Rp)uos=
-BDFChar: 4360 118148 6 0 5 -3 6
-i8EPOi8EN5*#nqY
-BDFChar: 4361 118149 6 0 5 -3 9
-i8EPOi8EPOi8>Rp)uos=
-BDFChar: 4362 118150 6 0 5 -3 9
-*#osVi8EPOi8>Rp)uos=
-BDFChar: 4363 118151 6 0 5 -3 9
-r;?KNi8EPOi8>Rp)uos=
-BDFChar: 4364 118152 6 0 5 -3 6
-*#oq<i8EN5*#nqY
-BDFChar: 4365 118153 6 0 5 -3 9
-i8EN5*#osVi8>Rp)uos=
-BDFChar: 4366 118154 6 0 5 -3 9
-*#oq<*#osVi8>Rp)uos=
-BDFChar: 4367 118155 6 0 5 -3 9
-r;?I4*#osVi8>Rp)uos=
-BDFChar: 4368 118156 6 0 5 -3 6
-r;?Kji8EN5*#nqY
-BDFChar: 4369 118157 6 0 5 -3 9
-i8EPkr;?KNi8>Rp)uos=
-BDFChar: 4370 118158 6 0 5 -3 9
-*#osrr;?KNi8>Rp)uos=
-BDFChar: 4371 118159 6 0 5 -3 9
-r;?Kjr;?KNi8>Rp)uos=
-BDFChar: 4372 118160 6 0 5 -3 9
-i8EMn!!!!=*#oq<)uos=
-BDFChar: 4373 118161 6 3 5 -3 9
-i8EMn!!!#Wi8EPOhuE`W
-BDFChar: 4374 118162 6 0 5 -3 9
-r;?Hm!!!!=*#oq<)uos=
-BDFChar: 4375 118163 6 0 5 -3 6
-i8EPO*#oq<*#nqY
-BDFChar: 4376 118164 6 0 5 -3 9
-*#osVi8EN5*#oq<)uos=
-BDFChar: 4377 118165 6 0 5 -3 9
-r;?KNi8EN5*#oq<)uos=
-BDFChar: 4378 118166 6 3 5 -3 6
-i8EPOi8EPOi8=S8
-BDFChar: 4379 118167 6 0 5 -3 9
-i8EN5*#oq<*#oq<)uos=
-BDFChar: 4380 118168 6 0 5 -3 9
-r;?I4*#oq<*#oq<)uos=
-BDFChar: 4381 118169 6 0 5 -3 6
-r;?Kj*#oq<*#nqY
-BDFChar: 4382 118170 6 0 5 -3 9
-i8EPkr;?I4*#oq<)uos=
-BDFChar: 4383 118171 6 0 5 -3 9
-*#osrr;?I4*#oq<)uos=
-BDFChar: 4384 118172 6 0 5 -3 2
-r;?I4*#nqY
-BDFChar: 4385 118173 6 0 5 -3 9
-i8EMn!!!#sr;7NS)uos=
-BDFChar: 4386 118174 6 0 5 -3 9
-*#opu!!!#sr;7NS)uos=
-BDFChar: 4387 118175 6 0 5 -3 9
-r;?Hm!!!#sr;7NS)uos=
-BDFChar: 4388 118176 6 0 5 -3 6
-i8EPOr;?I4*#nqY
-BDFChar: 4389 118177 6 0 5 -3 9
-i8EPOi8EPkr;7NS)uos=
-BDFChar: 4390 118178 6 0 5 -3 9
-*#osVi8EPkr;7NS)uos=
-BDFChar: 4391 118179 6 0 5 -3 9
-r;?KNi8EPkr;7NS)uos=
-BDFChar: 4392 118180 6 0 5 -3 6
-*#oq<r;?I4*#nqY
-BDFChar: 4393 118181 6 0 5 -3 9
-i8EN5*#osrr;7NS)uos=
-BDFChar: 4394 118182 6 0 5 -3 9
-*#oq<*#osrr;7NS)uos=
-BDFChar: 4395 118183 6 0 5 -3 9
-r;?I4*#osrr;7NS)uos=
-BDFChar: 4396 118184 6 0 5 -3 6
-r;?Kjr;?I4*#nqY
-BDFChar: 4397 118185 6 0 5 -3 9
-i8EPkr;?Kjr;7NS)uos=
-BDFChar: 4398 118186 6 0 5 -3 9
-*#osrr;?Kjr;7NS)uos=
-BDFChar: 4399 118187 6 0 5 -3 9
-r;?Kjr;?Kjr;7NS)uos=
-BDFChar: 4400 118188 6 0 5 -3 9
-i8EMnz!!)rpqu?]s
-BDFChar: 4401 118189 6 0 5 -3 9
-*#opuz!!)rpqu?]s
-BDFChar: 4402 118190 6 0 5 -3 9
-r;?Hmz!!)rpqu?]s
-BDFChar: 4403 118191 6 0 5 -3 6
-i8EPO!!!#sr;6Np
-BDFChar: 4404 118192 6 0 5 -3 9
-i8EPOi8EMn!!)rpqu?]s
-BDFChar: 4405 118193 6 0 5 -3 9
-*#osVi8EMn!!)rpqu?]s
-BDFChar: 4406 118194 6 0 5 -3 9
-r;?KNi8EMn!!)rpqu?]s
-BDFChar: 4407 118195 6 0 5 -3 6
-*#oq<!!!#sr;6Np
-BDFChar: 4408 118196 6 0 5 -3 9
-i8EN5*#opu!!)rpqu?]s
-BDFChar: 4409 118197 6 0 5 -3 9
-*#oq<*#opu!!)rpqu?]s
-BDFChar: 4410 118198 6 0 5 -3 9
-r;?I4*#opu!!)rpqu?]s
-BDFChar: 4411 118199 6 0 5 -3 6
-r;?Kj!!!#sr;6Np
-BDFChar: 4412 118200 6 0 5 -3 9
-i8EPkr;?Hm!!)rpqu?]s
-BDFChar: 4413 118201 6 0 5 -3 9
-*#osrr;?Hm!!)rpqu?]s
-BDFChar: 4414 118202 6 0 5 -3 9
-r;?Kjr;?Hm!!)rpqu?]s
-BDFChar: 4415 118203 6 0 5 -3 2
-i8EPkr;6Np
-BDFChar: 4416 118204 6 0 5 -3 9
-i8EMn!!!#Wi8FP2qu?]s
-BDFChar: 4417 118205 6 0 5 -3 9
-*#opu!!!#Wi8FP2qu?]s
-BDFChar: 4418 118206 6 0 5 -3 9
-r;?Hm!!!#Wi8FP2qu?]s
-BDFChar: 4419 118207 6 0 5 -3 6
-i8EPOi8EPkr;6Np
-BDFChar: 4420 118208 6 0 5 -3 9
-i8EPOi8EPOi8FP2qu?]s
-BDFChar: 4421 118209 6 0 5 -3 9
-*#osVi8EPOi8FP2qu?]s
-BDFChar: 4422 118210 6 0 5 -3 9
-r;?KNi8EPOi8FP2qu?]s
-BDFChar: 4423 118211 6 0 5 -3 6
-*#oq<i8EPkr;6Np
-BDFChar: 4424 118212 6 0 5 -3 9
-i8EN5*#osVi8FP2qu?]s
-BDFChar: 4425 118213 6 0 5 -3 9
-*#oq<*#osVi8FP2qu?]s
-BDFChar: 4426 118214 6 0 5 -3 9
-r;?I4*#osVi8FP2qu?]s
-BDFChar: 4427 118215 6 0 5 -3 6
-r;?Kji8EPkr;6Np
-BDFChar: 4428 118216 6 0 5 -3 9
-i8EPkr;?KNi8FP2qu?]s
-BDFChar: 4429 118217 6 0 5 -3 9
-*#osrr;?KNi8FP2qu?]s
-BDFChar: 4430 118218 6 0 5 -3 9
-r;?Kjr;?KNi8FP2qu?]s
-BDFChar: 4431 118219 6 0 5 -3 2
-*#osrr;6Np
-BDFChar: 4432 118220 6 0 5 -3 9
-i8EMn!!!!=*$"nSqu?]s
-BDFChar: 4433 118221 6 0 5 -3 9
-*#opu!!!!=*$"nSqu?]s
-BDFChar: 4434 118222 6 0 5 -3 9
-r;?Hm!!!!=*$"nSqu?]s
-BDFChar: 4435 118223 6 0 5 -3 6
-i8EPO*#osrr;6Np
-BDFChar: 4436 118224 6 0 5 -3 9
-i8EPOi8EN5*$"nSqu?]s
-BDFChar: 4437 118225 6 0 5 -3 9
-*#osVi8EN5*$"nSqu?]s
-BDFChar: 4438 118226 6 0 5 -3 9
-r;?KNi8EN5*$"nSqu?]s
-BDFChar: 4439 118227 6 0 5 -3 6
-*#oq<*#osrr;6Np
-BDFChar: 4440 118228 6 0 5 -3 9
-i8EN5*#oq<*$"nSqu?]s
-BDFChar: 4441 118229 6 0 5 -3 9
-*#oq<*#oq<*$"nSqu?]s
-BDFChar: 4442 118230 6 0 5 -3 9
-r;?I4*#oq<*$"nSqu?]s
-BDFChar: 4443 118231 6 0 5 -3 6
-r;?Kj*#osrr;6Np
-BDFChar: 4444 118232 6 0 5 -3 9
-i8EPkr;?I4*$"nSqu?]s
-BDFChar: 4445 118233 6 0 5 -3 9
-*#osrr;?I4*$"nSqu?]s
-BDFChar: 4446 118234 6 0 5 -3 9
-r;?Kjr;?I4*$"nSqu?]s
-BDFChar: 4447 118235 6 0 5 -3 9
-i8EMn!!!#sr;?Kjqu?]s
-BDFChar: 4448 118236 6 0 5 -3 9
-*#opu!!!#sr;?Kjqu?]s
-BDFChar: 4449 118237 6 0 5 -3 9
-r;?Hm!!!#sr;?Kjqu?]s
-BDFChar: 4450 118238 6 0 5 -3 6
-i8EPOr;?Kjr;6Np
-BDFChar: 4451 118239 6 0 5 -3 9
-*#osVi8EPkr;?Kjqu?]s
-BDFChar: 4452 118240 6 0 5 -3 9
-r;?KNi8EPkr;?Kjqu?]s
-BDFChar: 4453 118241 6 0 5 -3 6
-*#oq<r;?Kjr;6Np
-BDFChar: 4454 118242 6 0 5 -3 9
-i8EN5*#osrr;?Kjqu?]s
-BDFChar: 4455 118243 6 0 5 -3 9
-r;?I4*#osrr;?Kjqu?]s
-BDFChar: 4456 118244 6 0 5 -3 9
-i8EPkr;?Kjr;?Kjqu?]s
-BDFChar: 4457 118245 6 0 5 -3 9
-*#osrr;?Kjr;?Kjqu?]s
-BDFChar: 4458 117765 6 0 5 -3 -1
-#lFr.
-BDFChar: 4459 117766 6 3 5 -3 9
-5X7S"5X7S"5X7Tm5QCca
-BDFChar: 4460 117767 6 0 5 -3 9
-#RC\A#RC\A#RC_6#QOi)
-BDFChar: 4461 117768 6 0 6 -3 9
-P#OCP&.fBa&.fBa&-)\1
-BDFChar: 4462 117764 6 1 5 -1 6
-Leo3:p`ONp
-BDFChar: 4463 117763 6 0 6 1 5
-OB+PGO8o7\
-BDFChar: 4464 117762 6 0 6 1 5
-'%H^+&c_n3
-BDFChar: 4465 117761 6 0 6 0 6
-i(c[f6r)Y?
-BDFChar: 4466 117760 6 0 6 0 6
-7!qrFP5^%5
-BDFChar: 4467 117769 6 0 5 0 7
-5X;!8'GLfY
-BDFChar: 4468 117770 6 1 5 -2 11
-+<VdlJ3Y4g#S8+$+<UXa
-BDFChar: 4469 117771 6 0 5 1 6
-3)#\N&.AO=
-BDFChar: 4470 117772 6 0 5 1 6
-pl*j%:lGAS
-BDFChar: 4471 117773 6 0 5 1 6
-i/l#J5_&h7
-BDFChar: 4472 117774 6 0 5 0 6
-LmY-bW0iA@
-BDFChar: 4473 117775 6 0 5 0 6
-6tB9@<+JAs
-BDFChar: 4474 117776 6 0 4 -3 9
-&.fD7TYQ)nW0fOM&-)\1
-BDFChar: 4475 117777 6 0 4 -3 9
-&-s\g\A3X1TTB]r&-)\1
-BDFChar: 4476 117778 6 0 5 -3 9
-J:KmM+<VXH+@&2BJ,fQL
-BDFChar: 4477 117779 6 0 5 0 6
-84Z:q84Z8O
-BDFChar: 4478 117780 6 1 5 -3 9
-+<VdLp](<h+<VdL+92BA
-BDFChar: 4479 117781 6 0 6 -3 9
-^n?dF6pa4,7#6qt^]4?7
-BDFChar: 4480 117782 6 0 6 -3 9
-i0]1NJqAT+JqSfEhuE`W
-BDFChar: 4481 117783 6 0 5 -3 9
-r"L+Nz!!!uQqu?]s
-BDFChar: 4482 117784 6 0 5 2 4
-i4RtJ
-BDFChar: 4483 117785 6 0 6 0 6
-&/Z,P'GqA]
-BDFChar: 4484 117786 6 0 6 0 6
-&/]N;F;PPh
-BDFChar: 4485 117787 6 0 5 3 9
-"9\i1"9eW&
-BDFChar: 4486 117788 6 0 5 -3 3
-qud-*"9\i-
-BDFChar: 4487 117789 6 0 5 3 9
-r.'<JJ:N.M
-BDFChar: 4488 117790 6 0 5 -3 3
-J:N0#J:ROt
-BDFChar: 4489 117791 6 0 5 -3 9
-#RCtU,Uc2[OJ!^]5QCca
-BDFChar: 4490 117792 6 0 5 -3 9
-5X6HbOAJIr,SUdq#QOi)
-BDFChar: 4491 9812 12 1 10 -2 8
-$ign?&ccd!P!H?=ZTqE=It3&7s1eU7
-BDFChar: 4492 9813 12 1 10 -2 8
-$ign?s1gmM1B8$f&c`OE56/L7s1eU7
-BDFChar: 4493 9814 12 1 10 -2 8
-s1ka%J3ZAM56)i,+TNYc?@[Pks1eU7
-BDFChar: 4494 9815 12 1 10 -2 8
-$igV7,lgnp9RoBY+TN,T+TT<ns1eU7
-BDFChar: 4495 9816 12 1 10 -2 8
-'EBT_,61R@Kn,P@BYXm=&3q@'J%u$a
-BDFChar: 4496 9817 12 2 9 -2 8
-(aL@DIO$1*6@o.:
-BDFChar: 4497 9818 12 1 10 -2 8
-$ih=K*WU&-s1mL,beS(GIt7R7s1eU7
-BDFChar: 4498 9819 12 1 10 -2 8
-$ih=Ks1j,756)`)*WR5]561`!s1eU7
-BDFChar: 4499 9820 12 1 10 -2 8
-ZU"Q+s1j,756*nJ56*nJIt7R7s1eU7
-BDFChar: 4500 9821 12 1 10 -2 8
-$igb;-NJ@@It3$!56)`)561`!s1eU7
-BDFChar: 4501 9822 12 1 10 -2 8
-'EC;s0*$D#rIDV4DSQcJ+$`%UJ%u$a
-BDFChar: 4502 9823 12 2 9 -2 8
-(d'ntIQT`AIfKEJ
-BDFChar: 4503 117946 6 0 5 -3 4
-":P\ACm_<:
-BDFChar: 4504 117947 6 0 5 -3 4
-JAAsNfOWM(
-BDFChar: 4505 117948 6 0 5 2 9
-]Y%KS/:>82
-BDFChar: 4506 117949 6 0 5 2 9
-o^qA2d.e%I
-BDFChar: 4507 117950 6 1 5 -3 4
-#T+ERGW66O
-BDFChar: 4508 117951 6 0 4 -3 4
-JAAtqnDHRI
-BDFChar: 4509 117952 6 0 5 2 9
-$k*OQ*'D%7
-BDFChar: 4510 117953 6 0 5 2 9
-^qdb$i:%0Q
-BDFChar: 4511 117954 6 0 5 -3 4
-f\$-"HltO6
-BDFChar: 4512 117955 6 0 5 -3 4
-m-OZJp^lra
-BDFChar: 4513 117970 6 1 5 -3 3
-(a+(%W2Oq@
-BDFChar: 4514 117956 6 0 5 2 9
-4?P_g4FD\W
-BDFChar: 4515 117957 6 0 5 2 9
-nF5r:nG!.a
-BDFChar: 4516 117958 6 1 5 -3 4
-(`3NLi8FD*
-BDFChar: 4517 117959 6 0 4 -3 4
-JAC+4nG)eR
-BDFChar: 4518 117960 6 0 5 2 9
-4?OT'*'D%7
-BDFChar: 4519 117961 6 0 5 2 9
-nF5Aoi:%0Q
-BDFChar: 4520 117962 6 0 5 -3 4
-$k*Oa'KgcU
-BDFChar: 4521 117963 6 0 4 -3 4
-@,Tu4nBfhO
-BDFChar: 4522 117964 6 0 5 2 9
-r,`&M$lgr`
-BDFChar: 4523 117965 6 0 5 2 9
-kihC*o^iRi
-BDFChar: 4524 117966 6 3 5 -3 2
-+CJS"i*ZNb
-BDFChar: 4525 117967 6 0 2 -3 2
-JAAsNi4o<m
-BDFChar: 4526 117968 6 1 5 2 9
-(`54l3-]uK
-BDFChar: 4527 117969 6 0 4 2 9
-^qemdi:%$I
-BDFChar: 4528 117971 6 0 5 -3 5
-CcmqM,a;8=li7"c
-BDFChar: 4529 117972 6 0 5 2 9
-0^R^/$j_+Q
-BDFChar: 4530 117973 6 0 5 2 9
-r&c5mKS8FY
-BDFChar: 4531 118448 6 0 5 2 3
-e>rWM
-BDFChar: 4532 118449 6 1 5 0 7
-E/9=+:f)uC
-BDFChar: 4533 118450 6 0 5 -1 7
-GXt@rGl35>qu?]s
-BDFChar: 4534 118451 6 3 5 -3 -1
-JAC(C
-BDFChar: 4535 117865 6 0 6 0 6
-&6(XW3)gFh
-BDFChar: 4536 117866 6 0 6 -1 7
-&<]um`W/u$&-)\1
-BDFChar: 4537 117867 6 0 5 0 6
-Gl0Z44T'F(
-BDFChar: 4538 117868 6 0 5 0 6
-8Bf<%r;:d>
-BDFChar: 4539 117869 6 0 5 0 6
-Gl7'HnGIM2
-BDFChar: 4540 117870 6 0 5 0 6
-Gl7K`bfiTX
-BDFChar: 4541 117859 6 1 4 0 6
-n6kbTnF0fc
-BDFChar: 4542 117857 6 1 4 0 6
-@.<[Tn6k_c
-BDFChar: 4543 117856 6 0 5 1 4
-FSu&Y
-BDFChar: 4544 117858 6 0 5 1 4
-\GZ97
-BDFChar: 4545 117860 6 0 5 -2 7
-=T&(>&-rgi&-r79
-BDFChar: 4546 117847 6 1 5 0 7
-+E2:=E,bTN
-BDFChar: 4547 117849 6 1 5 0 7
-W;(=NE,]b=
-BDFChar: 4548 117846 6 0 5 1 5
-%!_\p$ig8-
-BDFChar: 4549 117848 6 0 5 1 5
-^j,d%^]4?7
-BDFChar: 4550 117861 6 0 5 1 5
-JG^r<$ig8-
-BDFChar: 4551 117863 6 0 5 1 5
-"T6X)^]4?7
-BDFChar: 4552 117862 6 1 5 1 6
-^d):(G^'2g
-BDFChar: 4553 117864 6 0 4 1 6
-nF07.&/YBI
-BDFChar: 4554 117872 6 0 5 0 6
-E7k(N*'!Ef
-BDFChar: 4555 117873 6 0 5 -3 6
-AE;gQr;:dn0JEJ,
-BDFChar: 4556 117874 6 0 5 0 6
-3,JN^i,CdY
-BDFChar: 4557 117875 6 0 5 0 9
-0JG2*r;>'7S<s9V
-BDFChar: 4558 117876 6 0 5 0 6
-0R2CNr-0mq
-BDFChar: 4559 117877 6 0 5 -3 6
-0R3N.r;:dn0JEJ,
-BDFChar: 4560 117878 6 0 5 0 6
-0R2s^r-0mq
-BDFChar: 4561 117879 6 0 5 0 9
-0JG2*r;?3bGVB*t
-BDFChar: 4562 117880 6 0 5 0 6
-*,sioi,BY9
-BDFChar: 4563 117882 6 0 5 0 6
-i&D\r*&ujV
-BDFChar: 4564 117881 6 0 5 0 7
-0R.j?r60hI
-BDFChar: 4565 117883 6 0 5 -1 6
-KS7SIr-3H?
-BDFChar: 4566 117884 6 0 6 -3 9
-^7qX-WiE)!WiEX^rVuou
-BDFChar: 4567 117885 6 0 6 -3 9
-rd__WWiE)!WiEX^rVuou
-BDFChar: 4568 117886 6 0 6 -3 9
-rdq_]WiE)!WiE(Vq>^Kq
-BDFChar: 4569 117887 6 0 6 -3 9
-rdq_]WiE)!Wf$WSrVuou
-BDFChar: 4570 117888 6 1 5 0 5
-#UlXM-jTeQ
-BDFChar: 4571 117889 6 0 5 0 4
-0E?=tqu?]s
-BDFChar: 4572 117890 6 0 4 0 5
-J=rj>TR["B
-BDFChar: 4573 117891 6 0 5 1 5
-quCsA0E;(Q
-BDFChar: 4574 117892 6 1 4 -3 9
-ORS?nn;rb$OHAsnO8o7\
-BDFChar: 4575 117893 6 0 5 1 5
-r)?Wpqu?]s
-BDFChar: 4576 117894 6 0 5 0 3
-^p&dq
-BDFChar: 4577 117895 6 0 5 0 3
-$oGp#
-BDFChar: 4578 117896 6 0 6 3 5
-m],[T
-BDFChar: 4579 117897 6 0 6 0 6
-W^NieW^Nie
-BDFChar: 4580 117898 6 0 6 -3 9
--n%JOJq<uSJj`!T-ia5I
-BDFChar: 4581 117899 6 0 6 -3 9
-mdA*7Jq<uSK#YgumJm4e
-BDFChar: 4582 117900 6 0 6 -3 9
-recl5MTWr9U5G,.rVuou
-BDFChar: 4583 117901 6 0 6 -3 9
-rpK3o`e&eo`l@H7rVuou
-BDFChar: 4584 117902 6 0 6 -3 9
-rr.FuJ:O#SR"0^;J,fQL
-BDFChar: 4585 117903 6 0 6 -3 9
-rr2orrr2'Bk5PAZrVuou
-BDFChar: 4586 117904 6 2 4 -3 9
-i'?3ci'?3ci'?3c5QCca
-BDFChar: 4587 117905 6 0 5 2 4
-W;NRo
-BDFChar: 4588 117906 6 0 5 1 5
-@'ok(?iU0,
-BDFChar: 4589 117907 6 0 5 1 5
-(ps4R(]XO9
-BDFChar: 4590 117908 6 0 5 1 5
-@'ohg?iU0,
-BDFChar: 4591 117909 6 0 5 1 5
-(ps4F(]XO9
-BDFChar: 4592 117910 6 0 5 0 7
-&1D5)r-/c4
-BDFChar: 4593 117911 6 0 6 0 6
-mR7&Gr^?/S
-BDFChar: 4594 117912 6 0 6 0 6
-]'cRX])K8@
-BDFChar: 4595 117913 6 0 6 0 6
-mR7'Fr^?/S
-BDFChar: 4596 117914 6 0 6 0 6
-])K9#Wp[Fu
-BDFChar: 4597 117915 6 0 6 0 6
-mR7'Rr^?/S
-BDFChar: 4598 117916 6 0 6 0 6
-])K9#])K8@
-BDFChar: 4599 117917 6 0 6 0 6
-K)W>@])I9]
-BDFChar: 4600 117918 6 0 6 1 5
-r#C/t49,?]
-BDFChar: 4601 117919 6 0 6 1 5
-IW55/GQ7^D
-BDFChar: 4602 117871 6 0 5 0 6
-Gl4rHbku\c
-BDFChar: 4603 117832 6 0 6 1 5
-5bO5<HiO-H
-BDFChar: 4604 117833 6 0 6 1 5
-":>e@HiO-H
-BDFChar: 4605 117834 6 0 6 2 7
-I+E[)<2oou
-BDFChar: 4606 117835 6 0 6 3 5
-3)okW
-BDFChar: 4607 117836 6 0 5 0 7
-GdRCmr('A3
-BDFChar: 4608 117837 6 0 5 0 7
-GdRCmr('B&
-BDFChar: 4609 117838 6 0 6 0 7
-&3*YgmX/ij
-BDFChar: 4610 117839 6 0 6 0 7
-&3*YgmX/h!
-BDFChar: 4611 117840 6 0 5 1 7
-`$fl;r((W(
-BDFChar: 4612 117841 6 0 6 0 7
-7OUB&If;aZ
-BDFChar: 4613 117842 6 0 5 0 6
-0R0t38;'M6
-BDFChar: 4614 117843 6 0 5 0 6
-KX>tX0M$is
-BDFChar: 4615 117844 6 0 5 1 7
-89hLd84^r)
-BDFChar: 4616 117845 6 0 5 0 7
-89hLd0M"aY
-BDFChar: 4617 11044 6 0 5 0 6
-Gl7L;r;:d>
-BDFChar: 4618 118261 6 0 5 0 7
-0R1f4Gl4qU
-BDFChar: 4619 9992 6 0 6 0 7
-+>B2^rg5A^
-BDFChar: 4620 128743 6 0 5 0 6
-0JIbLZnQ_)
-BDFChar: 4621 118264 6 0 5 0 6
-GVHN&GVCfO
-BDFChar: 4622 118265 6 0 6 0 7
-#T,>rr\>;r
-BDFChar: 4623 118266 6 1 5 0 4
-+E48%:]LIq
-BDFChar: 4624 118267 6 0 5 0 6
-0`9-c8Gp[3
-BDFChar: 4625 118268 6 0 5 0 6
-bkt"&bks-p
-BDFChar: 4626 118269 6 0 5 1 6
-+BW`qBF"S<
-BDFChar: 4627 118270 6 0 5 0 7
-+G<jQ+D?E>
-BDFChar: 4628 118271 6 0 5 0 7
-,QNo/+G:jC
-BDFChar: 4629 117850 6 0 5 -3 4
-GSkZZGjOdU
-BDFChar: 4630 117853 6 0 5 2 9
-r;9)V84Z;(
-BDFChar: 4631 117852 6 0 5 -3 4
-G[PbMGhh)m
-BDFChar: 4632 117854 6 0 5 2 9
-r;9)V84Z:q
-BDFChar: 4633 117855 6 0 5 2 9
-r;9)V84Z9f
-BDFChar: 4634 117851 6 0 5 -3 4
-GY!'5GdOjU
-BDFChar: 4635 117920 6 0 5 0 7
-":Q84r;?Kj
-BDFChar: 4636 117921 6 0 5 0 7
-JAC+4r;?Kj
-BDFChar: 4637 117922 6 0 5 0 5
-":4paN;NYU
-BDFChar: 4638 117923 6 0 5 0 5
-J3a%N`;BT8
-BDFChar: 4639 117924 6 0 5 0 6
-$kNttr;8YW
-BDFChar: 4640 117925 6 0 5 0 6
-^`Xcpr;?$a
-BDFChar: 4641 117926 6 0 5 -3 4
-$kOOH=I=Vl
-BDFChar: 4642 117927 6 0 5 -3 4
-^`X0oBOh7!
-BDFChar: 4643 117928 6 0 5 -3 4
-$kOOH5a[(T
-BDFChar: 4644 117929 6 0 5 -3 4
-^`X0o#\4'k
-BDFChar: 4645 117930 6 0 5 2 9
-KS5F`9HXlT
-BDFChar: 4646 117931 6 0 5 2 9
-KS1U!a:KK0
-BDFChar: 4647 117932 6 0 5 2 9
-KS4k@9HXlT
-BDFChar: 4648 117933 6 0 5 2 9
-KS0I6a:KK0
-BDFChar: 4649 117934 6 0 5 2 9
-KS4kL:b3.d
-BDFChar: 4650 117935 6 0 5 2 9
-KS0KL.*s*P
-BDFChar: 4651 117936 6 0 5 2 9
-KS4kL:`p;X
-BDFChar: 4652 117937 6 0 5 2 9
-KS0KL-kIN:
-BDFChar: 4653 117938 6 0 5 -3 3
-r.(<1TV.qX
-BDFChar: 4654 117939 6 0 5 -3 3
-qul'p'GM5]
-BDFChar: 4655 117940 6 0 5 3 9
-TU^Q10JI_O
-BDFChar: 4656 117941 6 0 5 3 9
-']]Dp0JI_O
-BDFChar: 4657 117942 6 0 5 -3 1
-r.)G1qu?]s
-BDFChar: 4658 117943 6 0 5 -3 1
-r'WqPqu?]s
-BDFChar: 4659 117944 6 0 5 2 9
-J>e"*J;f$V
-BDFChar: 4660 117945 6 0 5 2 9
-"LJ;R"N1H@
-BDFChar: 4661 118262 6 -1 6 -3 4
-4An:l]`1,X
-BDFChar: 4662 118263 6 -1 6 -3 4
-4A%^:4o`1-
-BDFChar: 4663 118256 6 1 4 -3 3
-?sitBnF5oI
-BDFChar: 4664 118257 6 1 3 4 9
-i*\f85X5;L
-BDFChar: 4665 118259 6 2 4 4 9
-i4qTC5X5;L
-BDFChar: 4666 118258 6 1 4 6 9
-n6fX3
-BDFChar: 4667 118260 6 2 3 4 9
-^qdb$^q]pM
-BDFChar: 4668 118246 6 0 5 -3 3
-0JEKOr3Wg2
-BDFChar: 4669 118247 6 0 5 4 9
-G^)c4KS0=*
-BDFChar: 4670 118248 6 0 5 -3 3
-E-MA%nG)n]
-BDFChar: 4671 118252 6 0 5 -3 3
-3-YE_4FI&,
-BDFChar: 4672 118249 6 0 4 4 9
-n8Kd0?n_Q\
-BDFChar: 4673 118253 6 1 5 4 9
-G]9<`0OOk\
-BDFChar: 4674 118250 6 0 5 -3 3
-E-MA)oXq[6
-BDFChar: 4675 118254 6 0 5 -3 3
-3-YG5]_$:G
-BDFChar: 4676 118251 6 0 5 3 9
-n9d&<,f"p1
-BDFChar: 4677 118255 6 0 5 3 9
-4SZ.BO:26l
-BDFChar: 4678 9688 6 0 6 -3 9
-rr2or`e&eo`r>u:rVuou
-BDFChar: 4679 9689 6 0 6 -3 9
-rr2or`k&am`r>u:rVuou
-BDFChar: 4680 9788 6 1 5 0 6
-+K083E2XlZ
-BDFChar: 4681 9644 6 0 5 0 3
-r;?Kj
-BDFChar: 4682 8616 6 1 5 0 7
-+E48%W,NmS
-BDFChar: 4683 8359 6 1 5 0 7
-i/j&YOLUC>
-BDFChar: 4684 8976 6 2 5 0 3
-n:6%>
-BDFChar: 4685 9668 6 1 5 1 5
-#WVT=#QOi)
-BDFChar: 4686 9658 6 1 5 1 5
-JDg4\J,fQL
-BDFChar: 4687 8771 6 1 5 2 5
-BWqL3
-BDFChar: 4688 8772 6 1 5 0 7
-&.iNZ+S\2e
-BDFChar: 4689 9768 6 1 5 0 7
-+E/Iu+<VdL
-BDFChar: 4690 127136 6 1 5 -2 8
-po)iDfVmH$fVnQF
-BDFChar: 4691 127137 6 1 5 -2 8
-pt2O$W2TLDLoC(K
-BDFChar: 4692 127138 6 1 5 -2 8
-pt2P/fSK=TLoC(K
-BDFChar: 4693 127139 6 1 5 -2 8
-pmC9tka;.tLoC(K
-BDFChar: 4694 127140 6 1 5 -2 8
-prKCikihfoLoC(K
-BDFChar: 4695 127141 6 1 5 -2 8
-pkZGIka;.tLoC(K
-BDFChar: 4696 127142 6 1 5 -2 8
-pt3*DW7^mtLoC(K
-BDFChar: 4697 127143 6 1 5 -2 8
-pk\.tf\#uOLoC(K
-BDFChar: 4698 127144 6 1 5 -2 8
-pt2OtW7^mtLoC(K
-BDFChar: 4699 127145 6 1 5 -2 8
-pt2Odkh,[_LoC(K
-BDFChar: 4700 127146 6 1 5 -2 8
-pk[STf\#uOLoC(K
-BDFChar: 4701 127147 6 1 5 -2 8
-prM[_W7^mtLoC(K
-BDFChar: 4702 127148 6 1 5 -2 8
-pt2OTW7^mtLoC(K
-BDFChar: 4703 127149 6 1 5 -2 8
-pt2ODR)o'TLoC(K
-BDFChar: 4704 127150 6 1 5 -2 8
-po(-YW2TLDLoC(K
-BDFChar: 4705 127153 6 1 5 -2 8
-pt2O$W2TKiLtMJ&
-BDFChar: 4706 127154 6 1 5 -2 8
-pt2P/fSK=$LtMJ&
-BDFChar: 4707 127155 6 1 5 -2 8
-pmC9tka;.DLtMJ&
-BDFChar: 4708 127156 6 1 5 -2 8
-prKCikihf?LtMJ&
-BDFChar: 4709 127157 6 1 5 -2 8
-pkZGIka;.DLtMJ&
-BDFChar: 4710 127158 6 1 5 -2 8
-pt3*DW7^mDLtMJ&
-BDFChar: 4711 127159 6 1 5 -2 8
-pk\.tf\#ttLtMJ&
-BDFChar: 4712 127160 6 1 5 -2 8
-pt2OtW7^mDLtMJ&
-BDFChar: 4713 127161 6 1 5 -2 8
-pt2Odkh,[/LtMJ&
-BDFChar: 4714 127162 6 1 5 -2 8
-pk[STf\#ttLtMJ&
-BDFChar: 4715 127163 6 1 5 -2 8
-prM[_W7^mDLtMJ&
-BDFChar: 4716 127164 6 1 5 -2 8
-pt2OTW7^mDLtMJ&
-BDFChar: 4717 127165 6 1 5 -2 8
-pt2ODR)o'$LtMJ&
-BDFChar: 4718 127166 6 1 5 -2 8
-po(-YW2TKiLtMJ&
-BDFChar: 4719 127167 6 1 5 -2 8
-q"XXZfSJ1Yq"XUa
-BDFChar: 4720 127169 6 1 5 -2 8
-pt2O$W2TLDLtMJ&
-BDFChar: 4721 127170 6 1 5 -2 8
-pt2P/fSK=TLtMJ&
-BDFChar: 4722 127171 6 1 5 -2 8
-pmC9tka;.tLtMJ&
-BDFChar: 4723 127172 6 1 5 -2 8
-prKCikihfoLtMJ&
-BDFChar: 4724 127173 6 1 5 -2 8
-pkZGIka;.tLtMJ&
-BDFChar: 4725 127174 6 1 5 -2 8
-pt3*DW7^mtLtMJ&
-BDFChar: 4726 127175 6 1 5 -2 8
-pk\.tf\#uOLtMJ&
-BDFChar: 4727 127176 6 1 5 -2 8
-pt2OtW7^mtLtMJ&
-BDFChar: 4728 127177 6 1 5 -2 8
-pt2Odkh,[_LtMJ&
-BDFChar: 4729 127178 6 1 5 -2 8
-pk[STf\#uOLtMJ&
-BDFChar: 4730 127179 6 1 5 -2 8
-prM[_W7^mtLtMJ&
-BDFChar: 4731 127180 6 1 5 -2 8
-pt2OTW7^mtLtMJ&
-BDFChar: 4732 127181 6 1 5 -2 8
-pt2ODR)o'TLtMJ&
-BDFChar: 4733 127182 6 1 5 -2 8
-po(-YW2TLDLtMJ&
-BDFChar: 4734 127183 12 3 9 -2 8
-rdo`RP.HgVJqEt%
-BDFChar: 4735 127185 6 1 5 -2 8
-pt2O$W2TLDW7^kF
-BDFChar: 4736 127186 6 1 5 -2 8
-pt2P/fSK=TW7^kF
-BDFChar: 4737 127187 6 1 5 -2 8
-pmC9tka;.tW7^kF
-BDFChar: 4738 127188 6 1 5 -2 8
-prKCikihfoW7^kF
-BDFChar: 4739 127189 6 1 5 -2 8
-pkZGIka;.tW7^kF
-BDFChar: 4740 127190 6 1 5 -2 8
-pt3*DW7^mtW7^kF
-BDFChar: 4741 127191 6 1 5 -2 8
-pk\.tf\#uOW7^kF
-BDFChar: 4742 127192 6 1 5 -2 8
-pt2OtW7^mtW7^kF
-BDFChar: 4743 127193 6 1 5 -2 8
-pt2Odkh,[_W7^kF
-BDFChar: 4744 127194 6 1 5 -2 8
-pk[STf\#uOW7^kF
-BDFChar: 4745 127195 6 1 5 -2 8
-prM[_W7^mtW7^kF
-BDFChar: 4746 127196 6 1 5 -2 8
-pt2OTW7^mtW7^kF
-BDFChar: 4747 127197 6 1 5 -2 8
-pt2ODR)o'TW7^kF
-BDFChar: 4748 127198 6 1 5 -2 8
-po(-YW2TLDW7^kF
-BDFChar: 4749 127199 6 1 5 -2 8
-q"XXZfSJ1Yq"XUa
-BDFChar: 4750 8462 6 1 5 0 7
-?m%^2BLn5P
-BDFChar: 4751 8463 6 1 5 0 7
-?nfAmBLn5P
-BDFChar: 4752 8495 6 1 5 0 5
-0M%;`Li<=o
-BDFChar: 4753 8550 6 0 6 0 7
-WiE)!WiAZ`
-BDFChar: 4754 8551 6 0 6 0 7
-Y-+q1Y-(Mp
-BDFChar: 4755 8555 6 0 6 0 7
-WiE'kWiE)!
-BDFChar: 4756 8556 6 1 5 0 7
-J:N0#J:N1F
-BDFChar: 4757 8557 6 1 5 0 7
-E/9$pJ:NGp
-BDFChar: 4758 8558 6 1 5 0 7
-i/ibNLkq/N
-BDFChar: 4759 8559 6 1 5 0 7
-LtJZ)LkpkC
-BDFChar: 4760 8572 6 3 3 0 7
-J:N0#J:N0#
-BDFChar: 4761 8573 6 1 5 0 4
-E/9%#Du]k<
-BDFChar: 4762 8574 6 1 5 0 7
-#RC]\Lkpk3
-BDFChar: 4763 8575 6 1 5 0 4
-d&<nAVuQet
-BDFChar: 4764 8528 6 1 5 0 8
-Lld^k+BV0rO8o7\
-BDFChar: 4765 8529 6 1 5 0 8
-Lld^k0PFREO8o7\
-BDFChar: 4766 8585 6 1 5 0 8
-8?f=+3(Ql%QiI*d
-BDFChar: 4767 8530 6 1 6 0 8
-Lld^k+D>l(VuQet
-BDFChar: 4768 8531 6 1 5 0 8
-Lld^k3(Ql%QiI*d
-BDFChar: 4769 8532 6 1 5 0 8
-Les2k3(Ql%QiI*d
-BDFChar: 4770 8533 6 1 5 0 8
-Lld^k+BVHrO8o7\
-BDFChar: 4771 8534 6 1 5 0 8
-Les2k+BVHrO8o7\
-BDFChar: 4772 8535 6 1 5 0 8
-aA@t+i)ig3O8o7\
-BDFChar: 4773 8536 6 0 5 0 8
-,\ZBq&1f4t8,rVi
-BDFChar: 4774 8537 6 1 6 0 8
-Lld^k-r=$1L]@DT
-BDFChar: 4775 8543 6 1 5 0 8
-Lld^k+@&2BJ,fQL
-BDFChar: 4776 8538 6 1 6 0 8
-aH05k-r=$1L]@DT
-BDFChar: 4777 8539 6 1 5 0 8
-Lld^k0PF:]O8o7\
-BDFChar: 4778 8540 6 1 5 0 8
-aA@t+n7YXsO8o7\
-BDFChar: 4779 8541 6 1 5 0 8
-aH05k0PF:]O8o7\
-BDFChar: 4780 8542 6 1 5 0 8
-aA@tk0PF:]O8o7\
-BDFChar: 4781 8576 6 1 5 0 7
-E2]_6W2QY6
-BDFChar: 4782 8577 6 1 5 0 7
-i/l$YW5t(Y
-BDFChar: 4783 8579 6 1 5 0 7
-E/4c*#RH6*
-BDFChar: 4784 8580 6 1 5 0 4
-E/4dUDu]k<
-BDFChar: 4785 8586 6 1 5 0 7
-p]qER5_+Z0
-BDFChar: 4786 8587 6 1 5 0 7
-E/9$p@"=&P
-BDFChar: 4787 8486 6 1 5 0 7
-E/9=+LtGPV
-BDFChar: 4788 8487 6 1 5 0 7
-fML4VLkpk+
-BDFChar: 4789 8451 6 0 5 0 7
-8@22)&.fN]
-BDFChar: 4790 8457 6 0 5 0 7
->d.$E&.fBa
-BDFChar: 4791 128163 12 1 11 -2 9
-"s=5&#Tu<]4og'4s+(&urIFouHN650
-BDFChar: 4792 127918 12 1 10 0 7
-1B;oT?@\##hSB0,s1i&n
-BDFChar: 4793 128190 12 1 11 -2 8
-s+'W)nR1ios5<q8^gOrchdF6-s53kW
-BDFChar: 4794 128191 12 1 11 -2 8
-%KJA:6pO/UO!'<&SfhQ/6pNV[%KHJ/
-BDFChar: 4795 128192 12 1 11 -2 8
-%KJA:6pO/UO!'<&SfhQ/6pNV[%KHJ/
-BDFChar: 4796 128164 12 1 11 -2 8
-!T3r#!'gO7*<69$#QW3O>QB9S^]4?7
-BDFChar: 4797 128193 12 1 11 -1 7
-GQ<BsK>@C-J09@bJ09@bJ%u$a
-BDFChar: 4798 128194 12 1 11 -1 7
-DubmuJH2>#O<C2]TKp;CIfKHK
-BDFChar: 4799 128153 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4800 128154 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4801 128155 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4802 128156 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4803 128150 12 1 11 -2 7
-EPVHZrZL*+hr%kWa+-AS/c[-s
-BDFChar: 4804 128151 12 1 11 -2 7
-EPT_)[@k.)^S"q!/q=Z:$312/
-BDFChar: 4805 128148 12 1 11 -2 7
-EPVJ0rS[S2pY^D64b+IO$312/
-BDFChar: 4806 128140 12 1 11 0 7
-s5:\#Wh>t,T-1;0`*iW'
-BDFChar: 4807 129293 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4808 129294 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4809 129505 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4810 128157 12 1 11 -2 7
-EPVV4PMgs66m.]/It/U@%KHV3
-BDFChar: 4811 128147 12 1 11 -2 9
-EPR)I0n;MS4+MgrJ&$QL5CagU%KHV3
-BDFChar: 4812 128149 12 1 11 -2 8
-!C-bF"5j3qCk2KbrW)otHiQ,+&-)\1
-BDFChar: 4813 128152 12 1 11 -2 8
-huJi=]7>CHJ&$QL4b+T(%q#Ou!5JR7
-BDFChar: 4814 128158 12 1 11 -2 8
-!C/a)6f<O2Ck2L-rZM2*I=O9W&-)\1
-BDFChar: 4815 128420 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4816 127892 12 2 10 -1 7
-G6%Yns+(-"IfMY4)upfU0E;(Q
-BDFChar: 4817 128189 12 1 11 -2 8
-s5<G*^gP(<NZa3%NZc6t^gQ]js53kW
-BDFChar: 4818 129653 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4819 129654 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4820 129655 12 1 11 -2 7
-EPVJ0s5<q8s58CB5CagU%KHV3
-BDFChar: 4821 128386 12 1 11 0 7
-s5:\#TV.DiRinN"^gR3#
-BDFChar: 4822 128387 12 1 11 0 7
-s58DMJY9]LJ0;QKJ0=mM
-BDFChar: 4823 9993 12 1 11 0 7
-s5:\#TV.DiRinN"^gR3#
-BDFChar: 4824 8987 12 3 9 -1 8
-rdo`L3&jm#rr)lt
-BDFChar: 4825 65532 6 1 5 -2 8
-fSBN`L]E6e!/T8-
-BDFChar: 4826 65533 6 0 6 -2 8
-&3)Xc<;(-U-o_b<
-BDFChar: 4827 128336 12 1 11 -2 8
-%KJ566pO4,L*2-lJ07*B5X7&S%KHJ/
-BDFChar: 4828 128337 12 1 11 -2 8
-%KJ566pO.*Kcl*mJ07*B5X7&S%KHJ/
-BDFChar: 4829 128338 12 1 11 -2 8
-%KJ566pO.*KHQ$mJ07*B5X7&S%KHJ/
-BDFChar: 4830 128339 12 1 11 -2 8
-%KJ566pO.*KHQ!lJKR3C5X7&S%KHJ/
-BDFChar: 4831 128340 12 1 11 -2 8
-%KJ566pO.*KHPpjJfmBF5X7&S%KHJ/
-BDFChar: 4832 128341 12 1 11 -2 8
-%KJ566pO.*KHPpjKHNZJ5X7&S%KHJ/
-BDFChar: 4833 128342 12 1 11 -2 8
-%KJ566pO.*KHPpjL`f5R5X7&S%KHJ/
-BDFChar: 4834 128343 12 1 11 -2 8
-%KJ566pO.*KHQ3rO<?eR5X7&S%KHJ/
-BDFChar: 4835 128344 12 1 11 -2 8
-%KJ566pO.*KHQd-J07*B5X7&S%KHJ/
-BDFChar: 4836 128345 12 1 11 -2 8
-%KJ566pO.*PTYo-J07*B5X7&S%KHJ/
-BDFChar: 4837 128346 12 1 11 -2 8
-%KJ566pOF2N$*crJ07*B5X7&S%KHJ/
-BDFChar: 4838 128347 12 1 11 -2 8
-%KJ566pO.*KHPpjJ07*B5X7&S%KHJ/
-BDFChar: 4839 128348 12 1 11 -2 8
-%KJ565X7Y$Jfo^hKHNZJ6pNJW%KHJ/
-BDFChar: 4840 128349 12 1 11 -2 8
-%KJ565X7S"JKT[iKHNZJ6pNJW%KHJ/
-BDFChar: 4841 128350 12 1 11 -2 8
-%KJ565X7S"J09UiKHNZJ6pNJW%KHJ/
-BDFChar: 4842 128351 12 1 11 -2 8
-%KJ565X7S"J09RhKcicK6pNJW%KHJ/
-BDFChar: 4843 128352 12 1 11 -2 8
-%KJ565X7S"J09LfL*/rN6pNJW%KHJ/
-BDFChar: 4844 128353 12 1 11 -2 8
-%KJ565X7S"J09LfKHNZJ6pNJW%KHJ/
-BDFChar: 4845 128354 12 1 11 -2 8
-%KJ565X7S"J09LfN$(eZ6pNJW%KHJ/
-BDFChar: 4846 128355 12 1 11 -2 8
-%KJ565X7S"J09dnPTW@Z6pNJW%KHJ/
-BDFChar: 4847 128356 12 1 11 -2 8
-%KJ565X7S"J0:@)KHNZJ6pNJW%KHJ/
-BDFChar: 4848 128357 12 1 11 -2 8
-%KJ565X7S"O<BK)KHNZJ6pNJW%KHJ/
-BDFChar: 4849 128358 12 1 11 -2 8
-%KJ565X7k*L`h?nKHNZJ6pNJW%KHJ/
-BDFChar: 4850 128359 12 1 11 -2 8
-%KJ565X7_&KHPpjKHNZJ6pNJW%KHJ/
-BDFChar: 4851 9733 6 1 5 1 6
-+<^GuE/4Jo
-BDFChar: 4852 9734 6 1 5 1 6
-+<^GUE/4Jo
-BDFChar: 4853 9312 12 1 11 -2 8
-*ro]a5X9uFN$*crKHQ9t5X8_m*rl9@
-BDFChar: 4854 9313 12 1 11 -2 8
-*ro]a5X:8NJfo^hL`h^#5X8_m*rl9@
-BDFChar: 4855 9314 12 1 11 -2 8
-*ro]a5X:8NJfo^hJfp!p5X8_m*rl9@
-BDFChar: 4856 9315 12 1 11 -2 8
-*ro]a5X:&HMBIp%JfoXf5X8_m*rl9@
-BDFChar: 4857 9316 12 1 11 -2 8
-*ro]a5X:>PL`hX!Jfp!p5X8_m*rl9@
-BDFChar: 4858 9317 12 1 11 -2 8
-*ro]a5X9uFL`hX!MBIQp5X8_m*rl9@
-BDFChar: 4859 9318 12 1 11 -2 8
-*ro]a5X:>PJfoXfKHPpj5X8_m*rl9@
-BDFChar: 4860 9319 12 1 11 -2 8
-*ro]a5X9uFMBIQpMBIQp5X8_m*rl9@
-BDFChar: 4861 9320 12 1 11 -2 8
-*ro]a5X9uFMBIWrJfo^h5X8_m*rl9@
-BDFChar: 4862 9321 12 1 11 -2 8
-*ro]a5X:GSZCmARP+]?.5X8_m*rl9@
-BDFChar: 4863 9322 12 1 11 -2 8
-*ro]a5X:GSZQPAQOW_9/5X8_m*rl9@
-BDFChar: 4864 9323 12 1 11 -2 8
-*ro]a5X:MUYb7+$Os%B05X8_m*rl9@
-BDFChar: 4865 9324 12 1 11 -2 8
-*ro]a5X:MUYb7+$OJ'3.5X8_m*rl9@
-BDFChar: 4866 9325 12 1 11 -2 8
-*ro]a5X:I)ZCmDSOJ'+V5X8_m*rl9@
-BDFChar: 4867 9326 12 1 11 -2 8
-*ro]a5X:O+Z65>ROJ'3.5X8_m*rl9@
-BDFChar: 4868 9327 12 1 11 -2 8
-*ro]a5X:GSZ65>RP+]?.5X8_m*rl9@
-BDFChar: 4869 9328 12 1 11 -2 8
-*ro]a5X:O+Yb7)NOW_1W5X8_m*rl9@
-BDFChar: 4870 9329 12 1 11 -2 8
-*ro]a5X:GSZCm=&P+]?.5X8_m*rl9@
-BDFChar: 4871 9330 12 1 11 -2 8
-*ro]a5X:GSZCm>QOJ'-,5X8_m*rl9@
-BDFChar: 4872 9331 12 1 11 -2 8
-*ro]a5X;RsMP--*U7f%>5X8_m*rl9@
-BDFChar: 4873 9450 12 1 11 -2 8
-*ro]a5X9uFMBId!MBIQp5X8_m*rl9@
-BDFChar: 4874 9470 12 1 11 -2 8
-*rpf+@).mIZCmARP+]?.@).9-*rl9@
-BDFChar: 4875 9461 12 1 11 -2 8
-*rpf+@).F<N$*crKHQ9t@).9-*rl9@
-BDFChar: 4876 9462 12 1 11 -2 8
-*rpf+@).^DJfo^hL`h^#@).9-*rl9@
-BDFChar: 4877 9463 12 1 11 -2 8
-*rpf+@).^DJfo^hJfp!p@).9-*rl9@
-BDFChar: 4878 9464 12 1 11 -2 8
-*rpf+@).L>MBIp%JfoXf@).9-*rl9@
-BDFChar: 4879 9465 12 1 11 -2 8
-*rpf+@).dFL`hX!Jfp!p@).9-*rl9@
-BDFChar: 4880 9466 12 1 11 -2 8
-*rpf+@).F<L`hX!MBIQp@).9-*rl9@
-BDFChar: 4881 9467 12 1 11 -2 8
-*rpf+@).dFJfoXfKHPpj@).9-*rl9@
-BDFChar: 4882 9468 12 1 11 -2 8
-*rpf+@).F<MBIQpMBIQp@).9-*rl9@
-BDFChar: 4883 9469 12 1 11 -2 8
-*rpf+@).F<MBIWrJfo^h@).9-*rl9@
-BDFChar: 4884 9460 12 2 10 -1 7
-4og'4SUg!Ug46bbNIZKY4obQ_
-BDFChar: 4885 9459 12 2 10 -1 7
-4og'4h11rEgjn73NIZKY4obQ_
-BDFChar: 4886 9458 12 2 10 -1 7
-4og'4h11rEh1440NIZKY4obQ_
-BDFChar: 4887 9457 12 2 10 -1 7
-4og'4fRTQDhLOF4NIZKY4obQ_
-BDFChar: 4888 9456 12 2 10 -1 7
-4og'4h11uFfmqe,NIZKY4obQ_
-BDFChar: 4889 9455 12 2 10 -1 7
-4og'4fRTHAfmqq0M1C'U4obQ_
-BDFChar: 4890 9454 12 2 10 -1 7
-4og'4gjkiDfRVh/NduTZ4obQ_
-BDFChar: 4891 9453 12 2 10 -1 7
-4og'4fmoZEh14@4M1C'U4obQ_
-BDFChar: 4892 9452 12 2 10 -1 7
-4og'4fmoZEh1471Lk'sT4obQ_
-BDFChar: 4893 9451 12 2 10 -1 7
-4og'4h11oDh14=3Lk'sT4obQ_
-BDFChar: 4894 9471 12 2 10 -1 7
-4og'4pOMR[l[\;OpOI_n4obQ_
-BDFChar: 4895 10102 12 2 10 -1 7
-4og'4pOMFWpON!gj+)UZ4obQ_
-BDFChar: 4896 10103 12 2 10 -1 7
-4og'4kCEG[pOM^_j+)UZ4obQ_
-BDFChar: 4897 10104 12 2 10 -1 7
-4og'4kCEG[pON-kkCA$^4obQ_
-BDFChar: 4898 10105 12 2 10 -1 7
-4og'4o76.Wj+.#Wqga.r4obQ_
-BDFChar: 4899 10106 12 2 10 -1 7
-4og'4j+-TKkCEG[kCA$^4obQ_
-BDFChar: 4900 10107 12 2 10 -1 7
-4og'4pOM^_kCDlKpOI_n4obQ_
-BDFChar: 4901 10108 12 2 10 -1 7
-4og'4j+.#WqgeEkpOI_n4obQ_
-BDFChar: 4902 10109 12 2 10 -1 7
-4og'4pOMR[pOMR[pOI_n4obQ_
-BDFChar: 4903 10110 12 2 10 -1 7
-4og'4pOMR[o76^gpOI_n4obQ_
-BDFChar: 4904 10111 12 2 10 -1 7
-4og'4h11rEg47n-NIZKY4obQ_
-BDFChar: 4905 10122 12 2 10 -1 7
-4og'4pOMFWpON!gj+)UZ4obQ_
-BDFChar: 4906 10123 12 2 10 -1 7
-4og'4kCEG[pOM^_j+)UZ4obQ_
-BDFChar: 4907 10124 12 2 10 -1 7
-4og'4kCEG[pON-kkCA$^4obQ_
-BDFChar: 4908 10125 12 2 10 -1 7
-4og'4o76.Wj+.#Wqga.r4obQ_
-BDFChar: 4909 10126 12 2 10 -1 7
-4og'4j+-TKkCEG[kCA$^4obQ_
-BDFChar: 4910 10127 12 2 10 -1 7
-4og'4pOM^_kCDlKpOI_n4obQ_
-BDFChar: 4911 10128 12 2 10 -1 7
-4og'4j+.#WqgeEkpOI_n4obQ_
-BDFChar: 4912 10129 12 2 10 -1 7
-4og'4pOMR[pOMR[pOI_n4obQ_
-BDFChar: 4913 10130 12 2 10 -1 7
-4og'4pOMR[o76^gpOI_n4obQ_
-BDFChar: 4914 10131 12 2 10 -1 7
-4og'4h11rEg47n-NIZKY4obQ_
-BDFChar: 4915 10112 12 1 11 -2 8
-*ro]a5X9uFN$*crKHQ9t5X8_m*rl9@
-BDFChar: 4916 10113 12 1 11 -2 8
-*ro]a5X:8NJfo^hL`h^#5X8_m*rl9@
-BDFChar: 4917 10114 12 1 11 -2 8
-*ro]a5X:8NJfo^hJfp!p5X8_m*rl9@
-BDFChar: 4918 10115 12 1 11 -2 8
-*ro]a5X:&HMBIp%JfoXf5X8_m*rl9@
-BDFChar: 4919 10116 12 1 11 -2 8
-*ro]a5X:>PL`hX!Jfp!p5X8_m*rl9@
-BDFChar: 4920 10117 12 1 11 -2 8
-*ro]a5X9uFL`hX!MBIQp5X8_m*rl9@
-BDFChar: 4921 10118 12 1 11 -2 8
-*ro]a5X:>PJfoXfKHPpj5X8_m*rl9@
-BDFChar: 4922 10119 12 1 11 -2 8
-*ro]a5X9uFMBIQpMBIQp5X8_m*rl9@
-BDFChar: 4923 10120 12 1 11 -2 8
-*ro]a5X9uFMBIWrJfo^h5X8_m*rl9@
-BDFChar: 4924 10121 12 1 11 -2 8
-*ro]a5X:GSZCmARP+]?.5X8_m*rl9@
-BDFChar: 4925 12881 12 1 11 -2 8
-*ro]a5X;RsM]e-)Tcgt?5X8_m*rl9@
-BDFChar: 4926 12882 12 1 11 -2 8
-*ro]a5X;XuLnKkQU*.(@5X8_m*rl9@
-BDFChar: 4927 12883 12 1 11 -2 8
-*ro]a5X;XuLnKkQTV/n>5X8_m*rl9@
-BDFChar: 4928 12884 12 1 11 -2 8
-*ro]a5X;TIMP-0+TV/ff5X8_m*rl9@
-BDFChar: 4929 12885 12 1 11 -2 8
-*ro]a5X;ZKMBJ**TV/n>5X8_m*rl9@
-BDFChar: 4930 12886 12 1 11 -2 8
-*ro]a5X;RsMBJ**U7f%>5X8_m*rl9@
-BDFChar: 4931 12887 12 1 11 -2 8
-*ro]a5X;ZKLnKj&Tcglg5X8_m*rl9@
-BDFChar: 4932 12888 12 1 11 -2 8
-*ro]a5X;RsMP-(SU7f%>5X8_m*rl9@
-BDFChar: 4933 12889 12 1 11 -2 8
-*ro]a5X;RsMP-*)TV/h<5X8_m*rl9@
-BDFChar: 4934 12890 12 1 11 -2 8
-*ro]a5X;RsMP--*MP.3s5X8_m*rl9@
-BDFChar: 4935 12891 12 1 11 -2 8
-*ro]a5X;RsM]e-)M'0-t5X8_m*rl9@
-BDFChar: 4936 12892 12 1 11 -2 8
-*ro]a5X;XuLnKkQMBK6u5X8_m*rl9@
-BDFChar: 4937 12893 12 1 11 -2 8
-*ro]a5X;XuLnKkQLnM's5X8_m*rl9@
-BDFChar: 4938 12894 12 1 11 -2 8
-*ro]a5X;TIMP-0+LnLuF5X8_m*rl9@
-BDFChar: 4939 12895 12 1 11 -2 8
-*ro]a5X;ZKMBJ**LnM's5X8_m*rl9@
-BDFChar: 4940 12977 12 1 11 -2 8
-*ro]a5X;RsMBJ**MP.3s5X8_m*rl9@
-BDFChar: 4941 12978 12 1 11 -2 8
-*ro]a5X;ZKLnKj&M'0&G5X8_m*rl9@
-BDFChar: 4942 12979 12 1 11 -2 8
-*ro]a5X;RsMP-(SMP.3s5X8_m*rl9@
-BDFChar: 4943 12980 12 1 11 -2 8
-*ro]a5X;RsMP-*)LnM!q5X8_m*rl9@
-BDFChar: 4944 12981 12 1 11 -2 8
-*ro]a5X:_[Wh?qrMP,eK5X8_m*rl9@
-BDFChar: 4945 12982 12 1 11 -2 8
-*ro]a5X:_[X!"qqM'._L5X8_m*rl9@
-BDFChar: 4946 12983 12 1 11 -2 8
-*ro]a5X:e]W1^[DMBIhM5X8_m*rl9@
-BDFChar: 4947 12984 12 1 11 -2 8
-*ro]a5X:e]W1^[DLnKYK5X8_m*rl9@
-BDFChar: 4948 12985 12 1 11 -2 8
-*ro]a5X:a1Wh?tsLnKQs5X8_m*rl9@
-BDFChar: 4949 12986 12 1 11 -2 8
-*ro]a5X:g3WZ\nrLnKYK5X8_m*rl9@
-BDFChar: 4950 12987 12 1 11 -2 8
-*ro]a5X:_[WZ\nrMP,eK5X8_m*rl9@
-BDFChar: 4951 12988 12 1 11 -2 8
-*ro]a5X:g3W1^YnM'.Wt5X8_m*rl9@
-BDFChar: 4952 12989 12 1 11 -2 8
-*ro]a5X:_[Wh?mFMP,eK5X8_m*rl9@
-BDFChar: 4953 12990 12 1 11 -2 8
-*ro]a5X:_[Wh?nqLnKSI5X8_m*rl9@
-BDFChar: 4954 12991 12 1 11 -2 8
-*ro]a5X;k&U7efbMP.3s5X8_m*rl9@
-BDFChar: 4955 12964 12 1 11 -2 8
-*ro]a6pQDJLEM6mKHQm05X8_m*rl9@
-BDFChar: 4956 12965 12 1 11 -2 8
-*ro]a6pSM[UnFNV^S$6&6pP.q*rl9@
-BDFChar: 4957 12966 12 1 11 -2 8
-*ro]a5X:qaKHQ!lKcl$k6pP.q*rl9@
-BDFChar: 4958 12967 12 1 11 -2 8
-*ro]a83idiL`ha$Os$)65X8_m*rl9@
-BDFChar: 4959 12968 12 1 11 -2 8
-*ro]a83idiL`ha$PouD95X8_m*rl9@
-BDFChar: 4960 12963 12 1 11 -2 8
-*ro]a5X<)WKHQU(PT[`65X8_m*rl9@
-BDFChar: 4961 12928 12 1 11 -2 8
-*ro]a5X9iBJ0:I,J09@b5X8_m*rl9@
-BDFChar: 4962 12929 12 1 11 -2 8
-*ro]a5X:>PJ09@bJ0:I,5X8_m*rl9@
-BDFChar: 4963 12930 12 1 11 -2 8
-*ro]a5X:qaJ09jpJ0:I,5X8_m*rl9@
-BDFChar: 4964 12931 12 1 11 -2 8
-*ro]a5X<)WWh?\kTV0&m5X8_m*rl9@
-BDFChar: 4965 12932 12 1 11 -2 8
-*ro]a?U08eT-/t5M'0R+5X8_m*rl9@
-BDFChar: 4966 12933 12 1 11 -2 8
-*ro]a6pR@eJ09^lMBJ$(5X8_m*rl9@
-BDFChar: 4967 12934 12 1 11 -2 8
-*ro]a83i(U]HE"QM'.j%5X8_m*rl9@
-BDFChar: 4968 12935 12 1 11 -2 8
-*ro]a:-aCRMBId!OW]c/5X8_m*rl9@
-BDFChar: 4969 12936 12 1 11 -2 8
-*ro]a83htRSfin5MP-.U5X8_m*rl9@
-BDFChar: 4970 12937 12 1 11 -2 8
-*ro]a6pQDJKHS%&KHPpj6pP.q*rl9@
-BDFChar: 4971 12938 12 1 11 -2 8
-*ro]a:I'aZO!'9%O!'9%;a=a+*rl9@
-BDFChar: 4972 12939 12 1 11 -2 8
-*ro]a6pR"[Pot`&MBJ$(5X8_m*rl9@
-BDFChar: 4973 12940 12 1 11 -2 8
-*ro]a6pQGK^*&FYPoukF9L*"$*rl9@
-BDFChar: 4974 12941 12 1 11 -2 8
-*ro]a6pQDJT-/e0NZaT06pP.q*rl9@
-BDFChar: 4975 12942 12 1 11 -2 8
-*ro]a:-apaY+UFj^S$i7J&#I-*rl9@
-BDFChar: 4976 12943 12 1 11 -2 8
-*ro]a6pQDJT-/e0KHS%&5X8_m*rl9@
-BDFChar: 4977 12944 12 1 11 -2 8
-*ro]a?U0_rOW^8=OW]c/?U/#7*rl9@
-BDFChar: 4978 13008 12 1 11 -2 8
-*ro]a5X:qaKcl*mKHPpj83gRu*rl9@
-BDFChar: 4979 13009 12 1 11 -2 8
-*ro]a5X9oDKHQd-KHPpj5X8_m*rl9@
-BDFChar: 4980 13010 12 1 11 -2 8
-*ro]a6pR@eOW]c/Jfo^h5X8_m*rl9@
-BDFChar: 4981 13011 12 1 11 -2 8
-*ro]a5X:>PKHPpjKHQm05X8_m*rl9@
-BDFChar: 4982 13012 12 1 11 -2 8
-*ro]a5X9oDT-/k2MBJ')5X8_m*rl9@
-BDFChar: 4983 13013 12 1 11 -2 8
-*ro]a5X:,JT-/t5M'/!)5X8_m*rl9@
-BDFChar: 4984 13014 12 1 11 -2 8
-*ro]a5X9uFT-/e0T-/e05X8_m*rl9@
-BDFChar: 4985 13015 12 1 11 -2 8
-*ro]a83i4YOW]2tJfp!p5X8_m*rl9@
-BDFChar: 4986 13016 12 1 11 -2 8
-*ro]a83i4YPTYW%KHQ'n5X8_m*rl9@
-BDFChar: 4987 13017 12 1 11 -2 8
-*ro]a5X:qaJKTLdJKUR-5X8_m*rl9@
-BDFChar: 4988 13018 12 1 11 -2 8
-*ro]a8jJ7VT-0"6MBIKn6pP.q*rl9@
-BDFChar: 4989 13019 12 1 11 -2 8
-*ro]a5X:_[JKU@'JfpR+5X8_m*rl9@
-BDFChar: 4990 13020 12 1 11 -2 8
-*ro]a5X:qaJKTOeL*2m,5X8_m*rl9@
-BDFChar: 4991 13021 12 1 11 -2 8
-*ro]a83htRT-0"6L`ha$5X8_m*rl9@
-BDFChar: 4992 13022 12 1 11 -2 8
-*ro]a5X:GSOW]K'Jfp!p5X8_m*rl9@
-BDFChar: 4993 13023 12 1 11 -2 8
-*ro]a83i4YOW]?#Jfp$q5X8_m*rl9@
-BDFChar: 4994 13024 12 1 11 -2 8
-*ro]a69pJPKHQm0KHPpj83gRu*rl9@
-BDFChar: 4995 13025 12 1 11 -2 8
-*ro]a5X:SWPotW#Jfp!p5X8_m*rl9@
-BDFChar: 4996 13026 12 1 11 -2 8
-*ro]a5X:>PJ0:I,KHPpj83gRu*rl9@
-BDFChar: 4997 13027 12 1 11 -2 8
-*ro]a6pQDJL*20mKHPpj5X8_m*rl9@
-BDFChar: 4998 13028 12 1 11 -2 8
-*ro]a6pQDJT-/e0KHPpj83gRu*rl9@
-BDFChar: 4999 13029 12 1 11 -2 8
-*ro]a5X:>PJ09@bJ0:I,5X8_m*rl9@
-BDFChar: 5000 13030 12 1 11 -2 8
-*ro]a5X:qaJKTXhJfpU,5X8_m*rl9@
-BDFChar: 5001 13031 12 1 11 -2 8
-*ro]a6pR@eJKT[iSKNS.6pP.q*rl9@
-BDFChar: 5002 13032 12 1 11 -2 8
-*ro]a5X9oDJfoXfKHQX)5X8_m*rl9@
-BDFChar: 5003 13033 12 1 11 -2 8
-*ro]a5X:2LMBI`uOW]c/5X8_m*rl9@
-BDFChar: 5004 13034 12 1 11 -2 8
-*ro]a5X:DRP9?A<O<BW-:I&='*rl9@
-BDFChar: 5005 13035 12 1 11 -2 8
-*ro]a5X:qaJKTLdJfp!p5X8_m*rl9@
-BDFChar: 5006 13036 12 1 11 -2 8
-*ro]a5X:8NOs$G@J=qE85X8_m*rl9@
-BDFChar: 5007 13037 12 1 11 -2 8
-*ro]a6pR@eKHQO&Pot`&5X8_m*rl9@
-BDFChar: 5008 13038 12 1 11 -2 8
-*ro]a5X:qaJKTgmKHPjh5X8_m*rl9@
-BDFChar: 5009 13039 12 1 11 -2 8
-*ro]a5X:>PJKTmoJfpR+6U5%p*rl9@
-BDFChar: 5010 13040 12 1 11 -2 8
-*ro]a6pQDJL`hKrOs$;<5X8_m*rl9@
-BDFChar: 5011 13041 12 1 11 -2 8
-*ro]a5X9lCM'.NqL*2m,5X8_m*rl9@
-BDFChar: 5012 13042 12 1 11 -2 8
-*ro]a5X:n`L`i<4L`h^#5X8_m*rl9@
-BDFChar: 5013 13043 12 1 11 -2 8
-*ro]a83htRO!'i5KHPpj6pP.q*rl9@
-BDFChar: 5014 13044 12 1 11 -2 8
-*ro]a5X:>PJfoXfJfp[.5X8_m*rl9@
-BDFChar: 5015 13045 12 1 11 -2 8
-*ro]a5X:n`JfpX-JfpX-5X8_m*rl9@
-BDFChar: 5016 13046 12 1 11 -2 8
-*ro]a5X:n`J0:I,JKTOe9L*"$*rl9@
-BDFChar: 5017 13047 12 1 11 -2 8
-*ro]a5X:2LMBId!Jfo^h83gRu*rl9@
-BDFChar: 5018 13048 12 1 11 -2 8
-*ro]a5X:2LMBId!MP-.U5X8_m*rl9@
-BDFChar: 5019 13049 12 1 11 -2 8
-*ro]a5X:,JL`hNsMBIj#5X8_m*rl9@
-BDFChar: 5020 13050 12 1 11 -2 8
-*ro]a5X:qaOW]c/OW^8=5X8_m*rl9@
-BDFChar: 5021 13051 12 1 11 -2 8
-*ro]a5X:qaOW]2tJfp!p5X8_m*rl9@
-BDFChar: 5022 13052 12 1 11 -2 8
-*ro]a5X9oDT-0"6T-/_.5X8_m*rl9@
-BDFChar: 5023 13053 12 1 11 -2 8
-*ro]a5X:qaJKT[iKHQm05X8_m*rl9@
-BDFChar: 5024 13054 12 1 11 -2 8
-*ro]a5X:qaJKUR-JKTOe9L*"$*rl9@
-BDFChar: 5025 9398 12 1 11 -2 8
-*ro]a5X9uFMBId!T-07=5X8_m*rl9@
-BDFChar: 5026 9399 12 1 11 -2 8
-*ro]a5X:n`OW^5<OW^5<5X8_m*rl9@
-BDFChar: 5027 9400 12 1 11 -2 8
-*ro]a5X:>POW]`.OW]Z,5X8_m*rl9@
-BDFChar: 5028 9401 12 1 11 -2 8
-*ro]a5X:n`OW]c/OW^5<5X8_m*rl9@
-BDFChar: 5029 9402 12 1 11 -2 8
-*ro]a5X:qaO<C,;O<C/<5X8_m*rl9@
-BDFChar: 5030 9403 12 1 11 -2 8
-*ro]a5X:qaO<C,;O<BW-5X8_m*rl9@
-BDFChar: 5031 9404 12 1 11 -2 8
-*ro]a5X:AQO<B`0OW]]-5X8_m*rl9@
-BDFChar: 5032 9405 12 1 11 -2 8
-*ro]a5X:GSOW^8=OW]c/5X8_m*rl9@
-BDFChar: 5033 9424 12 1 11 -2 8
-*ro]a5X:8NJfp'rOs#c-5X8_m*rl9@
-BDFChar: 5034 9425 12 1 11 -2 8
-*ro]a83htRNZa0$M'.g$5X8_m*rl9@
-BDFChar: 5035 9426 12 1 11 -2 8
-*ro]a5X:>POW]`.OW]Z,5X8_m*rl9@
-BDFChar: 5036 9427 12 1 11 -2 8
-*ro]a69p,FNZaK-Os#c-5X8_m*rl9@
-BDFChar: 5037 9428 12 1 11 -2 8
-*ro]a5X:8NOs$>=O<BQ+5X8_m*rl9@
-BDFChar: 5038 9429 12 1 11 -2 8
-*ro]a69p2HNZ`utKHPpj5X8_m*rl9@
-BDFChar: 5039 9430 12 1 11 -2 8
-*ro]a5X:>POs#o1NZ`or9L*"$*rl9@
-BDFChar: 5040 9431 12 1 11 -2 8
-*ro]a83htRN$+!#MBId!5X8_m*rl9@
-BDFChar: 5041 9432 12 1 11 -2 8
-*ro]a6pQ8FKHPpjKHPpj5X8_m*rl9@
-BDFChar: 5042 9433 12 1 11 -2 8
-*ro]a69p&DJfoXfJfoXf9L*"$*rl9@
-BDFChar: 5043 9434 12 1 11 -2 8
-*ro]a83htRMBIj#MBId!5X8_m*rl9@
-BDFChar: 5044 9435 12 1 11 -2 8
-*ro]a6pQDJKHPpjKHPpj5X8_m*rl9@
-BDFChar: 5045 9436 12 1 11 -2 8
-*ro]a5X:b\Pou>7Pou>75X8_m*rl9@
-BDFChar: 5046 9437 12 1 11 -2 8
-*ro]a5X:8NMBId!MBId!5X8_m*rl9@
-BDFChar: 5047 9438 12 1 11 -2 8
-*ro]a5X:>POW]c/OW]Z,5X8_m*rl9@
-BDFChar: 5048 9439 12 1 11 -2 8
-*ro]a5X:>PM'.WtNZa-#83gRu*rl9@
-BDFChar: 5049 9440 12 1 11 -2 8
-*ro]a5X:>POs#o1NZ`or69nqo*rl9@
-BDFChar: 5050 9441 12 1 11 -2 8
-*ro]a5X:2LN$*p!L`hKr5X8_m*rl9@
-BDFChar: 5051 9442 12 1 11 -2 8
-*ro]a5X:&HL`h?nJfp!p5X8_m*rl9@
-BDFChar: 5052 9443 12 1 11 -2 8
-*ro]a6pQDJNZ`utKHPjh5X8_m*rl9@
-BDFChar: 5053 9444 12 1 11 -2 8
-*ro]a5X:2LMBId!MBIWr5X8_m*rl9@
-BDFChar: 5054 9445 12 1 11 -2 8
-*ro]a5X:2LMBId!KHPpj5X8_m*rl9@
-BDFChar: 5055 9446 12 1 11 -2 8
-*ro]a5X:SWPou>7MBId!5X8_m*rl9@
-BDFChar: 5056 9447 12 1 11 -2 8
-*ro]a5X:2LMBIQpMBId!5X8_m*rl9@
-BDFChar: 5057 9448 12 1 11 -2 8
-*ro]a5X:2LMBId!L*2'j9L*"$*rl9@
-BDFChar: 5058 9449 12 1 11 -2 8
-*ro]a5X:>PJfo^hL`h^#5X8_m*rl9@
-BDFChar: 5059 9406 12 1 11 -2 8
-*ro]a5X9uFKHPpjKHPpj5X8_m*rl9@
-BDFChar: 5060 9407 12 1 11 -2 8
-*ro]a5X9oDJfoXfOs#]+5X8_m*rl9@
-BDFChar: 5061 9408 12 1 11 -2 8
-*ro]a5X:GSOs$8;Os#l05X8_m*rl9@
-BDFChar: 5062 9409 12 1 11 -2 8
-*ro]a5X:,JL`hKrL`ha$5X8_m*rl9@
-BDFChar: 5063 9410 12 1 11 -2 8
-*ro]a5X:GSRimt=Pou235X8_m*rl9@
-BDFChar: 5064 9411 12 1 11 -2 8
-*ro]a5X:GSR37b;P9>u15X8_m*rl9@
-BDFChar: 5065 9412 12 1 11 -2 8
-*ro]a5X:>POW]c/OW]Z,5X8_m*rl9@
-BDFChar: 5066 9413 12 1 11 -2 8
-*ro]a5X:>PM'.g$L`hKr5X8_m*rl9@
-BDFChar: 5067 9414 12 1 11 -2 8
-*ro]a5X:>POW]c/Pou)06U5%p*rl9@
-BDFChar: 5068 9415 12 1 11 -2 8
-*ro]a5X:>PM'.g$MBI`u5X8_m*rl9@
-BDFChar: 5069 9416 12 1 11 -2 8
-*ro]a5X:>PO<BQ+JKTsq5X8_m*rl9@
-BDFChar: 5070 9417 12 1 11 -2 8
-*ro]a5X:qaKHPpjKHPpj5X8_m*rl9@
-BDFChar: 5071 9418 12 1 11 -2 8
-*ro]a5X:GSOW]c/OW]Z,5X8_m*rl9@
-BDFChar: 5072 9419 12 1 11 -2 8
-*ro]a5X:GSOW]N(MBIQp5X8_m*rl9@
-BDFChar: 5073 9420 12 1 11 -2 8
-*ro]a5X:SWPou>7MBId!5X8_m*rl9@
-BDFChar: 5074 9421 12 1 11 -2 8
-*ro]a5X:GSMBIQpMBJ$(5X8_m*rl9@
-BDFChar: 5075 9422 12 1 11 -2 8
-*ro]a5X:GSMBIQpKHPpj5X8_m*rl9@
-BDFChar: 5076 9423 12 1 11 -2 8
-*ro]a5X:qaJfo^hL`i<45X8_m*rl9@
-BDFChar: 5077 894 6 2 3 -2 5
-^q]pM^q`3c
-BDFChar: 5078 900 6 3 4 6 7
-5_&h7
-BDFChar: 5079 901 6 2 4 6 9
-+@#q"
-BDFChar: 5080 903 6 2 4 3 5
-5i=m-
-BDFChar: 5081 8355 6 1 5 0 7
-GX+N55k%$(
-BDFChar: 5082 9674 6 1 5 -1 7
-+<XKWLepnj+92BA
-BDFChar: 5083 64258 6 1 5 0 8
-0MkU8:f'tb=9&=$
-BDFChar: 5084 9711 12 1 11 -2 8
-*ro]a5X9iBJ09@bJ09@b5X8_m*rl9@
-BDFChar: 5085 127921 12 1 11 -2 8
-%KJ_DJ&$3BlJUa]lJQg#J&":!%KHJ/
-BDFChar: 5086 126980 12 2 11 -2 8
-IfP"LLqpa?Wkc?aLqnh^JAD3#It.M!
-BDFChar: 5087 128174 12 1 11 -2 8
-%KI4DEPTt0MBG/L21T)M6pPY*4+I;2
-BDFChar: 5088 128175 12 1 11 -2 8
-!'g\F/tcsPlJO9[,QK"G/cYpf*WQ0?
-BDFChar: 5089 128187 12 1 11 -2 8
-J&"<75X7S"5X7S"J&#g7eR5&Cs53kW
-BDFChar: 5090 128197 12 1 11 -2 8
-s5<q8s58DMUnE5\UnE5\UnE5\s53kW
-BDFChar: 5091 128198 12 1 11 -2 8
-+Fr?Ws58DMUnE5\UnE5\UnE6Gs1eU7
-BDFChar: 5092 128231 12 1 11 0 7
-s5;11]:b9/QQWo5c=$\1
-BDFChar: 5093 128425 12 3 9 -2 8
-rdob$ri5stri5qt
-BDFChar: 5094 128426 12 1 11 -2 8
-s5:ZMs5<e4p#,`*s5<BSnR1lPs*t(L
-BDFChar: 5095 128427 12 1 11 -2 8
-s5:\#hdF6-^gR3#s5:`OdGRm[5MuMA
-BDFChar: 5096 128428 12 1 11 -2 8
-s58FcJAD3Cqr%#&qr%M4qr%A0s53kW
-BDFChar: 5097 128429 12 1 11 -1 7
-s58DM\KIoF\KHDF^S%6ms53kW
-BDFChar: 5098 128435 12 1 11 -2 8
-IfMb75la1N5lcB7+ohTCIitbas*t(L
-BDFChar: 5099 128440 12 1 11 -2 8
-%KJA:6pO/UO!'<&SfhQ/6pNV[%KHJ/
-BDFChar: 5100 128126 12 1 11 -1 8
-+Fk%(*rs'KY+Y4@J&":!0n:2C
-BDFChar: 5101 127800 12 1 11 -2 8
-%KIRNJ&(s>lJQZt4+MIhJ&$QL4+I;2
-BDFChar: 5102 128039 12 1 11 -2 8
-%KI4D&HEOG0n=8Z@)1^YZ(N_"4+I;2
-BDFChar: 5103 119558 12 3 10 0 6
-rrE'!rrE'!
-BDFChar: 5104 119559 12 3 10 0 6
-rrE'!rrD3^
-BDFChar: 5105 119560 12 3 10 0 6
-rrE'!rrCdR
-BDFChar: 5106 119561 12 3 10 0 6
-rrE'!k5bM^
-BDFChar: 5107 119562 12 3 10 0 6
-rrE'!k5aZF
-BDFChar: 5108 119563 12 3 10 0 6
-rrE'!k5a6:
-BDFChar: 5109 119564 12 3 10 0 6
-rrE'!gAq6R
-BDFChar: 5110 119565 12 3 10 0 6
-rrE'!gApC:
-BDFChar: 5111 119566 12 3 10 0 6
-rrE'!gAot.
-BDFChar: 5112 119567 12 3 10 0 6
-rrD3^rrE'!
-BDFChar: 5113 119568 12 3 10 0 6
-rrD3^rrD3^
-BDFChar: 5114 119569 12 3 10 0 6
-rrD3^rrCdR
-BDFChar: 5115 119570 12 3 10 0 6
-rrD3^k5bM^
-BDFChar: 5116 119571 12 3 10 0 6
-rrD3^k5aZF
-BDFChar: 5117 119572 12 3 10 0 6
-rrD3^k5a6:
-BDFChar: 5118 119573 12 3 10 0 6
-rrD3^gAq6R
-BDFChar: 5119 119574 12 3 10 0 6
-rrD3^gApC:
-BDFChar: 5120 119575 12 3 10 0 6
-rrD3^gAot.
-BDFChar: 5121 119576 12 3 10 0 6
-rrCdRrrE'!
-BDFChar: 5122 119577 12 3 10 0 6
-rrCdRrrD3^
-BDFChar: 5123 119578 12 3 10 0 6
-rrCdRrrCdR
-BDFChar: 5124 119579 12 3 10 0 6
-rrCdRk5bM^
-BDFChar: 5125 119580 12 3 10 0 6
-rrCdRk5aZF
-BDFChar: 5126 119581 12 3 10 0 6
-rrCdRk5a6:
-BDFChar: 5127 119582 12 3 10 0 6
-rrCdRgAq6R
-BDFChar: 5128 119583 12 3 10 0 6
-rrCdRgApC:
-BDFChar: 5129 119638 12 3 10 0 6
-gAot.gAot.
-BDFChar: 5130 119637 12 3 10 0 6
-gAot.gApC:
-BDFChar: 5131 119636 12 3 10 0 6
-gAot.gAq6R
-BDFChar: 5132 119635 12 3 10 0 6
-gAot.k5a6:
-BDFChar: 5133 119634 12 3 10 0 6
-gAot.k5aZF
-BDFChar: 5134 119633 12 3 10 0 6
-gAot.k5bM^
-BDFChar: 5135 119632 12 3 10 0 6
-gAot.rrCdR
-BDFChar: 5136 119584 12 3 10 0 6
-rrCdRgAot.
-BDFChar: 5137 119585 12 3 10 0 6
-k5bM^rrE'!
-BDFChar: 5138 119586 12 3 10 0 6
-k5bM^rrD3^
-BDFChar: 5139 119587 12 3 10 0 6
-k5bM^rrCdR
-BDFChar: 5140 119588 12 3 10 0 6
-k5bM^k5bM^
-BDFChar: 5141 119589 12 3 10 0 6
-k5bM^k5aZF
-BDFChar: 5142 119590 12 3 10 0 6
-k5bM^k5a6:
-BDFChar: 5143 119591 12 3 10 0 6
-k5bM^gAq6R
-BDFChar: 5144 119592 12 3 10 0 6
-k5bM^gApC:
-BDFChar: 5145 119593 12 3 10 0 6
-k5bM^gAot.
-BDFChar: 5146 119594 12 3 10 0 6
-k5aZFrrE'!
-BDFChar: 5147 119595 12 3 10 0 6
-k5aZFrrD3^
-BDFChar: 5148 119596 12 3 10 0 6
-k5aZFrrCdR
-BDFChar: 5149 119597 12 3 10 0 6
-k5aZFk5bM^
-BDFChar: 5150 119598 12 3 10 0 6
-k5aZFk5aZF
-BDFChar: 5151 119599 12 3 10 0 6
-k5aZFk5a6:
-BDFChar: 5152 119600 12 3 10 0 6
-k5aZFgAq6R
-BDFChar: 5153 119601 12 3 10 0 6
-k5aZFgApC:
-BDFChar: 5154 119602 12 3 10 0 6
-k5aZFgAot.
-BDFChar: 5155 119603 12 3 10 0 6
-k5a6:rrE'!
-BDFChar: 5156 119604 12 3 10 0 6
-k5a6:rrD3^
-BDFChar: 5157 119605 12 3 10 0 6
-k5a6:rrCdR
-BDFChar: 5158 119606 12 3 10 0 6
-k5a6:k5bM^
-BDFChar: 5159 119607 12 3 10 0 6
-k5a6:k5aZF
-BDFChar: 5160 119608 12 3 10 0 6
-k5a6:k5a6:
-BDFChar: 5161 119609 12 3 10 0 6
-k5a6:gAq6R
-BDFChar: 5162 119610 12 3 10 0 6
-k5a6:gApC:
-BDFChar: 5163 119611 12 3 10 0 6
-k5a6:gAot.
-BDFChar: 5164 119612 12 3 10 0 6
-gAq6RrrE'!
-BDFChar: 5165 119613 12 3 10 0 6
-gAq6RrrD3^
-BDFChar: 5166 119614 12 3 10 0 6
-gAq6RrrCdR
-BDFChar: 5167 119615 12 3 10 0 6
-gAq6Rk5bM^
-BDFChar: 5168 119616 12 3 10 0 6
-gAq6Rk5aZF
-BDFChar: 5169 119617 12 3 10 0 6
-gAq6Rk5a6:
-BDFChar: 5170 119618 12 3 10 0 6
-gAq6RgAq6R
-BDFChar: 5171 119619 12 3 10 0 6
-gAq6RgApC:
-BDFChar: 5172 119620 12 3 10 0 6
-gAq6RgAot.
-BDFChar: 5173 119621 12 3 10 0 6
-gApC:rrE'!
-BDFChar: 5174 119622 12 3 10 0 6
-gApC:rrD3^
-BDFChar: 5175 119623 12 3 10 0 6
-gApC:rrCdR
-BDFChar: 5176 119624 12 3 10 0 6
-gApC:k5bM^
-BDFChar: 5177 119625 12 3 10 0 6
-gApC:k5aZF
-BDFChar: 5178 119626 12 3 10 0 6
-gApC:k5a6:
-BDFChar: 5179 119627 12 3 10 0 6
-gApC:gAq6R
-BDFChar: 5180 119628 12 3 10 0 6
-gApC:gApC:
-BDFChar: 5181 119629 12 3 10 0 6
-gApC:gAot.
-BDFChar: 5182 119630 12 3 10 0 6
-gAot.rrE'!
-BDFChar: 5183 119631 12 3 10 0 6
-gAot.rrD3^
-BDFChar: 5184 9332 12 1 11 -2 8
-+FljF9L+gbKHPpjKHPpj?U-kA+FjFl
-BDFChar: 5185 9333 12 1 11 -2 8
-+Fm3P;*][TJfo^hL`hd%?U-kA+FjFl
-BDFChar: 5186 9334 12 1 11 -2 8
-+Fm3P;*][TL*2$iJKU't:-_'0+FjFl
-BDFChar: 5187 9335 12 1 11 -2 8
-+FldD7R2hROs$JA^EA+N69me$+FjFl
-BDFChar: 5188 9336 12 1 11 -2 8
-+Fmfa:dC*bSfiS,JKU't:-_'0+FjFl
-BDFChar: 5189 9337 12 1 11 -2 8
-+FlpH83i7ZSfj.<OW]c/:-_'0+FjFl
-BDFChar: 5190 9338 12 1 11 -2 8
-+Fmfa5sU#EJfo^hKHQ'n83fF*+FjFl
-BDFChar: 5191 9339 12 1 11 -2 8
-+Fm3P;*^6dNZaH,OW]c/:-_'0+FjFl
-BDFChar: 5192 9340 12 1 11 -2 8
-+Fm3P;*^6dOW]]-JKTOe9L(j.+FjFl
-BDFChar: 5193 9341 12 1 11 -2 8
-+Fm'L9gG6lN?F3'N?F3'?9gb@+FjFl
-BDFChar: 5194 9342 12 1 11 -2 8
-+Fm'L8jJsjMBId!MBId!?U-kA+FjFl
-BDFChar: 5195 9343 12 1 11 -2 8
-+Fm'L9gG*hM'.ZuN$+'%?U-kA+FjFl
-BDFChar: 5196 9344 12 1 11 -2 8
-+Fm'L9gG*hMBI`uM'.d#?9gb@+FjFl
-BDFChar: 5197 9345 12 1 11 -2 8
-+Fm$K90eshN?F3'O._=P>sLY?+FjFl
-BDFChar: 5198 9346 12 1 11 -2 8
-+Fm6Q9L,*jNZa0$M'.d#?9gb@+FjFl
-BDFChar: 5199 9347 12 1 11 -2 8
-+Fm'L9L,*jNZa<(N?F3'?9gb@+FjFl
-BDFChar: 5200 9348 12 1 11 -2 8
-+Fm6Q8O/[dM'.ZuMBId!?9gb@+FjFl
-BDFChar: 5201 9349 12 1 11 -2 8
-+Fm'L9gG6lMBIm$N?F3'?9gb@+FjFl
-BDFChar: 5202 9350 12 1 11 -2 8
-+Fm'L9gG6lN?F-%M'.Wt?9gb@+FjFl
-BDFChar: 5203 9351 12 1 11 -2 8
-+Fm'L<Bu6\N?F3'Pou>7?9gb@+FjFl
-BDFChar: 5204 9372 12 1 11 -2 8
-+Fl^B5X:AQOW]c/OW]i19gCs/+FjFl
-BDFChar: 5205 9373 12 1 11 -2 8
-+Fm9R:dC*bSfj.<OW]c/;*\GQ+FjFl
-BDFChar: 5206 9374 12 1 11 -2 8
-+Fl^B5X:>POW]`.O<BZ.:-_'0+FjFl
-BDFChar: 5207 9375 12 1 11 -2 8
-+FlaC5sTuDO!'Q-OW]c/;*[oB+FjFl
-BDFChar: 5208 9376 12 1 11 -2 8
-+Fl^B5X:>POW^8=O<BZ.:-_'0+FjFl
-BDFChar: 5209 9377 12 1 11 -2 8
-+FlsI83htRSfih3L`hKr83f^2+FjFl
-BDFChar: 5210 9378 12 1 11 -2 8
-+Fl^B:I($bOW]c/OW]]-5sR_$/q<p%
-BDFChar: 5211 9379 12 1 11 -2 8
-+Fm9R:dC*bSfj.<OW]c/;*[uD+FjFl
-BDFChar: 5212 9380 12 1 11 -2 8
-+FljF5X:8NKHPpjKHPpj6U3n%+FjFl
-BDFChar: 5213 9381 12 1 11 -2 8
-+FldD5X:&HJfoXfJfoXf69n..,_,jp
-BDFChar: 5214 9382 12 1 11 -2 8
-+Fm9R:dC*bOW]f0PTZJ=;F")E+FjFl
-BDFChar: 5215 9383 12 1 11 -2 8
-+Fm-N6pQDJKHPpjKHPpj6pO4,+FjFl
-BDFChar: 5216 9384 12 1 11 -2 8
-+Fl^B5X:b\Pou>7Pou>7<Brf7+FjFl
-BDFChar: 5217 9385 12 1 11 -2 8
-+Fl^B5X:n`OW]c/OW]c/;*[B3+FjFl
-BDFChar: 5218 9386 12 1 11 -2 8
-+Fl^B5X:>POW]c/OW]c/:-_'0+FjFl
-BDFChar: 5219 9387 12 1 11 -2 8
-+Fl^B?9jVqOW]c/OW^5<:d@iB0Rs-'
-BDFChar: 5220 9388 12 1 11 -2 8
-+Fl^B:I($bOW]c/OW]]-5sR_$+b0Om
-BDFChar: 5221 9389 12 1 11 -2 8
-+Fl^B5X:n`OW]`.O<BW-:d@92+FjFl
-BDFChar: 5222 9390 12 1 11 -2 8
-+Fl^B5X:AQO<BQ+JKTLd?9gb@+FjFl
-BDFChar: 5223 9391 12 1 11 -2 8
-+Fm!J83iahL`hKrL`hKr7mK=)+FjFl
-BDFChar: 5224 9392 12 1 11 -2 8
-+Fl^B5X:GSOW]c/OW]c/:I%01+FjFl
-BDFChar: 5225 9393 12 1 11 -2 8
-+Fl^B5X:GSOW]N(MBIQp6pO"&+FjFl
-BDFChar: 5226 9394 12 1 11 -2 8
-+Fl^B5X:GSOW]o3Potr,8jGX,+FjFl
-BDFChar: 5227 9395 12 1 11 -2 8
-+Fl^B5X:GSMBIQpKHQ-p;*[B3+FjFl
-BDFChar: 5228 9396 12 1 11 -2 8
-+Fl^B;*^6dOW]c/OW]]-5sR_$/q<p%
-BDFChar: 5229 9397 12 1 11 -2 8
-+Fl^B5X:qaJfo^hL`hd%?U-kA+FjFl
-BDFChar: 5230 9352 12 2 9 0 7
-+CLib+<Vp+
-BDFChar: 5231 9353 12 2 9 0 7
-E/4c2+@(SV
-BDFChar: 5232 9354 12 2 9 0 7
-E/4cR#RH?0
-BDFChar: 5233 9355 12 2 9 0 7
-#T+s\M#7Vg
-BDFChar: 5234 9356 12 2 9 0 7
-pjdna#RH?0
-BDFChar: 5235 9357 12 2 9 0 7
-0L10XLkpt1
-BDFChar: 5236 9358 12 2 9 0 7
-p]qEB+<X$=
-BDFChar: 5237 9359 12 2 9 0 7
-E/9<hLkpt1
-BDFChar: 5238 9360 12 2 9 0 7
-E/9=+GR+sm
-BDFChar: 5239 9361 12 1 10 0 7
-6i]gZaoG$68cVH`9#0N'
-BDFChar: 5240 9362 12 1 10 0 7
-6i]UTbQ($26i]UT7)86+
-BDFChar: 5241 9363 12 1 10 0 7
-6i]gZ_>ln&6i]UT8AOZ/
-BDFChar: 5242 9364 12 1 10 0 7
-6i]gZ_>lt(63'=P9#0N'
-BDFChar: 5243 9366 12 1 10 0 7
-:&mfba8em663'=P9#0N'
-BDFChar: 5244 9365 12 1 10 0 7
-6i]m\bQ(TB;ug5)7)7m!
-BDFChar: 5245 9367 12 1 10 0 7
-6i]aXa8em68cVH`9#0N'
-BDFChar: 5246 9368 12 1 10 0 7
-:&mT\_>ln&6i]UT7)7m!
-BDFChar: 5247 9369 12 1 10 0 7
-6i]gZaoFg08cVH`9#0N'
-BDFChar: 5248 9370 12 1 10 0 7
-6i]gZaoG$67K>aT6GVZt
-BDFChar: 5249 9371 12 1 10 0 7
-6ia4e.KCpu8cVH`MSS;g
-BDFChar: 5250 8967 6 2 4 -2 8
-J3Y5BJ3Y5BJ3Y4W
-BDFChar: 5251 9086 6 1 5 0 5
-E/9>F:tPaJ
-BDFChar: 5252 8478 6 1 5 0 7
-n;)niTW!sN
-BDFChar: 5253 8448 6 0 5 0 8
-A>lGG&1fM39E5%m
-BDFChar: 5254 8449 6 0 5 0 8
-A>lGG&1fe7=9&=$
-BDFChar: 5255 8453 6 1 5 0 8
-8<Ap@+AcaMO8o7\
-BDFChar: 5256 8454 6 1 5 0 8
-8<Ap@+@'V=QiI*d
-BDFChar: 5257 8750 6 1 5 -2 8
-(apMGW2QY6+J?LM
-BDFChar: 5258 8751 6 0 6 -2 8
-(+L_[WiE(H.&bJm
-BDFChar: 5259 8752 6 -1 7 -2 8
-'n@ca.KFquWdq+"WdoR!.KHIKe,TIK
-BDFChar: 5260 8481 12 1 11 0 7
-p])E:+94$E."Ek!."Er.
-BDFChar: 5261 8786 6 1 5 0 6
-J,o?Ep](R"
-BDFChar: 5262 8784 6 1 5 2 6
-+9;0:p](9o
-BDFChar: 5263 8785 6 1 5 0 6
-+9;0:p])E:
-BDFChar: 5264 8787 6 1 5 0 6
-#QXW"p],gE
-BDFChar: 5265 8895 6 1 5 1 5
-#T+s\p](9o
-BDFChar: 5266 8491 6 1 5 0 9
-+Aa2":f)uCLkl$2
-BDFChar: 5267 8810 6 1 6 0 6
-'IZeN:ad"X
-BDFChar: 5268 8811 6 1 6 0 6
-TMR$N-r?Q:
-BDFChar: 5269 8803 6 1 5 0 6
-p]1'hp]1'h
-BDFChar: 5270 8806 6 1 5 -1 7
-(gql%(]a=2p](9o
-BDFChar: 5271 8807 6 1 5 -1 7
-^b?$J^]=-0p](9o
-BDFChar: 5272 65504 12 4 8 -1 6
-+E49PTVufP
-BDFChar: 5273 65505 12 4 8 0 7
-0L.nm5X7TE
-BDFChar: 5274 65506 12 3 9 0 3
-rW3-&
-BDFChar: 5275 65507 12 0 11 9 9
-s6p!g
-BDFChar: 5276 65508 12 6 6 -2 8
-J:N0#!!!"LJ:N.M
-BDFChar: 5277 65509 12 4 8 0 8
-Lkpj`+S[)S+92BA
-BDFChar: 5278 65510 12 3 9 0 7
-6pt#R<;n9o
-BDFChar: 5279 8361 6 0 6 0 7
-6pt#R<;n9o
-BDFChar: 5280 12307 12 2 10 0 8
-s+(-"s*t(Lzs+(-"s*t(L
-BDFChar: 5281 12317 12 6 10 6 9
-f[r_c
-BDFChar: 5282 12318 12 2 6 6 9
-f[u:I
-BDFChar: 5283 12319 12 2 6 -2 1
-OHA,I
-BDFChar: 5284 12342 12 1 11 -2 8
-*ro]a5X<)WJ0;V"KHPpj6pP.q*rl9@
-BDFChar: 5285 13059 12 2 10 -2 8
-n,Q8bB7N5IJ,fQL:]O;l=9)G'O8o7\
-BDFChar: 5286 13069 12 2 10 -2 8
-5QLP/<.Iqu[t"GYO8t@BQ[fVI?iU0,
-BDFChar: 5287 13076 12 2 9 -1 8
-+S[)S+92oY#nI"9
-BDFChar: 5288 13080 12 2 10 -2 9
-&-,4NDuc5T&:e6j!!",A+94Y,:]T\Z
-BDFChar: 5289 13090 12 2 10 -2 8
-5QLM.:k1h3FoVdJDu_!\p])E:5QCca
-BDFChar: 5290 13091 12 2 10 -2 8
-5QLM.:k1h3FoVLB5QF%L?iX"'5QCca
-BDFChar: 5291 13094 12 3 9 -2 8
-TRahNJ,g8t()A.q
-BDFChar: 5292 13095 12 3 9 -2 8
-J:PG.J,fQf!X'>?
-BDFChar: 5293 13099 12 0 12 -2 8
-.KCjs.GuTS6i[2e5Tocn:p<56Fs$bb
-BDFChar: 5294 13110 12 0 11 -2 8
-!.Z3M;'6,e!5JR75bN(hf!$j4@3>OM
-BDFChar: 5295 13115 12 2 10 -2 8
-&-+rqVgo<Yze,U$[ci>0g^]4?7
-BDFChar: 5296 13129 12 2 10 -2 8
-?iU`<?iU`<^]6%g"FpW*"FpK&!rr<$
-BDFChar: 5297 13130 12 0 11 -2 9
-(]X^^)'B)*0H^e>!!#uk:nUjn:p>d!
-BDFChar: 5298 13133 12 2 10 -2 8
-&-,N,2h3"Nci=%GK`Hf,`IOe8M#[MU
-BDFChar: 5299 13137 12 2 10 -2 8
-O8tRHQ@KNsB)ho3K`Hf,`IOe8M#[MU
-BDFChar: 5300 13143 12 2 10 -2 8
-n,SaS(4ZsHB)ho35QF%L?iX"'5QCca
-BDFChar: 5301 12351 6 1 5 0 8
-pkXaYW7Zo^p](9o
-BDFChar: 5302 8525 6 0 5 0 8
-7&]=R&1fe7=9&=$
-BDFChar: 5303 8507 12 1 11 0 7
-n,Rt=KV7V'MEm1eMP,j"
-BDFChar: 5304 65514 6 1 5 0 6
-+E48%+<Vd,
-BDFChar: 5305 65515 6 1 5 1 5
-+;";Z+92BA
-BDFChar: 5306 65512 6 3 3 -3 9
-J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5307 65513 6 1 5 1 5
-+@,]e+92BA
-BDFChar: 5308 65516 6 1 5 0 6
-+<VdLW,NjZ
-BDFChar: 5309 65517 6 0 5 0 6
-r;?Kjr;?Hm
-BDFChar: 5310 65518 6 0 5 1 6
-0M$kM82(#D
-BDFChar: 5311 8765 6 1 5 2 4
-OJk\M
-BDFChar: 5312 13198 12 1 11 -3 5
-dGV#IWZ\;aWZ\;!!$D7a!Pe[8
-BDFChar: 5313 13199 12 1 11 -3 8
-J,k*"J,kGaOs$JAiZOC,M;S@V!$D<X
-BDFChar: 5314 13212 12 1 11 0 5
-dm0q+Wh?AbWh?Ab
-BDFChar: 5315 13213 12 1 11 0 5
-F$PVUJtR^gMP,!_
-BDFChar: 5316 13214 12 1 11 0 8
-J,k*"J,kKmP+\PBih2I-MP'qL
-BDFChar: 5317 13215 12 1 11 0 9
-!5JRW!'gPB!!(J5Wh?AbWh?Ab
-BDFChar: 5318 13217 12 2 11 0 9
-!It/8!.Y*cli<1KOoUXFOoUXF
-BDFChar: 5319 13252 12 1 11 0 5
-EPRGSJcLB&MBHoS
-BDFChar: 5320 20189 12 2 10 0 8
-#QPP=+ooH04obig#QP,1s*t(L
-BDFChar: 5321 13055 12 1 11 -1 8
-+TPR$MP,!_#GCpd:S:LV>2V^I
-BDFChar: 5322 13179 12 1 11 0 8
-pn/a[YMcL4-_UE',sWtG.%gP?
-BDFChar: 5323 13180 12 1 11 -1 8
-3<8L*Wh?qrkFfDZYFt?W3oC&>
-BDFChar: 5324 13181 12 1 10 0 8
--bpl*q#D]@-,<L\<</!YO2(_q
-BDFChar: 5325 13182 12 1 10 0 8
-4Fl^I\NoPtWW9TFlTcsc?,-F?
-BDFChar: 5326 8978 12 1 11 7 9
-*ro]aJ04gl
-BDFChar: 5327 12849 12 1 11 -2 8
-0n<7hGJK=`Z_4iOe"Dnt;*[B3+FjFl
-BDFChar: 5328 12850 12 1 11 -2 8
-."Hf_83if?OJ'@]d%I#(:r#=]+FjFl
-BDFChar: 5329 12857 12 1 11 -2 8
-.Y(/W;F$SAZ65;QOs#l0;8>F^+FjFl
-BDFChar: 5330 13261 12 1 11 0 7
-U4Atg_Z7RS_Z6E]U4B8:
-BDFChar: 5331 10186 6 2 4 -3 9
-5X7S"5X=6m5X7S"5QCca
-BDFChar: 5332 9702 6 1 5 1 5
-E/9=+Du]k<
-BDFChar: 5333 128528 12 1 11 -2 8
-*rmF65X:GSOW]/sJ0:I,5X6HB*rl9@
-BDFChar: 5334 128760 12 1 11 1 6
-%KI(@J&'TBJ&!dh
-BDFChar: 5335 8857 6 1 5 1 5
-E/:HKDu]k<
-BDFChar: 5336 8609 6 1 5 0 7
-+<[V%+K06%
-BDFChar: 5337 10710 6 1 5 0 6
-pkV`h:l+lH
-BDFChar: 5338 9083 6 1 6 0 7
-#RCuh&<L9B
-BDFChar: 5339 9101 6 1 5 0 6
-E)9A-:f,dE
-BDFChar: 5340 9723 6 1 5 1 5
-pkX`^p](9o
-BDFChar: 5341 9724 6 1 5 1 5
-q"XXZp](9o
-BDFChar: 5342 9150 6 3 5 0 8
-i.-?.J:N0#J,fQL
-BDFChar: 5343 9151 6 3 5 0 8
-J:N0#J:N0#huE`W
-BDFChar: 5344 9161 6 1 5 0 8
-p`L\%+<VdL+92BA
-BDFChar: 5345 9162 6 1 5 0 8
-+<VdL+<VdLp](9o
-BDFChar: 5346 9163 6 1 3 0 8
-i#j-b+<VdL+92BA
-BDFChar: 5347 9164 6 1 3 0 8
-+<VdL+<VdLhuE`W
-BDFChar: 5348 127344 6 0 6 -1 7
-rl2O\K"AP)rVuou
-BDFChar: 5349 127345 6 0 6 -1 7
-reA"qL:XsNrVuou
-BDFChar: 5350 127346 6 0 6 -1 7
-rl2O`^:q1urVuou
-BDFChar: 5351 127347 6 0 6 -1 7
-rf4Fu]"5>1rVuou
-BDFChar: 5352 127348 6 0 6 -1 7
-rdqkuL;(BRrVuou
-BDFChar: 5353 127349 6 0 6 -1 7
-rdqkuL;(C9rVuou
-BDFChar: 5354 127350 6 0 6 -1 7
-rl2O`ZF[WerVuou
-BDFChar: 5355 127351 6 0 6 -1 7
-rjo\PK"AP)rVuou
-BDFChar: 5356 127352 6 0 6 -1 7
-rl4BomdBM_rVuou
-BDFChar: 5357 127353 6 0 6 -1 7
-rpop^qRX8XrVuou
-BDFChar: 5358 127354 6 0 6 -1 7
-rjoP@NjcC-rVuou
-BDFChar: 5359 127355 6 0 6 -1 7
-rk?+\^:q=5rVuou
-BDFChar: 5360 127356 6 0 6 -1 7
-rjn8mWk,dQrVuou
-BDFChar: 5361 127357 6 0 6 -1 7
-rjnPeWj8qArVuou
-BDFChar: 5362 127358 6 0 6 -1 7
-rl2O\]"5JmrVuou
-BDFChar: 5363 127359 6 0 6 -1 7
-reA"qL;(C9rVuou
-BDFChar: 5364 127360 6 0 6 -1 7
-rl2O\]"5>mrVuou
-BDFChar: 5365 127361 6 0 6 -1 7
-reA"qL:4\)rVuou
-BDFChar: 5366 127362 6 0 6 -1 7
-rl2O``qm9drVuou
-BDFChar: 5367 127363 6 0 6 -1 7
-rdsS+mdBN2rVuou
-BDFChar: 5368 127364 6 0 6 -1 7
-rjo\P]"5JmrVuou
-BDFChar: 5369 127365 6 0 6 -1 7
-rjo\lf%09WrVuou
-BDFChar: 5370 127366 6 0 6 -1 7
-rjo\@WlEW@rVuou
-BDFChar: 5371 127367 6 0 6 -1 7
-rjo\lmaet\rVuou
-BDFChar: 5372 127368 6 0 6 -1 7
-rjo\lmdBN2rVuou
-BDFChar: 5373 127369 6 0 6 -1 7
-rdt"?mbY[0rVuou
-BDFChar: 5374 127312 12 2 10 -1 7
-4og'4pOMR[l[Zg%h10tT4obQ_
-BDFChar: 5375 127313 12 2 10 -1 7
-4og'4_gpQn_gpQn_gm4:4obQ_
-BDFChar: 5376 127314 12 2 10 -1 7
-4og'4j+,s9hgjO5j+)UZ4obQ_
-BDFChar: 5377 127315 12 2 10 -1 7
-4og'4_gpQnh14=3_gm4:4obQ_
-BDFChar: 5378 127316 12 2 10 -1 7
-4og'4_1:En_gpWp_17"84obQ_
-BDFChar: 5379 127317 12 2 10 -1 7
-4og'4_1:En_gpWphgg1V4obQ_
-BDFChar: 5380 127318 12 2 10 -1 7
-4og'4iIKg9fmqn/iIHCX4obQ_
-BDFChar: 5381 127319 12 2 10 -1 7
-4og'4h14=3_1:?lh10tT4obQ_
-BDFChar: 5382 127320 12 2 10 -1 7
-4og'4pON!gpON!gpOI_n4obQ_
-BDFChar: 5383 127321 12 2 10 -1 7
-4og'4qgeQoqgdFOkCA$^4obQ_
-BDFChar: 5384 127322 12 2 10 -1 7
-4og'4h1471a+2oph10tT4obQ_
-BDFChar: 5385 127323 12 2 10 -1 7
-4og'4msskWmsskWiIHCX4obQ_
-BDFChar: 5386 127324 12 2 10 -1 7
-4og'4h13UteUZ2#h10tT4obQ_
-BDFChar: 5387 127325 12 2 10 -1 7
-4og'4h13b#eUZ>'h10tT4obQ_
-BDFChar: 5388 127326 12 2 10 -1 7
-4og'4j+,s9h14=3j+)UZ4obQ_
-BDFChar: 5389 127327 12 2 10 -1 7
-4og'4j+-NIj+-TKmsolf4obQ_
-BDFChar: 5390 127328 12 2 10 -1 7
-4og'4j+,s9h14%+j+)IV4obQ_
-BDFChar: 5391 127329 12 2 10 -1 7
-4og'4j+-NIj+-HGm=9Zd4obQ_
-BDFChar: 5392 127330 12 2 10 -1 7
-4og'4j+-$;j+.)Yj+)UZ4obQ_
-BDFChar: 5393 127331 12 2 10 -1 7
-4og'4_1;91pON!gpOI_n4obQ_
-BDFChar: 5394 127332 12 2 10 -1 7
-4og'4h14=3h14=3j+)UZ4obQ_
-BDFChar: 5395 127333 12 2 10 -1 7
-4og'4h14=3l[\;OpOI_n4obQ_
-BDFChar: 5396 127334 12 2 10 -1 7
-4og'4eUZ2#eUZt9l[XHb4obQ_
-BDFChar: 5397 127335 12 2 10 -1 7
-4og'4h14gApOMR[h10tT4obQ_
-BDFChar: 5398 127336 12 2 10 -1 7
-4og'4h14gApON!gpOI_n4obQ_
-BDFChar: 5399 127337 12 2 10 -1 7
-4og'4_1;E5pOM^__17"84obQ_
-BDFChar: 5400 127243 12 1 11 -2 8
-*ro]a5X9uFMBId!MBIQp5X8_m*rl9@
-BDFChar: 5401 127244 12 2 10 -1 7
-4og'4pOMR[l[\;OpOI_n4obQ_
-BDFChar: 5402 127245 12 1 11 -2 8
-*ro]a5X:>PP9?,5R37M45X8_m*rl9@
-BDFChar: 5403 127248 12 1 11 -2 8
-+Fm3P;*^6dOW^8=OW]c/;*[B3+FjFl
-BDFChar: 5404 127249 12 1 11 -2 8
-+Fmc`;*^6dSfj.<OW]c/?9gb@+FjFl
-BDFChar: 5405 127250 12 1 11 -2 8
-+Fm3P;*^3cO<BW-O<BZ.:-_'0+FjFl
-BDFChar: 5406 127251 12 1 11 -2 8
-+Fm]^;F$?eOW]c/OW]f0>X1P>+FjFl
-BDFChar: 5407 127252 12 1 11 -2 8
-+Fmfa:dC*bSfj+;O<BW-?U-kA+FjFl
-BDFChar: 5408 127253 12 1 11 -2 8
-+Fmfa:dC*bSfj+;O<BW-:d@92+FjFl
-BDFChar: 5409 127254 12 1 11 -2 8
-+Fm3P;*^3cO<B`0OW]c/:-_'0+FjFl
-BDFChar: 5410 127255 12 1 11 -2 8
-+Fm<S;*^6dT-07=OW]c/;*[B3+FjFl
-BDFChar: 5411 127256 12 1 11 -2 8
-+Fm3P6pQDJKHPpjKHPpj:-_'0+FjFl
-BDFChar: 5412 127257 12 1 11 -2 8
-+FlsI5sTuDJKTLdOW]c/:-_'0+FjFl
-BDFChar: 5413 127258 12 1 11 -2 8
-+Fm<S;F$HhS03t;Os#l0;*[B3+FjFl
-BDFChar: 5414 127259 12 1 11 -2 8
-+Fm9R:dC*bO<BW-O<BW-?U-kA+FjFl
-BDFChar: 5415 127260 12 1 11 -2 8
-+Fm<S><nGrPou23OW]c/;*[B3+FjFl
-BDFChar: 5416 127261 12 1 11 -2 8
-+Fm<S=[8AtPou>7P9?&3;*[B3+FjFl
-BDFChar: 5417 127262 12 1 11 -2 8
-+Fm3P;*^6dOW]c/OW]c/:-_'0+FjFl
-BDFChar: 5418 127263 12 1 11 -2 8
-+Fmc`;*^6dOW^5<O<BW-:d@92+FjFl
-BDFChar: 5419 127264 12 1 11 -2 8
-+Fm3P;*^6dOW]c/OW]f09gD!0+FjFl
-BDFChar: 5420 127265 12 1 11 -2 8
-+Fmc`;*^6dSfj1=OW]c/;*[B3+FjFl
-BDFChar: 5421 127266 12 1 11 -2 8
-+Fm3P;*^3cNZ`lqJKU't:-_'0+FjFl
-BDFChar: 5422 127267 12 1 11 -2 8
-+Fmfa6pQDJKHPpjKHPpj6pO"&+FjFl
-BDFChar: 5423 127268 12 1 11 -2 8
-+Fm<S;*^6dOW]c/OW]c/:-_'0+FjFl
-BDFChar: 5424 127269 12 1 11 -2 8
-+Fm<S;*^6dMBId!MBIQp6pO"&+FjFl
-BDFChar: 5425 127270 12 1 11 -2 8
-+Fm<S;*^6dPou>7NZa3%8jGX,+FjFl
-BDFChar: 5426 127271 12 1 11 -2 8
-+Fm<S;*^!]KHPpjMBJ$(;*[B3+FjFl
-BDFChar: 5427 127272 12 1 11 -2 8
-+Fm<S;*^6dMBIQpKHPpj6pO"&+FjFl
-BDFChar: 5428 127273 12 1 11 -2 8
-+Fmfa69p2HKHQ'nL`hd%?U-kA+FjFl
-BDFChar: 5429 13003 12 1 11 -1 7
-8`3Sk`Sa0-8`3/_;'>f[!al!.
-BDFChar: 5430 12992 12 2 10 -1 7
-7t=!Xa+-R.7t=!X7"FKO$%N!U
-BDFChar: 5431 12993 12 1 10 -1 7
-A&+6m'>P5G,JZW2JjArn"Mb!;
-BDFChar: 5432 12994 12 1 10 -1 7
-A&+6m'>S'B'>P5GP!EPC"Mb!;
-BDFChar: 5433 12995 12 1 10 -1 7
-'>Q@g;nu9rPJI#[&jR-r"Mb!;
-BDFChar: 5434 12996 12 1 10 -1 7
-o>#rCK>?J3'>P5GP!EPC"Mb!;
-BDFChar: 5435 12997 12 1 10 -1 7
-,JZW2K>?J3PJE>HP!EPC"Mb!;
-BDFChar: 5436 12998 12 1 10 -1 7
-o=tu('>PeW,JZW269mq("Mb!;
-BDFChar: 5437 12999 12 1 10 -1 7
-A&+6mPJCWmPJE>HP!EPC"Mb!;
-BDFChar: 5438 13000 12 1 10 -1 7
-A&+6mPJE>HF2/DR,!\O]"Mb!;
-BDFChar: 5439 13001 12 1 11 -1 7
-8`3Ske_jFM<T$k"<?UNK!al!.
-BDFChar: 5440 13002 12 1 11 -1 7
-8`3/_g#,FE8`3/_8KdsS!al!.
-BDFChar: 5441 13145 12 2 11 -1 8
-!WYT<63,&V7"@[U7t<i)kC<q*
-BDFChar: 5442 13146 12 1 11 -1 8
-!<?QDOT6'1&jRX+6bn3Po=tO&
-BDFChar: 5443 13144 12 1 11 -1 8
-!<?QDOT:T\P!G0qPJE7[A&&8@
-BDFChar: 5444 13147 12 1 11 -1 8
-!<?QDOT6'1@R(Pk'>T\0A&&8@
-BDFChar: 5445 13148 12 1 11 -1 8
-!<<_I0`Y.f;F$C1qnNaC'>OdE
-BDFChar: 5446 13149 12 1 11 -1 8
-!<DZ*JH1><i]n,A'>T\0A&&8@
-BDFChar: 5447 13150 12 1 11 -1 8
-!<=:Y5lcPQi]rYlPJE7[A&&8@
-BDFChar: 5448 13151 12 1 11 -1 8
-!<DZ*&HEK[,![>;6bkqe6biku
-BDFChar: 5449 13152 12 1 11 -1 8
-!<?QDOT:T\@R-)APJE7[A&&8@
-BDFChar: 5450 13153 12 1 11 -1 8
-!<?QDOT:T\P!F%Q'>P^j6biku
-BDFChar: 5451 13154 12 1 11 -1 8
-!.[VU<.NN7<BsPL<PVQ6ks,<C
-BDFChar: 5452 13155 12 1 11 -1 8
-!.[VU8:]C/8O,j48\djsrBLFW
-BDFChar: 5453 13156 12 1 11 -1 8
-!.[VU<.Ms'76jF08\e.&rBLFW
-BDFChar: 5454 13157 12 1 11 -1 8
-!.[VU<.Ms'8O,^07DMk&ks,<C
-BDFChar: 5455 13158 12 1 11 -1 8
-!.[JQ9RtC'<BsPL?bf&0jZim?
-BDFChar: 5456 13159 12 1 11 -1 8
-!.\=i:k6s/=[5D@7DMk&ks,<C
-BDFChar: 5457 13160 12 1 11 -1 8
-!.[VU:k6s/=[5tP<PVQ6ks,<C
-BDFChar: 5458 13161 12 1 11 -1 8
-!.\=i7"E7l76jF08\djsks,<C
-BDFChar: 5459 13162 12 1 11 -1 8
-!.[VU<.NN78O-9@<PVQ6ks,<C
-BDFChar: 5460 13163 12 1 11 -1 8
-!.[VU<.NN7<Bs8D7DM:kks,<C
-BDFChar: 5461 13164 12 1 11 -1 8
-!.[VU["($L2*b/,<PXh!ks,<C
-BDFChar: 5462 13165 12 1 11 -1 8
-!.[VUW.6nD.6pHi8\g,^rBLFW
-BDFChar: 5463 13166 12 1 11 -1 8
-!.[VU["'I<,sY$e8\gDfrBLFW
-BDFChar: 5464 13167 12 1 11 -1 8
-!.[VU["'I<.6p<e7DP,fks,<C
-BDFChar: 5465 13168 12 1 11 -1 8
-!.[JQXFMn<2*b/,?bh<pjZim?
-BDFChar: 5466 13280 12 2 10 0 7
-:OkudaFI':8:X6]:OqYZ
-BDFChar: 5467 13281 12 1 10 0 7
-B>B`s'L3JM,X=a_LVWOI
-BDFChar: 5468 13282 12 1 10 0 7
-B>B`s'L6<H'L3?tQb[,s
-BDFChar: 5469 13283 12 1 10 0 7
-(Vhjm<'XO#PX,.3(Vg_M
-BDFChar: 5470 13284 12 1 10 0 7
-pV;GIKL"_9'L3?tQb[,s
-BDFChar: 5471 13285 12 1 10 0 7
--br,8KL"_9PX(HuQb[,s
-BDFChar: 5472 13286 12 1 10 0 7
-pV7J.'L4%],X=a_8&.MX
-BDFChar: 5473 13287 12 1 10 0 7
-B>B`sPX&lsPX(HuQb[,s
-BDFChar: 5474 13288 12 1 10 0 7
-B>B`sPX(SNF?gO*-br,8
-BDFChar: 5475 13289 12 1 11 0 7
-8`3SkeK@lM<?P9a<T**a
-BDFChar: 5476 13290 12 1 11 0 7
-8`3/_fcWlE8K^SI8`9Oi
-BDFChar: 5477 13291 12 1 11 0 7
-8`3Sk`?7V-8K^SI;;hBq
-BDFChar: 5478 13292 12 1 11 0 7
-8`3Sk`?7b173G#A<T**a
-BDFChar: 5479 13293 12 1 11 0 7
-7Gpl_bog$E<?PWk7H!8M
-BDFChar: 5480 13294 12 1 11 0 7
-?/SR&d3)TM73G#A<T**a
-BDFChar: 5481 13295 12 1 11 0 7
-8`3Ggd3)TM<?P9a<T**a
-BDFChar: 5482 13296 12 1 11 0 7
-?/S-o`?7V-8K^SI8`8hU
-BDFChar: 5483 13297 12 1 11 0 7
-8`3SkeK@HA<?P9a<T**a
-BDFChar: 5484 13298 12 1 11 0 7
-8`3SkeK@lM9cukI7H!DQ
-BDFChar: 5485 13299 12 1 11 0 7
-8`7!!2'=d7<?P9aQ/LmL
-BDFChar: 5486 13300 12 1 11 0 7
-8`6Qj3?Td/8K^SIM;\=T
-BDFChar: 5487 13301 12 1 11 0 7
-8`7!!,p4Ml8K^SIOl60\
-BDFChar: 5488 13302 12 1 11 0 7
-8`7!!,p4Yp73G#AQ/LmL
-BDFChar: 5489 13303 12 1 11 0 7
-7Gt9j/Kcq/<?PWkL#D&8
-BDFChar: 5490 13304 12 1 11 0 7
-?/Vt10d&L773G#AQ/LmL
-BDFChar: 5491 13305 12 1 11 0 7
-8`6ir0d&L7<?P9aQ/LmL
-BDFChar: 5492 13306 12 1 11 0 7
-?/VP%,p4Ml8K^SIM;[V@
-BDFChar: 5493 13307 12 1 11 0 7
-8`7!!2'=@+<?P9aQ/LmL
-BDFChar: 5494 13308 12 1 11 0 7
-8`7!!2'=d79cukIL#D2<
-BDFChar: 5495 13309 12 1 11 0 7
-8`7!!2'>oW2'=b![GXV!
-BDFChar: 5496 13310 12 1 11 0 7
-8`6Qj3?UoO.3L&^WSh&)
-BDFChar: 5497 12343 12 1 11 -1 8
-MBId!;*[uD+FkSb;*[uDMBId!
-BDFChar: 5498 12832 12 1 11 -2 8
-+Fl^B5X9iBJ0;V"J09@b5X7S"+FjFl
-BDFChar: 5499 12833 12 1 11 -2 8
-+Fl^B?U0,aJ09@bJ09@b?U-kA+FjFl
-BDFChar: 5500 12834 12 1 11 -2 8
-+Fl^B?U0,aJ09jpJ09@b?U-kA+FjFl
-BDFChar: 5501 12835 12 1 11 -2 8
-+Fl^BJ&&(WWh?DcYb7Y^J&"<7+FjFl
-BDFChar: 5502 12836 12 1 11 -2 8
-+Fl^BJ&$^[KHS#PM'.WtJ&"<7+FjFl
-BDFChar: 5503 12837 12 1 11 -2 8
-+FljF6pSM[J09^lMBJ$(;*[B3+FjFl
-BDFChar: 5504 12838 12 1 11 -2 8
-+Fm!J83i4Y\0-SML`hNs:I%01+FjFl
-BDFChar: 5505 12839 12 1 11 -2 8
-+Fl^B:-aCRMBId!M'.p';*[B3+FjFl
-BDFChar: 5506 12840 12 1 11 -2 8
-."FiR83jp4M'.WtOW]co@DG,n+FjFl
-BDFChar: 5507 12841 12 1 11 -2 8
-+Fl^B6pQDJKHQm0KHPpj6pO"&+FjFl
-BDFChar: 5508 12842 12 1 11 -2 8
-+Fm6Q8O/=ZM'.j%M'.p';a<T5+FjFl
-BDFChar: 5509 12843 12 1 11 -2 8
-+FljF6pR"[Pot`&MBId!;*[B3+FjFl
-BDFChar: 5510 12844 12 1 11 -2 8
-+FljF6pS2RQQVS:V'(Ga9L(j.+FjFl
-BDFChar: 5511 12845 12 1 11 -2 8
-+FljF6pSM[KHQ9tPoulq6pO"&+FjFl
-BDFChar: 5512 12846 12 1 11 -2 8
-,_/KP;*_:WKHS%&KHQO&J&"<7+FjFl
-BDFChar: 5513 12847 12 1 11 -2 8
-+FljF6pQDJT-/e0KHPpjJ&"<7+FjFl
-BDFChar: 5514 12848 12 1 11 -2 8
-+Fl^B?U0_rOW^8=OW]c/?U.IR+FjFl
-BDFChar: 5515 8263 6 1 5 0 7
-:oGd=:f%-g
-BDFChar: 5516 8264 6 1 5 0 7
-8>mq-84W_O
-BDFChar: 5517 8265 6 1 5 0 7
-OJmtsOH9I(
-BDFChar: 5518 8352 6 1 5 0 6
-@">b[E$.+?
-BDFChar: 5519 8770 6 1 5 2 5
-p],!3
-BDFChar: 5520 8774 6 1 5 -1 6
-BWqL3+S\2e
-BDFChar: 5521 8775 6 1 5 -1 8
-&.iNZ+S[)S5X5;L
-BDFChar: 5522 8778 6 1 5 0 6
-BWqJMYQ4Fu
-BDFChar: 5523 8779 6 1 5 0 7
-BWqJMYQ/@@
-BDFChar: 5524 8780 6 1 5 1 6
-Y\4%3!;HNo
-BDFChar: 5525 8769 6 1 5 1 6
-&.iNZ5X5;L
-BDFChar: 5526 8764 6 1 5 3 4
-BWqI:
-BDFChar: 5527 8763 6 1 5 1 6
-+96)Z!$D7A
-BDFChar: 5528 8858 6 0 6 0 6
-3(/q0P!h80
-BDFChar: 5529 10746 6 1 5 1 5
-:f-p`:]LIq
-BDFChar: 5530 128178 12 3 8 -3 9
-0JIbLbi!^cbku]>0E;(Q
-BDFChar: 5531 8607 6 1 5 0 7
-+E48%E2Xm%
-BDFChar: 5532 8909 6 1 5 2 5
-Y\4%3
-BDFChar: 5533 8767 6 1 5 1 5
-5bP&(&-)\1
-BDFChar: 5534 8760 6 1 5 3 5
-+9;0:
-BDFChar: 5535 8761 6 1 5 1 5
-#QX>o#QOi)
-BDFChar: 5536 8753 6 1 5 -2 8
-(apM?\@<Y(+J?LM
-BDFChar: 5537 8754 6 1 5 -2 8
-(apM?\@A2N+J?LM
-BDFChar: 5538 8755 6 1 5 -2 8
-(apMGTX_LF+J?LM
-BDFChar: 5539 8768 6 2 4 0 7
-5Th175_+AM
-BDFChar: 5540 8782 6 1 5 1 5
-+P6\H+92BA
-BDFChar: 5541 8783 6 1 5 2 5
-+P6\h
-BDFChar: 5542 8808 6 1 5 -2 7
-(gql%(_HHbpcnfZ
-BDFChar: 5543 8809 6 1 5 -2 7
-^b?$J^_$8`pcnfZ
-BDFChar: 5544 8813 6 1 5 -1 7
-&.kdZ+E48E5QCca
-BDFChar: 5545 8812 6 2 4 0 6
-TKo0CTKo.M
-BDFChar: 5546 9153 6 1 5 0 8
-p`OOSW2OYX+92BA
-BDFChar: 5547 9154 6 1 5 0 8
-+<YX%W2OYXp](9o
-BDFChar: 5548 9152 6 1 5 0 8
-+<YX%W2OYX+92BA
-BDFChar: 5549 9155 6 1 5 0 8
-+<VeGE2`OS+92BA
-BDFChar: 5550 9156 6 1 5 0 8
-p`L\uE2`OS+92BA
-BDFChar: 5551 9157 6 1 5 0 8
-+<VeGE2`OSp](9o
-BDFChar: 5552 9158 6 1 5 0 8
-+<Ve?YTP&2+92BA
-BDFChar: 5553 9159 6 1 5 0 8
-p`L\%BWrU%+92BA
-BDFChar: 5554 9160 6 1 5 0 8
-+<Ve?YTP&2p](9o
-BDFChar: 5555 8471 6 0 6 0 6
-3(1?hU-ps@
-BDFChar: 5556 8814 6 2 5 -1 7
-&.gO'TO;/(5QCca
-BDFChar: 5557 8815 6 1 4 -1 7
-+J<+M:gh(hJ,fQL
-BDFChar: 5558 8816 6 1 5 -2 8
-&.f[tTO9`%pcq(E
-BDFChar: 5559 8817 6 1 5 -2 8
-&.m2B-nsR%pcq(E
-BDFChar: 5560 8818 6 1 5 0 7
-(gql%(]\6R
-BDFChar: 5561 8819 6 1 5 0 7
-^b?$J^]8&P
-BDFChar: 5562 8820 6 1 5 -2 8
-&/]AZ?oT9BYWtGR
-BDFChar: 5563 8821 6 1 5 -2 8
-&C<*Z0]4'eYWtGR
-BDFChar: 5564 8822 6 1 5 -1 8
-(gql%(r.g20YdYg
-BDFChar: 5565 8823 6 1 5 -1 8
-^b?$J^_gI0?l/kD
-BDFChar: 5566 8824 6 1 5 -2 9
-+?3c%?o['u-nsR%
-BDFChar: 5567 8825 6 1 5 -2 9
-+Q+q%0]4ouTO9`%
-BDFChar: 5568 8826 6 1 5 1 5
-#Va%J#QOi)
-BDFChar: 5569 8827 6 1 5 1 5
-J7'4%J,fQL
-BDFChar: 5570 8828 6 1 5 0 6
-#Va%Ja=ml"
-BDFChar: 5571 8829 6 1 5 0 6
-J7'4%QsbFE
-BDFChar: 5572 8830 6 1 5 0 7
-#Va%J#QSPB
-BDFChar: 5573 8831 6 1 5 0 7
-J7'4%J,j8e
-BDFChar: 5574 8832 6 1 5 -1 7
-&.g6Di%QQE5QCca
-BDFChar: 5575 8833 6 1 5 -1 7
-&.kLB3+/CE5QCca
-BDFChar: 5576 8928 6 1 5 -2 8
-&.g6Di%X@K-pU#t
-BDFChar: 5577 8929 6 1 5 -2 8
-&.kLB3+07(TKkaB
-BDFChar: 5578 8926 6 1 5 0 6
-#Va=R^b?#o
-BDFChar: 5579 8927 6 1 5 0 6
-J7+aP(gqjo
-BDFChar: 5580 8924 6 1 5 0 6
-p]).=J7'2o
-BDFChar: 5581 8925 6 1 5 0 6
-p]/)`#Va$o
-BDFChar: 5582 8986 12 3 9 -2 8
-3&ilcP+$tj3&ikt
-BDFChar: 5583 128275 12 1 10 -1 8
-"+UM>"@*)TrW)otrW)otrW)ot
-BDFChar: 5584 128232 12 1 11 0 6
-5N)$=.%oZE.\O"R5MuMA
-BDFChar: 5585 128229 12 1 11 -2 8
-%KHh9)Z]Edb$`.q^gQ]jNZ`ips53kW
-BDFChar: 5586 128228 12 1 11 -2 8
-"98c/&HM^db$`M&^gQ]jNZ`ips53kW
-BDFChar: 5587 128128 12 1 11 -2 8
-*ro]a5X:e]]:cF%KHP0J+Fkql*rl9@
-BDFChar: 5588 128123 12 1 11 -2 8
-%KI(@+Frb8J07TPAACGq5X8=7C;9fL
-BDFChar: 5589 129695 12 1 11 -2 8
-s58PQKHPpjKHU<QKHPpjKHPpjs53kW
-BDFChar: 5590 127822 12 1 11 -2 9
-2ujou$ii/8J&)*Bs5<q8s58CBJ&"-r
-BDFChar: 5591 127823 12 1 11 -2 9
-2ujou$ii/8:-a=PJ09@bJ07*B6pNha
-BDFChar: 5592 129302 12 1 11 -2 8
-KHS%&s5:\#OW_GIs5<q8EPR(>5C`_6
-BDFChar: 5593 128203 12 2 10 -2 8
-*!#_`U4Bt.J:P@aJ:P.[K7JQ(s*t(L
-BDFChar: 5594 128220 12 1 11 -2 8
-IK71am!p4//q>'p/q>'p-f>ga&&8/F
-BDFChar: 5595 128195 12 2 11 -2 8
-rr@TM]`<T`]`<T`\H%0\T>4i"5C`_6
-BDFChar: 5596 128199 12 1 11 -2 8
-J&"<75X<_)s5<q8d9sat^gR3#s53kW
-BDFChar: 5597 128222 12 1 11 -2 8
-5QK^Bn,VqXhuM[8Dub065JSB!#J^<>
-BDFChar: 5598 128224 12 1 11 -2 8
-5JSC,.mP4BD*Yko^Yl,"^YnBbs53kW
-BDFChar: 5599 128240 12 1 11 -2 8
-s1j.m^L2S"^L2S"]3r-V]3p.3J%u$a
-BDFChar: 5600 128176 12 1 11 -2 8
-"onf,%"Juk/:^hf9L+IXS01'^5C`_6
-BDFChar: 5601 8911 6 1 5 1 5
-+<XKWL]@DT
-BDFChar: 5602 8910 6 1 5 1 5
-Lepnj+92BA
-BDFChar: 5603 8917 6 1 5 0 6
-:f-p`peXce
-BDFChar: 5604 8918 6 1 5 1 5
-(gr/-(]XO9
-BDFChar: 5605 8930 6 1 5 -2 8
-&.nW0TV2'&pcq(E
-BDFChar: 5606 8931 6 1 5 -2 8
-&.nUb-n+j5pcq(E
-BDFChar: 5607 8932 6 1 5 -1 6
-pjdmFp^m3c
-BDFChar: 5608 8933 6 1 5 -1 6
-p]q-2p^m3c
-BDFChar: 5609 8934 6 1 5 -2 7
-(gql%(a*Lr5X5;L
-BDFChar: 5610 8935 6 1 5 -2 7
-^b?$J^`[<p5X5;L
-BDFChar: 5611 8936 6 1 5 -2 7
-#Va%J#U!fb5X5;L
-BDFChar: 5612 8937 6 1 5 -2 7
-J7'4%J08O05X5;L
-BDFChar: 5613 8938 6 1 5 0 8
-&.f[lW+]9u5QCca
-BDFChar: 5614 8939 6 1 5 0 8
-&.m3mW3F'&5QCca
-BDFChar: 5615 8940 6 1 5 -2 8
-&.f[lW+\.5pcq(E
-BDFChar: 5616 8941 6 1 5 -2 8
-&.m3mW3G2&pcq(E
-BDFChar: 5617 8922 6 1 5 -3 9
-(gql%(]a=2^b?$J^]4?7
-BDFChar: 5618 8923 6 1 5 -3 9
-^b?$J^]=-0(gql%(]XO9
-BDFChar: 5619 8894 6 1 5 1 5
-JDcNNp](9o
-BDFChar: 5620 8919 6 1 5 1 5
-^bCQu^]4?7
-BDFChar: 5621 8920 6 0 6 1 5
-.TE?G.KBGK
-BDFChar: 5622 8921 6 0 6 1 5
-W)P6GVuQet
-BDFChar: 5623 8892 6 1 5 0 6
-p])F5:l'o-
-BDFChar: 5624 8893 6 1 5 0 6
-p]-,+:f&87
-BDFChar: 5625 8891 6 1 5 0 6
-Lknl(+9;0:
-BDFChar: 5626 8905 6 1 5 1 5
-LsVgAL]@DT
-BDFChar: 5627 8906 6 1 5 1 5
-Lfc'-L]@DT
-BDFChar: 5628 8907 6 1 5 1 5
-J3Y5RL]@DT
-BDFChar: 5629 8908 6 1 5 1 5
-#S8+TL]@DT
-BDFChar: 5630 8903 6 1 5 0 6
-+G`kh:l$4o
-BDFChar: 5631 9200 12 2 10 -2 8
-G6$ZRh125M8H;Hb5l`)/4of?u8H8_j
-BDFChar: 5632 9100 6 1 5 0 5
-YfQ#.f[p0(
-BDFChar: 5633 9213 6 3 3 1 5
-J:N0#J,fQL
-BDFChar: 5634 9214 6 0 6 0 6
-+@*`Xid<]c
-BDFChar: 5635 8258 6 0 6 -1 7
-&3(4L!(?6CWW3#!
-BDFChar: 5636 8273 6 2 4 -1 7
-5i=o#!'oI-TE"rl
-BDFChar: 5637 8353 6 1 5 -1 8
-:iP(6d*U.lE)6N7
-BDFChar: 5638 8354 6 1 5 0 7
-E/9%CYb7q6
-BDFChar: 5639 8357 6 1 5 -2 7
-&.n?0W2QYn5X5;L
-BDFChar: 5640 8358 6 0 6 0 7
-6tBj-<;oQZ
-BDFChar: 5641 8360 6 1 5 0 7
-^n@@9aKVVI
-BDFChar: 5642 8363 6 1 5 -2 8
-&9nb*OH>QcDufA-
-BDFChar: 5643 8365 6 1 5 0 7
-85N^h?r0Bb
-BDFChar: 5644 8366 6 1 5 0 7
-p`Lt=BWtm;
-BDFChar: 5645 8367 6 0 6 -3 7
-3)gS;-qID($kNsM
-BDFChar: 5646 8368 6 1 6 -1 8
-&1AqD(fYV<U^-r#
-BDFChar: 5647 8369 6 0 5 0 7
-E;W9)E'QZR
-BDFChar: 5648 8450 6 1 5 0 7
-E6,i1^qe$1
-BDFChar: 5649 8452 6 1 5 0 7
-+E4!HTPu#5
-BDFChar: 5650 8455 6 1 5 0 7
-E0,ThJ:NGp
-BDFChar: 5651 8456 6 1 5 0 7
-E/4cZ#RH6*
-BDFChar: 5652 8458 6 1 5 -3 5
--s2:eE%#[u^]4?7
-BDFChar: 5653 8459 6 0 6 0 7
-2HCMSBW0E_
-BDFChar: 5654 8460 6 0 6 0 7
-Au)4b,U=XI
-BDFChar: 5655 8461 6 1 5 0 7
-f\"jOf\"j/
-BDFChar: 5656 8464 6 1 5 0 7
-G`Y`5+E48E
-BDFChar: 5657 8465 6 1 5 0 7
-G_f0-&.")2
-BDFChar: 5658 8466 6 0 5 0 7
-85qP[+CM-E
-BDFChar: 5659 8467 6 1 4 0 7
-+AcI]5_+r(
-BDFChar: 5660 8468 6 0 5 0 7
-;#!jh<)ch!
-BDFChar: 5661 8469 6 1 5 0 7
-aN3T/\@@on
-BDFChar: 5662 8473 6 1 5 0 7
-nCZCGnA)iT
-BDFChar: 5663 8474 6 1 5 -1 7
-E7igqf\"hq2uipY
-BDFChar: 5664 8477 6 1 5 0 7
-nCZC_nCZCG
-BDFChar: 5665 8484 6 1 5 0 7
-p_Y\=?speF
-BDFChar: 5666 8480 6 0 6 5 7
-IU:G&
-BDFChar: 5667 8578 6 -1 7 0 7
-4oe.SS:IViWdpUi8H:pS
-BDFChar: 5668 8494 6 1 6 0 6
-0M'Fc^dp-Z
-BDFChar: 5669 8498 6 1 5 0 7
-#RC\AGR+TM
-BDFChar: 5670 8526 6 1 4 0 5
-&.idl&F]Z"
-BDFChar: 5671 8662 6 1 5 2 6
-n=\.,&-)\1
-BDFChar: 5672 8663 6 1 5 2 6
-GUQ[m5QCca
-BDFChar: 5673 8664 6 1 5 0 4
-5c@d5GQ7^D
-BDFChar: 5674 8665 6 1 5 0 4
-&?*sKn,NFg
-BDFChar: 5675 8670 6 1 5 0 7
-+E48%p`T>S
-BDFChar: 5676 8671 6 1 5 0 7
-+S[)S+K06%
-BDFChar: 5677 8676 6 1 5 1 5
-OJ)BAO8o7\
-BDFChar: 5678 8677 6 1 5 1 5
-81=6]8,rVi
-BDFChar: 5679 8678 6 1 5 1 5
-+F(tP+92BA
-BDFChar: 5680 8679 6 1 5 0 6
-+E5t0:f)*2
-BDFChar: 5681 8680 6 1 5 1 5
-+Rkcf+92BA
-BDFChar: 5682 8681 6 1 5 0 6
-E)9A-fPhr5
-BDFChar: 5683 8682 6 1 5 0 6
-+E5t0E):KR
-BDFChar: 5684 8606 6 1 6 1 5
--rBh<-ia5I
-BDFChar: 5685 8608 6 0 5 1 5
-:al5i:]LIq
-BDFChar: 5686 8965 6 1 5 0 5
-p`NC0Lkl$2
-BDFChar: 5687 8966 6 1 5 0 7
-p]1(3:f)t(
-BDFChar: 5688 8604 6 1 6 2 5
-i4u9*
-BDFChar: 5689 8605 6 1 6 2 5
-*"5f>
-BDFChar: 5690 8622 6 1 5 1 5
-#Z1:mJ,fQL
-BDFChar: 5691 8644 6 1 5 0 5
-&GQf%pcnfZ
-BDFChar: 5692 8646 6 1 5 0 5
-5kmSUp^dE*
-BDFChar: 5693 8647 6 1 5 0 5
-5kmT0pcnfZ
-BDFChar: 5694 8649 6 1 5 0 5
-&GQeJp^dE*
-BDFChar: 5695 8645 6 1 5 0 6
-;".:X:j>e:
-BDFChar: 5696 8648 6 1 5 0 6
-;#!j`:f'sg
-BDFChar: 5697 8650 6 1 5 0 6
-:f'tb;#!ie
-BDFChar: 5698 8653 6 1 5 -1 7
-&.gO?TQjj05QCca
-BDFChar: 5699 8655 6 1 5 -1 7
-&.gPb..CV05QCca
-BDFChar: 5700 8654 6 0 6 -1 7
-#RDi+epJkg+92BA
-BDFChar: 5701 8666 6 0 5 0 6
-&3O@u?p"u#
-BDFChar: 5702 8667 6 1 6 0 6
-+Rg6G)"8XJ
-BDFChar: 5703 8683 6 1 5 0 6
-+E5t0fSK;&
-BDFChar: 5704 8684 6 1 5 0 6
-+Ahi0fSK;&
-BDFChar: 5705 8686 6 1 5 0 7
-+Af"5Lepoe
-BDFChar: 5706 8685 6 1 5 0 6
-+E7*ppo*rf
-BDFChar: 5707 8688 6 0 6 1 5
-ke)Y_kPtS_
-BDFChar: 5708 8691 6 1 5 0 6
-+E5t0fPhr5
-BDFChar: 5709 8693 6 1 5 0 6
-:j>f5;".9]
-BDFChar: 5710 8694 6 1 5 -1 7
-&GQeJp^e#3&-)\1
-BDFChar: 5711 9735 6 1 5 0 7
-&0O5g5U[I/
-BDFChar: 5712 9736 6 0 5 0 7
-pkY$)TTkD*
-BDFChar: 5713 9636 6 0 6 0 6
-rdt-$rdt+L
-BDFChar: 5714 9637 6 0 6 0 6
-ri2uuWiH$u
-BDFChar: 5715 9639 6 0 6 0 6
-rfYF$P03b(
-BDFChar: 5716 9638 6 0 6 0 6
-ri5stri5qt
-BDFChar: 5717 9640 6 0 6 0 6
-rfX/$P,A3Y
-BDFChar: 5718 9641 6 0 6 0 6
-ri4PLeuJ]L
-BDFChar: 5719 9703 6 0 6 0 6
-rpoXNo()b[
-BDFChar: 5720 9704 6 0 6 0 6
-rgo^QSt>o]
-BDFChar: 5721 9705 6 0 6 0 6
-rr2cbikkZp
-BDFChar: 5722 9706 6 0 6 0 6
-re?H)^Ae*3
-BDFChar: 5723 9645 6 0 5 0 3
-r.Kb$
-BDFChar: 5724 9686 6 0 3 0 6
-0Q?ONn8L&]
-BDFChar: 5725 9687 6 3 6 0 6
-^u4_OnDM(^
-BDFChar: 5726 9677 6 0 6 0 6
-3,GUpWbaWp
-BDFChar: 5727 9676 6 0 6 0 6
-&4?MM!(7@u
-BDFChar: 5728 9696 6 0 6 3 6
-3(/@M
-BDFChar: 5729 9697 6 0 6 0 3
-Jq?BM
-BDFChar: 5730 9692 6 0 3 3 6
-0L1/=
-BDFChar: 5731 9693 6 3 6 3 6
-^`X1"
-BDFChar: 5732 9694 6 3 6 0 3
-&.fu"
-BDFChar: 5733 9695 6 0 3 0 3
-J:Km=
-BDFChar: 5734 9708 6 0 6 0 6
-&1Aqp<.b)L
-BDFChar: 5735 9709 6 0 6 0 6
-&3)XkFRoD2
-BDFChar: 5736 9710 6 0 6 0 6
-&3)XS>b:op
-BDFChar: 5737 9690 6 0 6 3 9
-rr2or`k&_]
-BDFChar: 5738 9691 6 0 6 -3 3
-]"5o\rr2ls
-BDFChar: 5739 9720 6 0 6 0 6
-re-)hTYQ'X
-BDFChar: 5740 9721 6 0 6 0 6
-r^%eA$3gP3
-BDFChar: 5741 9722 6 0 6 0 6
-JA@h>LkPa-
-BDFChar: 5742 9655 6 1 5 -1 7
-JA@h>Lle:FJ,fQL
-BDFChar: 5743 9659 6 1 5 1 5
-JDdrqJ,fQL
-BDFChar: 5744 9665 6 1 5 -1 7
-#T+s\Le&p2#QOi)
-BDFChar: 5745 9669 6 1 5 1 5
-#WV$-#QOi)
-BDFChar: 5746 9652 6 1 5 1 5
-+E2;pp](9o
-BDFChar: 5747 9653 6 1 5 1 5
-+Abmjp](9o
-BDFChar: 5748 9662 6 1 5 1 5
-q"SfI+92BA
-BDFChar: 5749 9663 6 1 5 1 5
-pkVaC+92BA
-BDFChar: 5750 9656 6 2 4 1 5
-JAC*YJ,fQL
-BDFChar: 5751 9657 6 2 4 1 5
-JA@hnJ,fQL
-BDFChar: 5752 9666 6 2 4 1 5
-+CO,8+92BA
-BDFChar: 5753 9667 6 2 4 1 5
-+CLjM+92BA
-BDFChar: 5754 9862 6 0 6 0 6
-3(/@UJj_Qu
-BDFChar: 5755 9864 6 0 6 0 6
-3.1`!rd6[*
-BDFChar: 5756 9865 6 0 6 0 6
-3.1_Vrd6[*
-BDFChar: 5757 8687 6 1 5 -1 7
-+Af"5Leu`[p](9o
-BDFChar: 5758 11029 6 0 6 0 6
-rkd[cqYpHo
-BDFChar: 5759 11028 6 0 6 0 6
-rr0X'Ne[N5
-BDFChar: 5760 11027 6 0 6 0 6
-rdob$rr2ls
-BDFChar: 5761 11026 6 0 6 0 6
-rr2orJqEt%
-BDFChar: 5762 11034 6 0 6 0 6
-WW7VNJcMeN
-BDFChar: 5763 11057 6 1 5 -1 7
-5kmT0pcq+>5QCca
-BDFChar: 5764 11192 6 1 5 0 6
-+Ahi0E):KR
-BDFChar: 5765 10629 6 1 4 -2 8
-0MkT=TV.sN:f&hG
-BDFChar: 5766 10630 6 2 5 -2 8
-^n@>s:f'tbTV0(#
-BDFChar: 5767 9760 12 1 11 -2 8
-@)/q<n_bO?.Y&dp&HFG6n_gRC@))aB
-BDFChar: 5768 9762 12 1 11 -2 8
-%KJ56EPQq:s5<e4KHO#T?U-i+%KHJ/
-BDFChar: 5769 9763 12 1 11 -1 8
-$31Y<21RE35Ce*rhdEU[*rp;r
-BDFChar: 5770 9765 6 1 5 0 7
-+AblWp`L\%
-BDFChar: 5771 9766 6 1 5 0 7
-+E/Iu+CHlG
-BDFChar: 5772 9767 6 0 5 0 7
-3$]b/+K07X
-BDFChar: 5773 9769 6 0 6 0 6
-3"V8POq9SQ
-BDFChar: 5774 9764 6 0 6 -1 7
-&FNLW<&di:;ucmu
-BDFChar: 5775 9770 6 0 6 0 7
-4CZCeaOFZ]
-BDFChar: 5776 9771 6 -1 7 -1 7
-#QRj)Lk)LUWdq+"S:F02)uos=
-BDFChar: 5777 9772 6 -1 7 -1 7
->l^mTWdq+"h14gA^49Jh#QOi)
-BDFChar: 5778 9773 6 0 5 0 7
-0F.dq1^J2R
-BDFChar: 5779 9774 12 1 11 -2 8
-%KJA:6pO.*KHPpjNZ_=eAAC'Q%KHJ/
-BDFChar: 5780 9775 12 1 11 -2 8
-%KJ565X9QZp`SrHr*Y#iJ&":!%KHJ/
-BDFChar: 5781 9789 6 0 5 -1 8
-i&DPn$k+*m38ac:
-BDFChar: 5782 9790 6 1 6 -1 8
-*,o<D^qel9E#\iX
-BDFChar: 5783 9761 6 1 5 0 7
-n/)ur@)0R&
-BDFChar: 5784 3647 6 1 5 -1 8
-+Rl>.n>N:an/q]2
-BDFChar: 5785 8241 6 1 8 0 8
-5bLXZ+@)r,.KBGK
-BDFChar: 5786 8490 6 1 5 0 7
-Lle:fOH>9S
-BDFChar: 5787 9743 12 1 11 -2 8
-J&$RWT-3[^/q?ea<BsDHNZ`ips53kW
-BDFChar: 5788 9742 12 1 11 -2 8
-J&)*Bi8E!j5CbJ=AADrqjP]Rds53kW
-BDFChar: 5789 9750 6 0 6 0 7
-3,CuNJqAUR
-BDFChar: 5790 9751 6 0 6 0 7
-3.-+$rr2or
-BDFChar: 5791 9832 12 1 11 0 8
-$@iik'`\SkC;?)W^gR3#5C`_6
-BDFChar: 5792 10016 6 0 8 -1 7
-4ocQ&Lk*Tts+&4ALk$HF4obQ_
-BDFChar: 5793 9646 6 1 4 0 7
-nF5r:nF5r:
-BDFChar: 5794 9647 6 1 4 0 7
-n;r`nOH>Rn
-BDFChar: 5795 9648 6 0 5 0 3
-I!k_a
-BDFChar: 5796 9649 6 0 5 0 3
-Hpiec
-BDFChar: 5797 9747 6 1 5 -1 8
-Lknl(+<XKWLkl$2
-BDFChar: 5798 8880 6 1 5 0 6
-&-su*0F/3i
-BDFChar: 5799 8881 6 1 5 0 6
-5_*5Z@":KB
-BDFChar: 5800 8889 6 1 5 0 6
-+<U[:!$EBa
-BDFChar: 5801 8890 6 2 4 0 6
-i'9Om5X7R7
-BDFChar: 5802 8912 6 1 5 0 6
-3'b!H\3N"R
-BDFChar: 5803 8913 6 1 5 0 6
-i"5*#kRcYP
-BDFChar: 5804 8914 6 0 6 0 6
-3(1?XWiE'!
-BDFChar: 5805 8915 6 0 6 0 6
-WiE)!\jSLX
-BDFChar: 5806 8916 6 1 5 0 7
-+<YX%W2QYn
-BDFChar: 5807 10013 6 1 5 0 7
-+<^G%+<VdL
-BDFChar: 5808 10014 6 1 5 0 7
-E7g!!:f'u-
-BDFChar: 5809 10015 6 1 6 0 7
-0JNG&0JG17
-BDFChar: 5810 10017 6 0 6 0 7
-&1ING7/eSG
-BDFChar: 5811 10018 6 0 6 0 6
-&.fEP&.fBQ
-BDFChar: 5812 10019 6 0 6 -1 7
-&3(5#r_sFg&-)\1
-BDFChar: 5813 10020 6 0 6 0 6
-3&oLgei5Vh
-BDFChar: 5814 10021 6 0 6 -1 7
-&3(5#r_sFg&-)\1
-BDFChar: 5815 10023 6 0 6 0 6
-&.g80-kHpi
-BDFChar: 5816 10027 6 1 5 1 6
-+<^GUE/4Jo
-BDFChar: 5817 10028 6 1 5 1 6
-+<^GuE/4Jo
-BDFChar: 5818 10031 6 1 5 1 6
-+<^GuE/4Jo
-BDFChar: 5819 10025 6 1 5 1 6
-+<^GUE/4Jo
-BDFChar: 5820 10032 6 1 5 1 6
-+<^GUE/4Jo
-BDFChar: 5821 10026 6 0 6 0 7
-3,J#7`fb^/
-BDFChar: 5822 10033 6 0 6 0 6
-&Cu4gI+Ai/
-BDFChar: 5823 10034 6 1 5 0 5
-+K/+5W#u'?
-BDFChar: 5824 10035 6 0 6 0 6
-&6(Xg3)gFh
-BDFChar: 5825 10036 6 0 6 0 6
-&6(Xg3)gFh
-BDFChar: 5826 10037 6 0 6 0 6
-&6(Xg3)gFh
-BDFChar: 5827 10070 6 0 6 0 6
-&3*YW<&bEh
-BDFChar: 5828 11030 6 0 6 0 6
-&3+e&F>sg3
-BDFChar: 5829 11031 6 0 6 0 6
-&3*pd>W<8p
-BDFChar: 5830 11032 6 0 6 0 6
-&3,(:6mrTH
-BDFChar: 5831 11033 6 0 6 0 6
-&1BsGHoMZ;
-BDFChar: 5832 11210 6 0 6 3 6
-3.1`)
-BDFChar: 5833 11211 6 0 6 0 3
-rr.:)
-BDFChar: 5834 9753 6 0 5 0 7
-+=n'@A9;eK
-BDFChar: 5835 10087 6 1 6 0 7
-&C;P-R(,*q
-BDFChar: 5836 10086 6 0 5 0 6
-A@N1aG]5VB
-BDFChar: 5837 10085 6 0 5 0 6
-@.<r=q!_Yk
-BDFChar: 5838 10083 6 1 5 -1 8
-;#'g)+<UY,E$,,\
-BDFChar: 5839 10082 6 1 5 -1 8
-E;93I+<UY,E$,,\
-BDFChar: 5840 10068 12 3 8 -2 8
-Gl5bo*&oW+!&-),
-BDFChar: 5841 10069 12 5 6 -2 8
-^qdb$^qdb$!5QAM
-BDFChar: 5842 10071 12 5 6 -2 8
-^qdb$^qdb$!5QAM
-BDFChar: 5843 10799 6 1 5 1 5
-Leo3jL]@DT
-BDFChar: 5844 9135 6 0 5 3 3
-qu?]s
-BDFChar: 5845 11373 6 1 5 0 7
-BUFU3LkqF3
-BDFChar: 5846 11362 6 0 5 0 7
-+<Ve?YTP&N
-BDFChar: 5847 581 6 1 5 0 7
-+<XKW:l'p`
-BDFChar: 5848 573 6 1 5 0 7
-5X7Tm5X7SZ
-BDFChar: 5849 574 6 1 5 0 7
-p`Lt=+CLib
-BDFChar: 5850 571 6 1 5 -1 8
-&9+#0TV.t!E'OC'
-BDFChar: 5851 570 6 1 5 -1 8
-&9+#8W;*=4a?T_*
-BDFChar: 5852 572 6 1 5 -1 6
-&9+#0TZD(;
-BDFChar: 5853 579 6 1 5 0 7
-E(EN=8E`T`
-BDFChar: 5854 696 6 2 4 3 7
-TV,[8^]4?7
-BDFChar: 5855 7611 6 2 4 4 8
-i#k:8huE`W
-BDFChar: 5856 7615 6 2 4 4 8
-5bR&.5QCca
-BDFChar: 5857 8370 6 1 5 -1 8
-+E49PTX^r!E$,,\
-BDFChar: 5858 8372 6 0 5 0 8
-0LuKI0`41,0E;(Q
-BDFChar: 5859 8373 6 1 5 -1 8
-+E49PTV.sVE$,,\
-BDFChar: 5860 8376 6 1 5 0 7
-p]1(3+<VdL
-BDFChar: 5861 8377 6 1 5 0 7
-p^m33i#iRB
-BDFChar: 5862 8378 6 1 5 0 7
-5Ytk8@)tlX
-BDFChar: 5863 8380 6 1 5 0 7
-+<YX%W2QYn
-BDFChar: 5864 8382 6 1 5 0 8
-:iP(>J:N/8p](9o
-BDFChar: 5865 567 6 2 4 -2 5
-?m$R7+<[=B
-BDFChar: 5866 10761 6 0 6 0 6
-Jj_!u-q&Xe
-BDFChar: 5867 975 6 1 5 -2 7
-Lle:F^n?dF&0LrQ
-BDFChar: 5868 983 6 1 5 -2 5
-Lle:fOGFGj
-BDFChar: 5869 10096 6 1 5 -1 7
-3&kkri,EWp2uipY
-BDFChar: 5870 10097 6 1 5 -1 7
-i8AQn3,iiphuE`W
-BDFChar: 5871 10100 6 1 4 -2 8
-0OS9r@)-/X?skYg
-BDFChar: 5872 10101 6 2 5 -2 8
-^gLPX?nbtr?spbM
-BDFChar: 5873 10098 6 2 4 -2 8
-+@(I-J:N0#J3Y4W
-BDFChar: 5874 10099 6 2 4 -2 8
-J3Y5"+<VdL+@(GW
-BDFChar: 5875 9752 6 0 6 -1 7
--oa3;rmhVl+92BA
-BDFChar: 5876 127808 12 2 10 -2 8
-@fZ7RpOI_n)utHgs+(-"CB+V?"98E%
-BDFChar: 5877 884 6 2 3 6 8
-5X9i"
-BDFChar: 5878 885 6 2 3 -1 1
-5X9i"
-BDFChar: 5879 11037 6 2 4 2 4
-i8EMn
-BDFChar: 5880 11038 6 2 4 2 4
-i1T!.
-BDFChar: 5881 9725 12 4 8 1 5
-pkX`^p](9o
-BDFChar: 5882 11035 12 2 10 -1 7
-s+(-"s+(-"s+(-"s+(-"s*t(L
-BDFChar: 5883 11036 12 2 10 -1 7
-s+#WMJ:N0#J:N0#J:N0#s*t(L
-BDFChar: 5884 9726 12 4 8 1 5
-q"XXZp](9o
-BDFChar: 5885 11039 6 1 5 1 6
-+E7,NE,YdW
-BDFChar: 5886 11040 6 1 5 1 6
-+AdlM:iHC7
-BDFChar: 5887 11041 6 1 5 0 6
-+AdlMLeo2o
-BDFChar: 5888 11043 6 0 5 1 5
-0R3M?0E;(Q
-BDFChar: 5889 11045 6 1 5 1 5
-+E7*p+92BA
-BDFChar: 5890 11046 6 1 5 1 5
-+Adkj+92BA
-BDFChar: 5891 11047 6 1 5 0 6
-+E2;pE,Zp"
-BDFChar: 5892 11048 6 1 5 0 6
-+Abmj:f&87
-BDFChar: 5893 11049 6 2 4 2 4
-5i=m-
-BDFChar: 5894 11050 6 2 4 1 5
-5X=6m5QCca
-BDFChar: 5895 11051 6 2 4 1 5
-5X:u-5QCca
-BDFChar: 5896 11052 6 0 5 1 5
-Gl7L;GQ7^D
-BDFChar: 5897 11053 6 0 5 1 5
-G_Ca'GQ7^D
-BDFChar: 5898 11054 6 1 5 0 6
-E;95'q"Se.
-BDFChar: 5899 11055 6 1 5 0 6
-E/9=+Lkp!M
-BDFChar: 5900 11205 6 1 5 1 5
-+<YWBp](9o
-BDFChar: 5901 11206 6 1 5 1 5
-pi(0p+92BA
-BDFChar: 5902 11207 6 1 5 1 5
-#WVT=#QOi)
-BDFChar: 5903 11208 6 1 5 1 5
-JDg4\J,fQL
-BDFChar: 5904 8232 6 0 0 0 0
+BDFChar: -1 12352 12 0 0 0 0
 z
-BDFChar: 5905 11091 6 1 6 1 5
+BDFChar: 3684 129792 6 0 2 6 9
+i8EPO
+BDFChar: 3685 129793 6 3 5 6 9
+i8EPO
+BDFChar: 3686 129794 6 0 5 6 9
+r;?Kj
+BDFChar: 3687 129795 6 0 2 1 5
+i8EPOhuE`W
+BDFChar: 3688 129796 6 0 2 1 9
+i8EPOi8EPOhuE`W
+BDFChar: 3689 129797 6 0 5 1 9
+*#oq<i8EPOhuE`W
+BDFChar: 3690 129798 6 0 5 1 9
+r;?Kji8EPOhuE`W
+BDFChar: 3691 129799 6 3 5 1 5
+i8EPOhuE`W
+BDFChar: 3692 129800 6 0 5 1 9
+i8EPO*#oq<)uos=
+BDFChar: 3693 129801 6 3 5 1 9
+i8EPOi8EPOhuE`W
+BDFChar: 3694 129802 6 0 5 1 9
+r;?Kj*#oq<)uos=
+BDFChar: 3695 129803 6 0 5 1 5
+r;?Kjqu?]s
+BDFChar: 3696 129804 6 0 5 1 9
+i8EPOr;?Kjqu?]s
+BDFChar: 3697 129805 6 0 5 1 9
+*#oq<r;?Kjqu?]s
+BDFChar: 3698 129806 6 0 5 1 9
+r;?Kjr;?Kjqu?]s
+BDFChar: 3699 129807 6 0 2 -3 0
+i8EPO
+BDFChar: 3700 129808 6 0 2 -3 9
+i8EPOz!8uenhuE`W
+BDFChar: 3701 129809 6 0 5 -3 9
+*#oq<z!8uenhuE`W
+BDFChar: 3702 129810 6 0 5 -3 9
+r;?Kjz!8uenhuE`W
+BDFChar: 3703 129811 6 0 2 -3 5
+i8EPOi8EPOhuE`W
+BDFChar: 3704 129812 6 0 5 -3 9
+*#oq<i8EPOi8EPOhuE`W
+BDFChar: 3705 129813 6 0 5 -3 9
+r;?Kji8EPOi8EPOhuE`W
+BDFChar: 3706 129814 6 0 5 -3 5
+*#oq<*8oc5huE`W
+BDFChar: 3707 129815 6 0 5 -3 9
+i8EPO*#oq<*8oc5huE`W
+BDFChar: 3708 129816 6 0 5 -3 9
+*#oq<*#oq<*8oc5huE`W
+BDFChar: 3709 129817 6 0 5 -3 9
+r;?Kj*#oq<*8oc5huE`W
+BDFChar: 3710 129818 6 0 5 -3 5
+r;?Kjr8?MkhuE`W
+BDFChar: 3711 129819 6 0 5 -3 9
+i8EPOr;?Kjr8?MkhuE`W
+BDFChar: 3712 129820 6 0 5 -3 9
+*#oq<r;?Kjr8?MkhuE`W
+BDFChar: 3713 129821 6 0 5 -3 9
+r;?Kjr;?Kjr8?MkhuE`W
+BDFChar: 3714 129822 6 3 5 -3 0
+i8EPO
+BDFChar: 3715 129823 6 0 5 -3 9
+i8EPOz!#usu)uos=
+BDFChar: 3716 129824 6 3 5 -3 9
+i8EPOz!8uenhuE`W
+BDFChar: 3717 129825 6 0 5 -3 9
+r;?Kjz!#usu)uos=
+BDFChar: 3718 129826 6 0 5 -3 5
+i8EPOi#E^V)uos=
+BDFChar: 3719 129827 6 0 5 -3 9
+i8EPOi8EPOi#E^V)uos=
+BDFChar: 3720 129828 6 0 5 -3 9
+*#oq<i8EPOi#E^V)uos=
+BDFChar: 3721 129829 6 0 5 -3 9
+r;?Kji8EPOi#E^V)uos=
+BDFChar: 3722 129830 6 3 5 -3 5
+i8EPOi8EPOhuE`W
+BDFChar: 3723 129831 6 0 5 -3 9
+i8EPO*#oq<*#oq<)uos=
+BDFChar: 3724 129832 6 0 5 -3 9
+r;?Kj*#oq<*#oq<)uos=
+BDFChar: 3725 129833 6 0 5 -3 5
+r;?Kjr#?[r)uos=
+BDFChar: 3726 129834 6 0 5 -3 9
+i8EPOr;?Kjr#?[r)uos=
+BDFChar: 3727 129835 6 0 5 -3 9
+*#oq<r;?Kjr#?[r)uos=
+BDFChar: 3728 129836 6 0 5 -3 9
+r;?Kjr;?Kjr#?[r)uos=
+BDFChar: 3729 129837 6 0 5 -3 0
+r;?Kj
+BDFChar: 3730 129838 6 0 5 -3 9
+i8EPOz!;ucmqu?]s
+BDFChar: 3731 129839 6 0 5 -3 9
+*#oq<z!;ucmqu?]s
+BDFChar: 3732 129840 6 0 5 -3 9
+r;?Kjz!;ucmqu?]s
+BDFChar: 3733 129841 6 0 5 -3 5
+i8EPOi;ENNqu?]s
+BDFChar: 3734 129842 6 0 5 -3 9
+i8EPOi8EPOi;ENNqu?]s
+BDFChar: 3735 129843 6 0 5 -3 9
+*#oq<i8EPOi;ENNqu?]s
+BDFChar: 3736 129844 6 0 5 -3 9
+r;?Kji8EPOi;ENNqu?]s
+BDFChar: 3737 129845 6 0 5 -3 5
+*#oq<*;oa4qu?]s
+BDFChar: 3738 129846 6 0 5 -3 9
+i8EPO*#oq<*;oa4qu?]s
+BDFChar: 3739 129847 6 0 5 -3 9
+*#oq<*#oq<*;oa4qu?]s
+BDFChar: 3740 129848 6 0 5 -3 9
+r;?Kj*#oq<*;oa4qu?]s
+BDFChar: 3741 129849 6 0 5 -3 5
+r;?Kjr;?Kjqu?]s
+BDFChar: 3742 129850 6 0 5 -3 9
+i8EPOr;?Kjr;?Kjqu?]s
+BDFChar: 3743 129851 6 0 5 -3 9
+*#oq<r;?Kjr;?Kjqu?]s
+BDFChar: 3744 117793 6 1 2 4 8
+^qdb$^]4?7
+BDFChar: 3745 117794 6 4 5 4 8
+^qdb$^]4?7
+BDFChar: 3746 117795 6 1 5 4 8
+f\"j/fDkmO
+BDFChar: 3747 117796 6 1 2 -2 2
+^qdb$^]4?7
+BDFChar: 3748 117797 6 1 2 -2 8
+^qdb$^];0c^qd_c
+BDFChar: 3749 117798 6 1 5 -2 8
+(`4),(]_@e^qd_c
+BDFChar: 3750 117799 6 1 5 -2 8
+f\"j/fDr_&^qd_c
+BDFChar: 3751 117800 6 4 5 -2 2
+^qdb$^]4?7
+BDFChar: 3752 117801 6 1 5 -2 8
+^qdb$^]52g(`4(i
+BDFChar: 3753 117802 6 4 5 -2 8
+^qdb$^];0c^qd_c
+BDFChar: 3754 117803 6 1 5 -2 8
+f\"j/fDla*(`4(i
+BDFChar: 3755 117804 6 1 5 -2 2
+f\"j/fDkmO
+BDFChar: 3756 117805 6 1 5 -2 8
+^qdb$^]<$>f\"gV
+BDFChar: 3757 117806 6 1 5 -2 8
+(`4),(]`4@f\"gV
+BDFChar: 3758 117807 6 1 5 -2 8
+f\"j/fDsRVf\"gV
+BDFChar: 3759 118353 6 1 2 6 8
+^qd_c
+BDFChar: 3760 118354 6 4 5 6 8
+^qd_c
+BDFChar: 3761 118355 6 1 5 6 8
+f\"gV
+BDFChar: 3762 118356 6 1 2 2 4
+^qd_c
+BDFChar: 3763 118357 6 1 2 2 8
+^qd_c^qd_c
+BDFChar: 3764 118358 6 1 5 2 8
+(`4(i^qd_c
+BDFChar: 3765 118359 6 1 5 2 8
+f\"gV^qd_c
+BDFChar: 3766 118360 6 4 5 2 4
+^qd_c
+BDFChar: 3767 118361 6 1 5 2 8
+^qd_c(`4(i
+BDFChar: 3768 118362 6 4 5 2 8
+^qd_c^qd_c
+BDFChar: 3769 118363 6 1 5 2 8
+f\"gV(`4(i
+BDFChar: 3770 118364 6 1 5 2 4
+f\"gV
+BDFChar: 3771 118365 6 1 5 2 8
+^qd_cf\"gV
+BDFChar: 3772 118366 6 1 5 2 8
+(`4(if\"gV
+BDFChar: 3773 118367 6 1 5 2 8
+f\"gVf\"gV
+BDFChar: 3774 118368 6 1 2 -2 0
+^qd_c
+BDFChar: 3775 118369 6 1 2 -2 8
+^qd_cz^qd_c
+BDFChar: 3776 118370 6 1 5 -2 8
+(`4(iz^qd_c
+BDFChar: 3777 118371 6 1 5 -2 8
+f\"gVz^qd_c
+BDFChar: 3778 118372 6 1 2 -2 4
+^qd_c^qd_c
+BDFChar: 3779 118373 6 1 2 -2 8
+^qd_c^qd_c^qd_c
+BDFChar: 3780 118374 6 1 5 -2 8
+(`4(i^qd_c^qd_c
+BDFChar: 3781 118375 6 1 5 -2 8
+f\"gV^qd_c^qd_c
+BDFChar: 3782 118376 6 1 5 -2 4
+(`4(i^qd_c
+BDFChar: 3783 118377 6 1 5 -2 8
+^qd_c(`4(i^qd_c
+BDFChar: 3784 118378 6 1 5 -2 8
+(`4(i(`4(i^qd_c
+BDFChar: 3785 118379 6 1 5 -2 8
+f\"gV(`4(i^qd_c
+BDFChar: 3786 118380 6 1 5 -2 4
+f\"gV^qd_c
+BDFChar: 3787 118381 6 1 5 -2 8
+^qd_cf\"gV^qd_c
+BDFChar: 3788 118382 6 1 5 -2 8
+(`4(if\"gV^qd_c
+BDFChar: 3789 118383 6 1 5 -2 8
+f\"gVf\"gV^qd_c
+BDFChar: 3790 118384 6 4 5 -2 0
+^qd_c
+BDFChar: 3791 118385 6 1 5 -2 8
+^qd_cz(`4(i
+BDFChar: 3792 118386 6 4 5 -2 8
+^qd_cz^qd_c
+BDFChar: 3793 118387 6 1 5 -2 8
+f\"gVz(`4(i
+BDFChar: 3794 118388 6 1 5 -2 4
+^qd_c(`4(i
+BDFChar: 3795 118389 6 1 5 -2 8
+^qd_c^qd_c(`4(i
+BDFChar: 3796 118390 6 1 5 -2 8
+(`4(i^qd_c(`4(i
+BDFChar: 3797 118391 6 1 5 -2 8
+f\"gV^qd_c(`4(i
+BDFChar: 3798 118392 6 4 5 -2 4
+^qd_c^qd_c
+BDFChar: 3799 118393 6 1 5 -2 8
+^qd_c(`4(i(`4(i
+BDFChar: 3800 118394 6 4 5 -2 8
+^qd_c^qd_c^qd_c
+BDFChar: 3801 118395 6 1 5 -2 8
+f\"gV(`4(i(`4(i
+BDFChar: 3802 118396 6 1 5 -2 4
+f\"gV(`4(i
+BDFChar: 3803 118397 6 1 5 -2 8
+^qd_cf\"gV(`4(i
+BDFChar: 3804 118398 6 1 5 -2 8
+(`4(if\"gV(`4(i
+BDFChar: 3805 118399 6 1 5 -2 8
+f\"gVf\"gV(`4(i
+BDFChar: 3806 118400 6 1 5 -2 0
+f\"gV
+BDFChar: 3807 118401 6 1 5 -2 8
+^qd_czf\"gV
+BDFChar: 3808 118402 6 1 5 -2 8
+(`4(izf\"gV
+BDFChar: 3809 118403 6 1 5 -2 8
+f\"gVzf\"gV
+BDFChar: 3810 118404 6 1 5 -2 4
+^qd_cf\"gV
+BDFChar: 3811 118405 6 1 5 -2 8
+^qd_c^qd_cf\"gV
+BDFChar: 3812 118406 6 1 5 -2 8
+(`4(i^qd_cf\"gV
+BDFChar: 3813 118407 6 1 5 -2 8
+f\"gV^qd_cf\"gV
+BDFChar: 3814 118408 6 1 5 -2 4
+(`4(if\"gV
+BDFChar: 3815 118409 6 1 5 -2 8
+^qd_c(`4(if\"gV
+BDFChar: 3816 118410 6 1 5 -2 8
+(`4(i(`4(if\"gV
+BDFChar: 3817 118411 6 1 5 -2 8
+f\"gV(`4(if\"gV
+BDFChar: 3818 118412 6 1 5 -2 4
+f\"gVf\"gV
+BDFChar: 3819 118413 6 1 5 -2 8
+^qd_cf\"gVf\"gV
+BDFChar: 3820 118414 6 1 5 -2 8
+(`4(if\"gVf\"gV
+BDFChar: 3821 118415 6 1 5 -2 8
+f\"gVf\"gVf\"gV
+BDFChar: 3822 130032 6 1 5 -1 7
+E/9=+!/QGeDu]k<
+BDFChar: 3823 130033 6 5 5 0 6
+J:N.MJ:N.M
+BDFChar: 3824 130034 6 1 5 -1 7
+E!Q^TE.EIhDu]k<
+BDFChar: 3825 130035 6 2 5 -1 7
+i"-G2i"-G2huE`W
+BDFChar: 3826 130036 6 1 5 0 6
+Lkpk+#RC\9
+BDFChar: 3827 130037 6 1 5 -1 7
+E.EIhE!Q^TDu]k<
+BDFChar: 3828 130038 6 1 5 -1 7
+E.EIhE/9=+Du]k<
+BDFChar: 3829 130039 6 1 5 0 7
+E/9=+!!ii9
+BDFChar: 3830 130040 6 1 5 -1 7
+E/9=+E/9=+Du]k<
+BDFChar: 3831 130041 6 1 5 -1 7
+E/9=+E!Q^TDu]k<
+BDFChar: 3832 118000 6 0 5 0 7
+G_EH"PdH*g
+BDFChar: 3833 118001 6 1 4 0 7
+E6s]n:f'u-
+BDFChar: 3834 118002 6 0 5 0 7
+G_EHR-sVH'
+BDFChar: 3835 118003 6 0 5 0 7
+G_G][FS(62
+BDFChar: 3836 118004 6 0 5 0 7
+*$eLjK_,ru
+BDFChar: 3837 118005 6 0 5 0 7
+r.M_=FS(62
+BDFChar: 3838 118006 6 0 5 0 7
+G_ES[['YL2
+BDFChar: 3839 118007 6 0 5 0 7
+r.O\V-n$K'
+BDFChar: 3840 118008 6 0 5 0 7
+G_EGW['YL2
+BDFChar: 3841 118009 6 0 5 0 7
+G_EH2KQMll
+BDFChar: 3842 117974 6 0 5 0 7
+G_EH2KXA,a
+BDFChar: 3843 117975 6 0 5 0 7
+pk6#1['YM]
+BDFChar: 3844 117976 6 0 5 0 7
+G_EH6\?pp6
+BDFChar: 3845 117977 6 0 5 0 7
+pk6#]['YM]
+BDFChar: 3846 117978 6 0 5 0 7
+r.M_=\@dLm
+BDFChar: 3847 117979 6 0 5 0 7
+r.M_=\=fMQ
+BDFChar: 3848 117980 6 0 5 0 7
+I"]/.['YL6
+BDFChar: 3849 117981 6 0 5 0 7
+r3Wha['[4<
+BDFChar: 3850 117982 6 1 5 0 7
+pk[R!:tUU!
+BDFChar: 3851 117983 6 0 5 0 7
+*#')$oX'9r
+BDFChar: 3852 117984 6 0 5 0 7
+r3WPmR&m[m
+BDFChar: 3853 117985 6 0 5 0 7
+i1Qa9TY,sU
+BDFChar: 3854 117986 6 0 5 0 7
+bd<%V['[4<
+BDFChar: 3855 117987 6 0 5 0 7
+gpE<1UnkBa
+BDFChar: 3856 117988 6 0 5 0 7
+G_EH2['YL2
+BDFChar: 3857 117989 6 0 5 0 7
+pk6#]KXd]5
+BDFChar: 3858 117990 6 0 5 0 7
+G_EH2[&fL>
+BDFChar: 3859 117991 6 0 5 0 7
+pk6#]KWMQY
+BDFChar: 3860 117992 6 0 5 0 7
+I"]/"AFtQM
+BDFChar: 3861 117993 6 1 5 0 7
+pk[R!:f'u-
+BDFChar: 3862 117994 6 0 5 0 7
+r3Wi<['YL2
+BDFChar: 3863 117995 6 0 5 0 7
+r3Wi<KLeWf
+BDFChar: 3864 117996 6 0 5 0 7
+r3Wi<KS6_V
+BDFChar: 3865 117997 6 0 5 0 7
+r3Wh%8@5c%
+BDFChar: 3866 117998 6 1 5 0 7
+po(.D:f'u-
+BDFChar: 3867 117999 6 0 5 0 7
+r.O\j:qVJZ
+BDFChar: 3868 129852 6 0 2 -3 0
+J:PGn
+BDFChar: 3869 129853 6 0 4 -3 0
+JAC[L
+BDFChar: 3870 129854 6 0 2 -3 3
+J:N0c^qek.
+BDFChar: 3871 129855 6 0 5 -3 4
+JAAtYnF65N
+BDFChar: 3872 129856 6 0 2 -3 7
+J:N0#JAAt9^u4,N
+BDFChar: 3873 129857 6 0 5 -3 9
+*'AUrr;?Kjr;?Kjqu?]s
+BDFChar: 3874 129858 6 0 5 -3 9
+":RD?r;?Kjr;?Kjqu?]s
+BDFChar: 3875 129859 6 0 5 -3 9
+*'?>GI!g>>r;?Kjqu?]s
+BDFChar: 3876 129860 6 0 5 -3 8
+":P\Y4?S#hr;?Kj
+BDFChar: 3877 129861 6 0 5 -3 9
+*#oq\4?P`RI!g>>qu?]s
+BDFChar: 3878 129862 6 0 5 -3 4
+$lhD-r;?Kj
+BDFChar: 3879 129863 6 3 5 -3 0
++<Y(M
+BDFChar: 3880 129864 6 1 5 -3 0
+#T.g]
+BDFChar: 3881 129865 6 3 5 -3 3
++<Ve7?sqmm
+BDFChar: 3882 129866 6 0 5 -3 4
+":P\Y4?S#h
+BDFChar: 3883 129867 6 3 5 -3 7
++<VdL+CJSb@,TrC
+BDFChar: 3884 129868 6 0 5 -3 9
+i:-O:r;?Kjr;?Kjqu?]s
+BDFChar: 3885 129869 6 0 5 -3 9
+JAC[Lr;?Kjr;?Kjqu?]s
+BDFChar: 3886 129870 6 0 5 -3 9
+i:-7*q"XX^r;?Kjqu?]s
+BDFChar: 3887 129871 6 0 5 -3 8
+JAAtYnF65Nr;?Kj
+BDFChar: 3888 129872 6 0 5 -3 9
+i8EP_nF5rBq"XX^qu?]s
+BDFChar: 3889 129873 6 0 5 -3 4
+^u4_[r;?Kj
+BDFChar: 3890 129874 6 0 5 -3 9
+r;?Kjr;?Kjr-WlS)uos=
+BDFChar: 3891 129875 6 0 5 -3 9
+r;?Kjr;?Kjr-UU8"98E%
+BDFChar: 3892 129876 6 0 5 -3 9
+r;?Kjr;:qiHosMR)uos=
+BDFChar: 3893 129877 6 0 5 -2 9
+r;?Kjr-UUh*"35Y
+BDFChar: 3894 129878 6 0 5 -3 9
+r;:qiI!g<(4?P_G)uos=
+BDFChar: 3895 129879 6 0 2 6 9
+i4skn
+BDFChar: 3896 129880 6 0 4 6 9
+q!c(L
+BDFChar: 3897 129881 6 0 2 3 9
+i5!.DJ:N.M
+BDFChar: 3898 129882 6 0 5 2 9
+r:odNi5!-Y
+BDFChar: 3899 129883 6 0 2 -1 9
+i8EP/^qda9J:N.M
+BDFChar: 3900 129884 6 0 5 2 9
+r;?Kjr:&X[
+BDFChar: 3901 129885 6 0 5 -3 9
+r;?Kjr;?Kjr:p'VhuE`W
+BDFChar: 3902 129886 6 0 5 -3 9
+r;?Kjr;?Kjr:ocsJ,fQL
+BDFChar: 3903 129887 6 0 5 -3 9
+r;?Kjr;??bq!deBhuE`W
+BDFChar: 3904 129888 6 0 5 -2 9
+r;?Kjr:odNi5!-Y
+BDFChar: 3905 129889 6 0 5 -3 9
+r;?Kfq"XXRnF5r*huE`W
+BDFChar: 3906 129890 6 3 5 6 9
+i*[ZM
+BDFChar: 3907 129891 6 1 5 6 9
+pimV]
+BDFChar: 3908 129892 6 3 5 3 9
+i*]r#+<Vd,
+BDFChar: 3909 129893 6 0 5 2 9
+r-UUh*"35Y
+BDFChar: 3910 129894 6 3 5 -1 9
+i8EO$?sm@b+<Vd,
+BDFChar: 3911 129895 6 0 5 2 9
+r;?Kjr&br-
+BDFChar: 3912 129896 6 0 5 -3 9
+r-WlS4<,=\4?S"=qu?]s
+BDFChar: 3913 129897 6 0 5 -3 8
+KS7Rnr;?Kjr;?Kj
+BDFChar: 3914 129898 6 0 5 -3 9
+r:p'VnDN6_nF65Jqu?]s
+BDFChar: 3915 129899 6 0 5 -2 9
+r;?Kjr;?Kjbfk`n
+BDFChar: 3916 129900 6 0 2 -2 8
+J:PGNi8EP/^jpq8
+BDFChar: 3917 129902 6 3 5 -2 8
++<Y'"i8EO$?m$Ql
+BDFChar: 3918 129901 6 0 5 5 9
+r-3H?0E;(Q
+BDFChar: 3919 129903 6 0 5 -3 1
+0JI`rqu?]s
+BDFChar: 3920 129946 6 0 5 -3 9
+r-3H?0E;(Q0JI`rqu?]s
+BDFChar: 3921 129947 6 0 5 -2 8
+KS7Rnr;?K:b_1WL
+BDFChar: 3922 9698 6 0 5 -3 8
+"9],A*#oq\4FDPS
+BDFChar: 3923 9699 6 0 5 -3 8
+J:PGNi8EP_nG)eV
+BDFChar: 3924 9700 6 0 5 -2 9
+r:p'VnDN6_^qbJN
+BDFChar: 3925 9701 6 0 5 -2 9
+r-WlS4<,=\$k*7A
+BDFChar: 3926 129941 6 0 5 -3 9
+]Y#3ai:Q[6n6cZp]Dqp3
+BDFChar: 3927 129942 6 0 5 -3 9
+o^q&A*5&qs4;blpoDejk
+BDFChar: 3928 129943 6 0 5 -3 6
+r;?Hm!!!#sr;6Np
+BDFChar: 3929 129944 6 0 5 -3 9
+88KQYOP!*?,d`Zc8,rVi
+BDFChar: 3930 129945 6 0 5 -3 9
+8D'$2,]$$(OL-9L8,rVi
+BDFChar: 3931 129932 6 0 2 -3 9
+TKo/8TKo/8TKo/8TE"rl
+BDFChar: 3932 129933 6 3 5 -3 9
+5bLB85bLB85bLB85QCca
+BDFChar: 3933 129934 6 0 5 3 9
+W)T]pW)T\q
+BDFChar: 3934 129935 6 0 6 -3 2
+<2rot<2oou
+BDFChar: 3935 129936 6 0 5 -3 9
+<2`cp<2`cp<2`cp;ucmu
+BDFChar: 3936 129937 6 0 5 -3 9
+r;?Kjr;?Jk<2`cp;ucmu
+BDFChar: 3937 129938 6 0 5 -3 9
+<2`cp<2`dor;?Kjqu?]s
+BDFChar: 3938 129940 6 0 5 -3 9
+>eF=S>eF=S>eF=S>Q=a(
+BDFChar: 3939 129948 6 0 4 -1 9
+W)0EhTKo/8J3\Vb
+BDFChar: 3940 129949 6 0 5 -2 9
+W)P/Z-klq$#Qt,1
+BDFChar: 3941 129950 6 0 5 -3 8
+"98Q1'F5C$'IZqZ
+BDFChar: 3942 129951 6 0 4 -3 7
+J3\WMTKo/HW)0Dm
+BDFChar: 3943 130020 6 1 4 3 9
+nF5r:nF5oI
+BDFChar: 3944 130021 6 1 4 -3 2
+nF5r:nF-DX
+BDFChar: 3945 130022 6 0 2 0 6
+i8EPOi8EMn
+BDFChar: 3946 130023 6 3 5 0 6
+i8EPOi8EMn
+BDFChar: 3947 130016 6 0 5 3 9
+KS5#384YE7
+BDFChar: 3948 130017 6 3 5 -3 9
++@&2BJ:N0#J:KmM+92BA
+BDFChar: 3949 130018 6 0 5 -3 2
+0M"`fKS0=*
+BDFChar: 3950 130019 6 0 2 -3 9
+J3Z@B+<VdL+<Wp7J,fQL
+BDFChar: 3951 130024 6 0 5 3 9
+r;?KjG^(nB
+BDFChar: 3952 130025 6 3 5 -3 9
++CJU8i8EPOi8A!N+92BA
+BDFChar: 3953 130026 6 0 5 -3 2
+0R.j?r;6Np
+BDFChar: 3954 130027 6 0 2 -3 9
+JAAtYi8EPOi8DDdJ,fQL
+BDFChar: 3955 130028 6 3 5 3 9
+i8EPO?sk)W
+BDFChar: 3956 130029 6 0 2 -3 2
+JAAtYi8=S8
+BDFChar: 3957 130030 6 3 5 -3 2
++CJU8i8=S8
+BDFChar: 3958 130031 6 0 2 3 9
+i8EPO^qbI#
+BDFChar: 3959 130000 6 0 6 -3 3
+!X&c?+@(GW
+BDFChar: 3960 130001 6 0 6 3 9
+!X&c?+@(GW
+BDFChar: 3961 130002 6 0 6 3 9
+J3Y4g#Qt2/
+BDFChar: 3962 130003 6 0 6 -3 3
+J3Y4g#Qt2/
+BDFChar: 3963 130004 6 0 2 -3 9
+J:N0#5X7S"5Th0l+92BA
+BDFChar: 3964 130005 6 3 5 -3 9
+J:N0#5X7S"5Th0l+92BA
+BDFChar: 3965 130006 6 3 5 -3 9
++<VdL5X7S"5_+B8J,fQL
+BDFChar: 3966 130007 6 0 2 -3 9
++<VdL5X7S"5_+B8J,fQL
+BDFChar: 3967 130008 6 0 6 3 9
+Jj`!T-kHpi
+BDFChar: 3968 130009 6 3 6 -3 9
+&0N)\5_+B85X6G7&-)\1
+BDFChar: 3969 130010 6 0 6 -3 3
+&.g6<6puV,
+BDFChar: 3970 130011 6 0 3 -3 9
+J3Z@B+:o(q+<Wp7J,fQL
+BDFChar: 3971 130012 6 0 5 -3 9
+KS5#384Z9B82)_O0E;(Q
+BDFChar: 3972 130013 6 0 6 -3 9
+!X&c?+@(HB+:ne]!WW3#
+BDFChar: 3973 130014 6 0 5 -3 9
+0JG1784Z9B8;)YLKE(uP
+BDFChar: 3974 130015 6 0 6 -3 9
+J3Y4g#Qt23#S8+DJ,fQL
+BDFChar: 3975 129952 6 0 3 3 9
+&0N)\5_+@b
+BDFChar: 3976 129953 6 3 6 3 9
+J3Z@B+:o(a
+BDFChar: 3977 129954 6 0 3 -3 3
+J:KmM+<V3q
+BDFChar: 3978 129955 6 3 6 -3 3
+&.fs,5X9i"
+BDFChar: 3979 129956 6 0 3 -3 9
+&0N)\5_+B85X6G7&-)\1
+BDFChar: 3980 129957 6 3 6 -3 9
+J3Z@B+:o(q+<Wp7J,fQL
+BDFChar: 3981 129958 6 0 6 -3 3
+Jq?BY-n#W,
+BDFChar: 3982 129959 6 0 6 3 9
+&1Aqp7"U!j
+BDFChar: 3983 129960 6 0 6 -3 9
+&0N)\5_+@d"9\u9&-)\1
+BDFChar: 3984 129961 6 0 6 -3 9
+&-rOE"9O1*5X6G7&-)\1
+BDFChar: 3985 129962 6 0 6 -3 9
+&-rOE"9O1,6prFO&-)\1
+BDFChar: 3986 129963 6 0 6 -3 9
+&0N)\5_+H<6prFO&-)\1
+BDFChar: 3987 129964 6 0 6 -3 9
+&1Aqp7"U!l"9\u9&-)\1
+BDFChar: 3988 129965 6 0 6 -3 9
+&1Aqp7"U#@5X6G7&-)\1
+BDFChar: 3989 129966 6 0 6 -3 9
+&1Aqp7"U#B6prFO&-)\1
+BDFChar: 3990 118298 6 2 5 -3 3
+0Q:FX^qd_c
+BDFChar: 3991 118299 6 2 5 -3 4
+nF5q_^qdb$
+BDFChar: 3992 118300 6 2 3 -3 4
+^qdb$^qdb$
+BDFChar: 3993 118301 6 2 5 -3 4
+JAC+4nBetd
+BDFChar: 3994 118302 6 2 5 2 4
+nF5oI
+BDFChar: 3995 118303 6 0 5 2 4
+r;?Hm
+BDFChar: 3996 118304 6 0 5 -3 4
+r;?IH0JG17
+BDFChar: 3997 118305 6 0 5 -3 0
+KZs@=
+BDFChar: 3998 118306 6 0 3 -3 0
+JAC)^
+BDFChar: 3999 118307 6 2 3 -3 -2
+^q]pM
+BDFChar: 4000 118308 6 0 3 -3 3
+^u/U>0JG0\
+BDFChar: 4001 118309 6 0 3 2 4
+nF5oI
+BDFChar: 4002 118310 6 0 3 -3 4
+&28(mn?=T#
+BDFChar: 4003 118311 6 0 3 -3 4
+nF5p$0JG17
+BDFChar: 4004 118312 6 2 5 -3 9
+^qdb$_!pj_^qdb$^]4?7
+BDFChar: 4005 118313 6 2 3 -3 9
+^qdb$^qdb$^qdb$^]4?7
+BDFChar: 4006 118314 6 2 5 -3 9
+i,C@]z!"^i'huE`W
+BDFChar: 4007 118315 6 2 5 6 9
+i,C@]
+BDFChar: 4008 118316 6 2 5 -3 0
+&28(]
+BDFChar: 4009 118317 6 2 3 8 9
+^q]pM
+BDFChar: 4010 118318 6 2 5 -3 9
+^qdbD?uRf=@,Si9^]4?7
+BDFChar: 4011 118319 6 0 5 -1 7
+":Q:FnG!t3"98E%
+BDFChar: 4012 118320 6 2 3 9 9
+^]4?7
+BDFChar: 4013 118321 6 2 3 -3 -3
+^]4?7
+BDFChar: 4014 118322 6 0 5 -1 7
+KZs@=0R3N>KE(uP
+BDFChar: 4015 118323 6 0 5 -3 7
+KZs@=0JG170JG0\
+BDFChar: 4016 118324 6 0 5 -1 7
+":Q:Jr;>KgJ,fQL
+BDFChar: 4017 118325 6 2 5 -3 7
+&25eW?sqp.^qd_c
+BDFChar: 4018 118326 6 0 3 -3 9
+0JG170_"T$0JG170E;(Q
+BDFChar: 4019 118327 6 0 3 -3 9
+0JG2"@,SiY?uReR0E;(Q
+BDFChar: 4020 118328 6 0 3 -3 9
+E8\N^z!._lCDu]k<
+BDFChar: 4021 118329 6 0 3 -3 9
+0JKa#n8L'80JG170E;(Q
+BDFChar: 4022 118330 6 0 5 -3 9
+0JG170`:kH0JG170E;(Q
+BDFChar: 4023 118331 6 0 3 6 9
+E8\N^
+BDFChar: 4024 118332 6 2 3 2 9
+^qdb$^qdb$
+BDFChar: 4025 118333 6 2 5 2 9
+^qdb$_!pj_
+BDFChar: 4026 118334 6 2 5 3 9
+^qdbD?uRe"
+BDFChar: 4027 118335 6 2 5 2 9
+^qe=dnDM*4
+BDFChar: 4028 118336 6 0 5 2 9
+0JG170`:kH
+BDFChar: 4029 118337 6 0 5 3 7
+KZs@=0E;(Q
+BDFChar: 4030 118338 6 0 5 6 9
+Gl5d=
+BDFChar: 4031 118339 6 0 3 3 9
+0JG2"@,Sg#
+BDFChar: 4032 118340 6 0 3 2 9
+0JG170_"T$
+BDFChar: 4033 118341 6 0 4 1 9
+0JG2"i8F)a(]XO9
+BDFChar: 4034 118342 6 0 3 2 9
+0JKa#n8L&m
+BDFChar: 4035 118343 6 2 3 -3 1
+^qdb$^]4?7
+BDFChar: 4036 118344 6 2 3 -3 7
+^qdb$^qdb$^qd_c
+BDFChar: 4037 118345 6 2 3 -1 1
+^qd_c
+BDFChar: 4038 118346 6 2 3 -1 4
+^qdb$^q]pM
+BDFChar: 4039 118347 6 2 3 -1 7
+^qdb$^qdb$^]4?7
+BDFChar: 4040 118348 6 2 3 -1 9
+^qdb$^qdb$^qd_c
+BDFChar: 4041 118349 6 2 3 2 4
+^qd_c
+BDFChar: 4042 118350 6 2 3 2 7
+^qdb$^q]pM
+BDFChar: 4043 118351 6 2 3 5 7
+^qd_c
+BDFChar: 4044 118352 6 2 3 5 9
+^qdb$^]4?7
+BDFChar: 4045 129904 6 1 1 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 4046 129905 6 2 2 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 4047 129906 6 3 3 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 4048 129907 6 3 3 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 4049 129908 6 4 4 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 4050 129909 6 5 5 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 4051 129910 6 0 5 6 7
+r;6Np
+BDFChar: 4052 129911 6 0 5 5 6
+r;6Np
+BDFChar: 4053 129912 6 0 5 3 4
+r;6Np
+BDFChar: 4054 129913 6 0 5 1 2
+r;6Np
+BDFChar: 4055 129914 6 0 5 -1 0
+r;6Np
+BDFChar: 4056 129915 6 0 5 -2 -1
+r;6Np
+BDFChar: 4057 129916 6 0 6 -3 9
+J:N0#J:N0#J:N1LrVuou
+BDFChar: 4058 129917 6 0 6 -3 9
+rr.FuJ:N0#J:N0#J,fQL
+BDFChar: 4059 129918 6 0 6 -3 9
+rr)s#!WiE)!WiE)!WW3#
+BDFChar: 4060 129919 6 0 6 -3 9
+!WiE)!WiE)!WiH&rVuou
+BDFChar: 4061 129920 6 0 6 -3 9
+rr)ltz!!!#urVuou
+BDFChar: 4062 129921 6 0 6 -3 9
+rr)ltrW)otrVurtrVuou
+BDFChar: 4063 129922 6 0 5 7 9
+r;?Hm
+BDFChar: 4064 129923 6 0 5 5 9
+r;?Kjqu?]s
+BDFChar: 4065 129924 6 0 5 2 9
+r;?Kjr;?Kj
+BDFChar: 4066 129925 6 0 5 0 9
+r;?Kjr;?Kjr;6Np
+BDFChar: 4067 129926 6 0 5 -1 9
+r;?Kjr;?Kjr;?Hm
+BDFChar: 4068 129927 6 5 6 -3 9
+^qdb$^qdb$^qdb$^]4?7
+BDFChar: 4069 129928 6 4 6 -3 9
+i8EPOi8EPOi8EPOhuE`W
+BDFChar: 4070 129929 6 3 6 -3 9
+nF5r:nF5r:nF5r:n,NFg
+BDFChar: 4071 129930 6 2 6 -3 9
+q"XXZq"XXZq"XXZp](9o
+BDFChar: 4072 129931 6 1 6 -3 9
+r;?Kjr;?Kjr;?Kjqu?]s
+BDFChar: 4073 129967 6 0 5 1 5
+0JNDY0E;(Q
+BDFChar: 4074 129968 6 1 5 -1 6
+JAC+4pu%5F
+BDFChar: 4075 129985 6 0 5 0 7
+]YMJ(aRm9\
+BDFChar: 4076 129979 6 0 6 -1 7
+GYH>9L<`PA49,?]
+BDFChar: 4077 129980 6 0 6 -3 9
+rr)s#H:ge%H3+0IrVuou
+BDFChar: 4078 129989 6 1 5 0 7
+E,Zrp+<XL:
+BDFChar: 4079 129990 6 1 5 0 7
+E,_ap+<XKW
+BDFChar: 4080 129991 6 1 5 0 7
+E,[4ETHI'%
+BDFChar: 4081 129992 6 1 5 0 7
+E,_Ih-m2?J
+BDFChar: 4082 129993 6 1 5 0 7
+E,Zrp:l+mC
+BDFChar: 4083 129994 6 1 5 0 7
++AdlMLoAs^
+BDFChar: 4084 129995 6 0 5 1 6
+8@1oYZq(/s
+BDFChar: 4085 129998 6 0 3 -3 9
+nF5r:nF5r:nF5r:n,NFg
+BDFChar: 4086 129999 6 0 1 -3 9
+^qdb$^qdb$^qdb$^]4?7
+BDFChar: 4087 129997 6 2 4 2 6
+5iCSYTE"rl
+BDFChar: 4088 129996 6 3 5 4 7
+i.-@9
+BDFChar: 4089 129976 6 0 6 -3 9
+!WiE93.1]:&eYfY!WW3#
+BDFChar: 4090 129975 6 0 6 -3 9
+!WiuI&eP%i3"c8o!WW3#
+BDFChar: 4091 129974 6 0 6 -3 9
+rr)m?0KAti0H^AprVuou
+BDFChar: 4092 129973 6 0 6 -3 9
+rr)m'(cZt((^L-@rVuou
+BDFChar: 4093 129984 6 0 5 1 6
+bd9o3[*/LM
+BDFChar: 4094 129972 6 0 6 -1 8
+rr2cZg4J2Lrr)lt
+BDFChar: 4095 129969 6 0 6 -1 8
+rr2cjp9r97rr)lt
+BDFChar: 4096 129970 6 1 5 0 7
+(^PAR\/>!+
+BDFChar: 4097 129971 6 0 5 0 7
+J=,6pi%P]N
+BDFChar: 4098 129977 6 1 5 1 6
+E/9$pJG9*E
+BDFChar: 4099 129978 6 0 5 1 5
+p]L^&qu?]s
+BDFChar: 4100 129981 6 0 6 -3 9
+I!iN:f%09?f"/G?HiO-H
+BDFChar: 4101 129982 6 0 6 -3 9
+rr2orrr2inqYKpZmJm4e
+BDFChar: 4102 129983 6 0 6 -3 9
+mdAZW]"3:#]%5I#mJm4e
+BDFChar: 4103 129988 6 0 6 -1 8
+rl2PGp?qAJmf!1d
+BDFChar: 4104 129986 6 0 5 0 7
+r!7t#"S`8l
+BDFChar: 4105 129987 6 0 5 5 7
+p]U?l
+BDFChar: 4106 129200 6 1 4 0 5
+nA(]Y&.egA
+BDFChar: 4107 129201 6 1 4 0 6
+i"-H]TYU$s
+BDFChar: 4108 129203 6 1 5 0 7
+E,]dkE$,/U
+BDFChar: 4109 129204 6 0 6 -1 7
+rr2?BK&5qprVuou
+BDFChar: 4110 129205 6 0 6 -1 7
+rr2?*Wp]<CrVuou
+BDFChar: 4111 129207 6 0 6 -1 7
+rpK4BWlFK+rVuou
+BDFChar: 4112 129206 6 0 6 -1 7
+rr2?ZK(eX3rVuou
+BDFChar: 4113 129208 6 1 5 1 5
+i4u9&+92BA
+BDFChar: 4114 129209 6 1 5 1 5
+3#JSZ+92BA
+BDFChar: 4115 129210 6 1 5 1 5
++@)kB2uipY
+BDFChar: 4116 129211 6 1 5 1 5
++:tKehuE`W
+BDFChar: 4117 129202 6 1 5 0 6
++:rdZTR]9-
+BDFChar: 4118 9255 6 1 5 1 5
+W)0EhVuQet
+BDFChar: 4119 9256 6 1 5 0 6
+:oI3h:oI1j
+BDFChar: 4120 9257 6 0 5 -3 9
+W)T]pW)T]pW)T]pVuQet
+BDFChar: 4121 9217 6 1 4 -2 8
+@":Kb^]72-E)9@2
+BDFChar: 4122 9218 6 1 4 -2 8
+@":Kb^]72-+Abl7
+BDFChar: 4123 9219 6 1 4 -2 8
+i.0a9huHSM+Abl7
+BDFChar: 4124 9220 6 1 4 -2 8
+i.0a9huI^=+<Vd,
+BDFChar: 4125 9221 6 1 4 -3 8
+i.0a9huFlr:f&8G
+BDFChar: 4126 9222 6 1 4 -2 8
+5bR&.TE%eb?r0Z"
+BDFChar: 4127 9223 6 1 4 -2 8
+^nAK9^]6Vb5X98g
+BDFChar: 4128 9232 6 1 4 -2 8
+^n@?n^]6Vb5X98g
+BDFChar: 4129 9233 6 1 4 -2 8
+^n@?n^]5Kb+<YV'
+BDFChar: 4130 9234 6 1 4 -2 8
+^n@?n^]5KR&0Pol
+BDFChar: 4131 9235 6 1 4 -2 8
+^n@?n^]7aR+:qo\
+BDFChar: 4132 9236 6 1 4 -2 8
+^n@?n^]6&bE"EQ\
+BDFChar: 4133 9237 6 1 4 -2 8
+OO14nO8r*R?r0Z"
+BDFChar: 4134 9238 6 1 4 -2 8
+@":Kb^]72-+<Vd,
+BDFChar: 4135 9239 6 1 4 -2 8
+i.0a9huI.]?r152
+BDFChar: 4136 9240 6 1 5 -2 8
+@"<cX?iW`2=@bs_
+BDFChar: 4137 9241 6 1 4 -2 8
+i.0a9huHSmE)9@2
+BDFChar: 4138 9242 6 1 4 -2 8
+@":Kb^]7b=?r152
+BDFChar: 4139 9243 6 1 4 -2 8
+i.0a9huGGr5X7"'
+BDFChar: 4140 9249 6 1 4 -2 8
+^n@?n^]8<r+<Vd,
+BDFChar: 4141 9250 6 1 5 0 7
+:gcQX84Z9j
+BDFChar: 4142 9251 6 1 5 -2 -1
+M"grM
+BDFChar: 4143 9253 6 1 5 0 6
++@qS:8<=qo
+BDFChar: 4144 9254 6 1 5 0 7
+E/9$0+<UY,
+BDFChar: 4145 118283 6 0 5 -3 9
+$nu's^qdb$^gLP($ig8-
+BDFChar: 4146 118284 6 0 5 -3 9
+^b?TB$k*OQ$lBg8^]4?7
+BDFChar: 4147 118282 6 0 6 -3 9
+Jq?BY-n(716prFO&-)\1
+BDFChar: 4148 118281 6 0 6 -3 9
+&1Aqp7"URM-q$ITJcGcN
+BDFChar: 4149 118285 6 0 5 3 3
+bQ%VC
+BDFChar: 4150 118286 6 2 3 3 3
+^]4?7
+BDFChar: 4151 118287 6 0 5 0 3
+qud-*
+BDFChar: 4152 118291 6 0 3 -3 9
+&.fBan.6-B&.fBa&-)\1
+BDFChar: 4153 118292 6 0 3 -3 9
+n.6-B&.fBan.6-B&-)\1
+BDFChar: 4154 118293 6 0 3 -3 9
+n.6-Bn.6-Bn.6-B&-)\1
+BDFChar: 4155 118294 6 3 6 -3 9
+n:6%>J:N0#J:N0#J,fQL
+BDFChar: 4156 118295 6 3 6 -3 9
+J:N0#J:N0#J:N0#n,NFg
+BDFChar: 4157 118296 6 0 3 -3 9
+n.6-B&.fBa&.fBa&-)\1
+BDFChar: 4158 118297 6 0 3 -3 9
+&.fBa&.fBa&.fBan,NFg
+BDFChar: 4159 118288 6 0 5 0 3
+r"'DN
+BDFChar: 4160 118289 6 0 5 0 3
+r'Wq@
+BDFChar: 4161 118290 6 0 5 0 3
+r)?Wp
+BDFChar: 4162 118280 6 0 5 0 6
+r.ITp0JG0\
+BDFChar: 4163 118279 6 0 2 3 7
++CO,8+92BA
+BDFChar: 4164 118278 6 1 5 0 6
+E)9C+:f)*2
+BDFChar: 4165 118277 6 0 5 1 6
+r.MGaK_tfM
+BDFChar: 4166 118276 6 0 5 1 3
+KS97'
+BDFChar: 4167 118275 6 0 5 4 6
+r.K_'
+BDFChar: 4168 118274 6 0 5 1 5
+82.DAqu?]s
+BDFChar: 4169 118273 6 0 5 1 6
+KQmIsG_?%s
+BDFChar: 4170 118272 6 0 5 1 6
+KLeX)8;$sC
+BDFChar: 4171 117808 6 2 5 -3 5
+&.fs,5X9jMJ,fQL
+BDFChar: 4172 117809 6 0 5 6 9
+$nsqs
+BDFChar: 4173 117810 6 0 5 6 9
+^b?#s
+BDFChar: 4174 117811 6 0 3 -3 5
+J:KmM+<V4,&-)\1
+BDFChar: 4175 117812 6 0 2 -3 9
++@&1W5X9jMJ:N0#J,fQL
+BDFChar: 4176 117813 6 0 5 -3 9
+":,P]+@&1WJ:N0#J,fQL
+BDFChar: 4177 117814 6 0 5 -3 9
+J3Y4g&-rOI"9\i1"98E%
+BDFChar: 4178 117815 6 3 5 -3 9
+J3Z@b5X6G7+<VdL+92BA
+BDFChar: 4179 117816 6 0 2 -3 9
+J:N0#J:N/85X7S"+92BA
+BDFChar: 4180 117817 6 0 5 -3 9
+J:N0#J3Z@b+<V4$"98E%
+BDFChar: 4181 117818 6 0 5 -3 9
+"9\i1":,8=&.fsLJ,fQL
+BDFChar: 4182 117819 6 3 5 -3 9
++<VdL+<Vdl5X7S"J,fQL
+BDFChar: 4183 117820 6 2 5 1 9
+J:N/85Th0\&-)\1
+BDFChar: 4184 117821 6 0 5 -3 0
+J3Yds
+BDFChar: 4185 117822 6 0 5 -3 0
+":-]s
+BDFChar: 4186 117823 6 0 3 1 9
+&.fBq+@&2BJ,fQL
+BDFChar: 4187 117824 6 0 5 -1 8
+qu?`p!!)os!;lfs
+BDFChar: 4188 117825 6 1 4 -3 9
+OH>QcOH>QcOH>QcO8o7\
+BDFChar: 4189 117826 6 0 5 -3 9
+8Gl"Lr('BV84`YL8,rVi
+BDFChar: 4190 117827 6 0 6 -3 9
+Jj_!u-q&YT-kIdpJcGcN
+BDFChar: 4191 117828 6 0 4 -3 9
+W2QYnW2QYnW2QYnVuQet
+BDFChar: 4192 117829 6 0 5 -3 9
+quHWpquHWpquHWpqu?]s
+BDFChar: 4193 117830 6 0 5 -2 9
+,_-.c&:c//6kFks
+BDFChar: 4194 117831 6 0 5 -3 9
+:dbRW&<m/;XFLl#'EA+5
+BDFChar: 4195 118416 6 0 1 7 9
+^qd_c
+BDFChar: 4196 118417 6 1 2 7 9
+^qd_c
+BDFChar: 4197 118418 6 3 4 7 9
+^qd_c
+BDFChar: 4198 118419 6 4 5 7 9
+^qd_c
+BDFChar: 4199 118420 6 0 1 4 6
+^qd_c
+BDFChar: 4200 118421 6 1 2 4 6
+^qd_c
+BDFChar: 4201 118422 6 3 4 4 6
+^qd_c
+BDFChar: 4202 118423 6 4 5 4 6
+^qd_c
+BDFChar: 4203 118424 6 0 1 0 2
+^qd_c
+BDFChar: 4204 118425 6 1 2 0 2
+^qd_c
+BDFChar: 4205 118426 6 3 4 0 2
+^qd_c
+BDFChar: 4206 118427 6 4 5 0 2
+^qd_c
+BDFChar: 4207 118428 6 0 1 -3 -1
+^qd_c
+BDFChar: 4208 118429 6 1 2 -3 -1
+^qd_c
+BDFChar: 4209 118430 6 3 4 -3 -1
+^qd_c
+BDFChar: 4210 118431 6 4 5 -3 -1
+^qd_c
+BDFChar: 4211 118432 6 3 5 -3 -1
+i8EMn
+BDFChar: 4212 118433 6 1 5 -3 -1
+q"XUa
+BDFChar: 4213 118434 6 0 4 -3 -1
+q"XUa
+BDFChar: 4214 118435 6 0 2 -3 -1
+i8EMn
+BDFChar: 4215 118436 6 0 1 -3 2
+^qdb$^q]pM
+BDFChar: 4216 118437 6 0 1 -3 5
+^qdb$^qdb$^]4?7
+BDFChar: 4217 118438 6 0 1 1 9
+^qdb$^qdb$^]4?7
+BDFChar: 4218 118439 6 0 1 4 9
+^qdb$^q]pM
+BDFChar: 4219 118440 6 0 2 7 9
+i8EMn
+BDFChar: 4220 118441 6 0 4 7 9
+q"XUa
+BDFChar: 4221 118442 6 1 5 7 9
+q"XUa
+BDFChar: 4222 118443 6 3 5 7 9
+i8EMn
+BDFChar: 4223 118444 6 4 5 4 9
+^qdb$^q]pM
+BDFChar: 4224 118445 6 4 5 1 9
+^qdb$^qdb$^]4?7
+BDFChar: 4225 118446 6 4 5 -3 5
+^qdb$^qdb$^]4?7
+BDFChar: 4226 118447 6 4 5 -3 2
+^qdb$^q]pM
+BDFChar: 4227 118016 6 0 2 3 6
+i8EPO
+BDFChar: 4228 118017 6 0 5 3 9
+*#osVi8EMn
+BDFChar: 4229 118018 6 0 5 3 9
+r;?KNi8EMn
+BDFChar: 4230 118019 6 3 5 3 6
+i8EPO
+BDFChar: 4231 118020 6 0 5 3 9
+i8EN5*#opu
+BDFChar: 4232 118021 6 0 5 3 9
+r;?I4*#opu
+BDFChar: 4233 118022 6 0 5 3 6
+r;?Kj
+BDFChar: 4234 118023 6 0 5 3 9
+i8EPkr;?Hm
+BDFChar: 4235 118024 6 0 5 3 9
+*#osrr;?Hm
+BDFChar: 4236 118025 6 0 2 0 2
+i8EMn
+BDFChar: 4237 118026 6 0 2 0 9
+i8EMn!!!#Wi8=S8
+BDFChar: 4238 118027 6 0 5 0 9
+*#opu!!!#Wi8=S8
+BDFChar: 4239 118028 6 0 5 0 9
+r;?Hm!!!#Wi8=S8
+BDFChar: 4240 118029 6 0 2 0 9
+i8EPOi8EPOi8=S8
+BDFChar: 4241 118030 6 0 5 0 9
+*#osVi8EPOi8=S8
+BDFChar: 4242 118031 6 0 5 0 9
+r;?KNi8EPOi8=S8
+BDFChar: 4243 118032 6 0 5 0 6
+*#oq<i8EMn
+BDFChar: 4244 118033 6 0 5 0 9
+i8EN5*#osVi8=S8
+BDFChar: 4245 118034 6 0 5 0 9
+*#oq<*#osVi8=S8
+BDFChar: 4246 118035 6 0 5 0 9
+r;?I4*#osVi8=S8
+BDFChar: 4247 118036 6 0 5 0 6
+r;?Kji8EMn
+BDFChar: 4248 118037 6 0 5 0 9
+i8EPkr;?KNi8=S8
+BDFChar: 4249 118038 6 0 5 0 9
+*#osrr;?KNi8=S8
+BDFChar: 4250 118039 6 0 5 0 9
+r;?Kjr;?KNi8=S8
+BDFChar: 4251 118040 6 3 5 0 2
+i8EMn
+BDFChar: 4252 118041 6 0 5 0 9
+i8EMn!!!!=*#nqY
+BDFChar: 4253 118042 6 3 5 0 9
+i8EMn!!!#Wi8=S8
+BDFChar: 4254 118043 6 0 5 0 9
+r;?Hm!!!!=*#nqY
+BDFChar: 4255 118044 6 0 5 0 6
+i8EPO*#opu
+BDFChar: 4256 118045 6 0 5 0 9
+i8EPOi8EN5*#nqY
+BDFChar: 4257 118046 6 0 5 0 9
+*#osVi8EN5*#nqY
+BDFChar: 4258 118047 6 0 5 0 9
+r;?KNi8EN5*#nqY
+BDFChar: 4259 118048 6 0 5 0 9
+i8EN5*#oq<*#nqY
+BDFChar: 4260 118049 6 3 5 0 9
+i8EPOi8EPOi8=S8
+BDFChar: 4261 118050 6 0 5 0 9
+r;?I4*#oq<*#nqY
+BDFChar: 4262 118051 6 0 5 0 6
+r;?Kj*#opu
+BDFChar: 4263 118052 6 0 5 0 9
+i8EPkr;?I4*#nqY
+BDFChar: 4264 118053 6 0 5 0 9
+*#osrr;?I4*#nqY
+BDFChar: 4265 118054 6 0 5 0 9
+r;?Kjr;?I4*#nqY
+BDFChar: 4266 118055 6 0 5 0 2
+r;?Hm
+BDFChar: 4267 118056 6 0 5 0 9
+i8EMn!!!#sr;6Np
+BDFChar: 4268 118057 6 0 5 0 9
+*#opu!!!#sr;6Np
+BDFChar: 4269 118058 6 0 5 0 9
+r;?Hm!!!#sr;6Np
+BDFChar: 4270 118060 6 0 5 0 9
+i8EPOi8EPkr;6Np
+BDFChar: 4271 118059 6 0 5 0 6
+i8EPOr;?Hm
+BDFChar: 4272 118061 6 0 5 0 9
+*#osVi8EPkr;6Np
+BDFChar: 4273 118062 6 0 5 0 9
+r;?KNi8EPkr;6Np
+BDFChar: 4274 118063 6 0 5 0 6
+*#oq<r;?Hm
+BDFChar: 4275 118064 6 0 5 0 9
+i8EN5*#osrr;6Np
+BDFChar: 4276 118065 6 0 5 0 9
+*#oq<*#osrr;6Np
+BDFChar: 4277 118066 6 0 5 0 9
+r;?I4*#osrr;6Np
+BDFChar: 4278 118067 6 0 5 0 6
+r;?Kjr;?Hm
+BDFChar: 4279 118068 6 0 5 0 9
+i8EPkr;?Kjr;6Np
+BDFChar: 4280 118069 6 0 5 0 9
+*#osrr;?Kjr;6Np
+BDFChar: 4281 118070 6 0 2 -3 9
+i8EMnz!!(s8huE`W
+BDFChar: 4282 118071 6 0 5 -3 9
+*#opuz!!(s8huE`W
+BDFChar: 4283 118072 6 0 5 -3 9
+r;?Hmz!!(s8huE`W
+BDFChar: 4284 118073 6 0 2 -3 6
+i8EPO!!!#Wi8=S8
+BDFChar: 4285 118074 6 0 2 -3 9
+i8EPOi8EMn!!(s8huE`W
+BDFChar: 4286 118075 6 0 5 -3 9
+*#osVi8EMn!!(s8huE`W
+BDFChar: 4287 118076 6 0 5 -3 9
+r;?KNi8EMn!!(s8huE`W
+BDFChar: 4288 118077 6 0 5 -3 6
+*#oq<!!!#Wi8=S8
+BDFChar: 4289 118078 6 0 5 -3 9
+i8EN5*#opu!!(s8huE`W
+BDFChar: 4290 118079 6 0 5 -3 9
+*#oq<*#opu!!(s8huE`W
+BDFChar: 4291 118080 6 0 5 -3 9
+r;?I4*#opu!!(s8huE`W
+BDFChar: 4292 118081 6 0 5 -3 6
+r;?Kj!!!#Wi8=S8
+BDFChar: 4293 118082 6 0 5 -3 9
+i8EPkr;?Hm!!(s8huE`W
+BDFChar: 4294 118083 6 0 5 -3 9
+*#osrr;?Hm!!(s8huE`W
+BDFChar: 4295 118084 6 0 5 -3 9
+r;?Kjr;?Hm!!(s8huE`W
+BDFChar: 4296 118085 6 0 2 -3 9
+i8EMn!!!#Wi8EPOhuE`W
+BDFChar: 4297 118086 6 0 5 -3 9
+*#opu!!!#Wi8EPOhuE`W
+BDFChar: 4298 118087 6 0 5 -3 9
+r;?Hm!!!#Wi8EPOhuE`W
+BDFChar: 4299 118088 6 0 2 -3 6
+i8EPOi8EPOi8=S8
+BDFChar: 4300 118089 6 0 5 -3 9
+*#osVi8EPOi8EPOhuE`W
+BDFChar: 4301 118090 6 0 5 -3 9
+r;?KNi8EPOi8EPOhuE`W
+BDFChar: 4302 118091 6 0 5 -3 6
+*#oq<i8EPOi8=S8
+BDFChar: 4303 118092 6 0 5 -3 9
+i8EN5*#osVi8EPOhuE`W
+BDFChar: 4304 118093 6 0 5 -3 9
+r;?I4*#osVi8EPOhuE`W
+BDFChar: 4305 118094 6 0 5 -3 6
+r;?Kji8EPOi8=S8
+BDFChar: 4306 118095 6 0 5 -3 9
+i8EPkr;?KNi8EPOhuE`W
+BDFChar: 4307 118096 6 0 5 -3 9
+*#osrr;?KNi8EPOhuE`W
+BDFChar: 4308 118097 6 0 5 -3 2
+*#osVi8=S8
+BDFChar: 4309 118098 6 0 5 -3 9
+i8EMn!!!!=*$!nphuE`W
+BDFChar: 4310 118099 6 0 5 -3 9
+*#opu!!!!=*$!nphuE`W
+BDFChar: 4311 118100 6 0 5 -3 9
+r;?Hm!!!!=*$!nphuE`W
+BDFChar: 4312 118101 6 0 5 -3 6
+i8EPO*#osVi8=S8
+BDFChar: 4313 118102 6 0 5 -3 9
+i8EPOi8EN5*$!nphuE`W
+BDFChar: 4314 118103 6 0 5 -3 9
+*#osVi8EN5*$!nphuE`W
+BDFChar: 4315 118104 6 0 5 -3 9
+r;?KNi8EN5*$!nphuE`W
+BDFChar: 4316 118105 6 0 5 -3 6
+*#oq<*#osVi8=S8
+BDFChar: 4317 118106 6 0 5 -3 9
+i8EN5*#oq<*$!nphuE`W
+BDFChar: 4318 118107 6 0 5 -3 9
+*#oq<*#oq<*$!nphuE`W
+BDFChar: 4319 118108 6 0 5 -3 9
+r;?I4*#oq<*$!nphuE`W
+BDFChar: 4320 118109 6 0 5 -3 6
+r;?Kj*#osVi8=S8
+BDFChar: 4321 118110 6 0 5 -3 9
+i8EPkr;?I4*$!nphuE`W
+BDFChar: 4322 118111 6 0 5 -3 9
+*#osrr;?I4*$!nphuE`W
+BDFChar: 4323 118112 6 0 5 -3 9
+r;?Kjr;?I4*$!nphuE`W
+BDFChar: 4324 118113 6 0 5 -3 2
+r;?KNi8=S8
+BDFChar: 4325 118114 6 0 5 -3 9
+i8EMn!!!#sr;>L2huE`W
+BDFChar: 4326 118115 6 0 5 -3 9
+*#opu!!!#sr;>L2huE`W
+BDFChar: 4327 118116 6 0 5 -3 9
+r;?Hm!!!#sr;>L2huE`W
+BDFChar: 4328 118117 6 0 5 -3 6
+i8EPOr;?KNi8=S8
+BDFChar: 4329 118118 6 0 5 -3 9
+i8EPOi8EPkr;>L2huE`W
+BDFChar: 4330 118119 6 0 5 -3 9
+*#osVi8EPkr;>L2huE`W
+BDFChar: 4331 118120 6 0 5 -3 9
+r;?KNi8EPkr;>L2huE`W
+BDFChar: 4332 118121 6 0 5 -3 6
+*#oq<r;?KNi8=S8
+BDFChar: 4333 118122 6 0 5 -3 9
+i8EN5*#osrr;>L2huE`W
+BDFChar: 4334 118123 6 0 5 -3 9
+*#oq<*#osrr;>L2huE`W
+BDFChar: 4335 118124 6 0 5 -3 9
+r;?I4*#osrr;>L2huE`W
+BDFChar: 4336 118125 6 0 5 -3 6
+r;?Kjr;?KNi8=S8
+BDFChar: 4337 118126 6 0 5 -3 9
+i8EPkr;?Kjr;>L2huE`W
+BDFChar: 4338 118127 6 0 5 -3 9
+*#osrr;?Kjr;>L2huE`W
+BDFChar: 4339 118128 6 0 5 -3 9
+r;?Kjr;?Kjr;>L2huE`W
+BDFChar: 4340 118129 6 0 5 -3 9
+i8EMnz!!!uY)uos=
+BDFChar: 4341 118130 6 3 5 -3 9
+i8EMnz!!(s8huE`W
+BDFChar: 4342 118131 6 0 5 -3 9
+r;?Hmz!!!uY)uos=
+BDFChar: 4343 118132 6 0 5 -3 6
+i8EPO!!!!=*#nqY
+BDFChar: 4344 118133 6 0 5 -3 9
+i8EPOi8EMn!!!uY)uos=
+BDFChar: 4345 118134 6 0 5 -3 9
+*#osVi8EMn!!!uY)uos=
+BDFChar: 4346 118135 6 0 5 -3 9
+r;?KNi8EMn!!!uY)uos=
+BDFChar: 4347 118136 6 3 5 -3 6
+i8EPO!!!#Wi8=S8
+BDFChar: 4348 118137 6 0 5 -3 9
+i8EN5*#opu!!!uY)uos=
+BDFChar: 4349 118138 6 3 5 -3 9
+i8EPOi8EMn!!(s8huE`W
+BDFChar: 4350 118139 6 0 5 -3 9
+r;?I4*#opu!!!uY)uos=
+BDFChar: 4351 118140 6 0 5 -3 6
+r;?Kj!!!!=*#nqY
+BDFChar: 4352 118141 6 0 5 -3 9
+i8EPkr;?Hm!!!uY)uos=
+BDFChar: 4353 118142 6 0 5 -3 9
+*#osrr;?Hm!!!uY)uos=
+BDFChar: 4354 118143 6 0 5 -3 9
+r;?Kjr;?Hm!!!uY)uos=
+BDFChar: 4355 118144 6 0 5 -3 2
+i8EN5*#nqY
+BDFChar: 4356 118145 6 0 5 -3 9
+i8EMn!!!#Wi8>Rp)uos=
+BDFChar: 4357 118146 6 0 5 -3 9
+*#opu!!!#Wi8>Rp)uos=
+BDFChar: 4358 118147 6 0 5 -3 9
+r;?Hm!!!#Wi8>Rp)uos=
+BDFChar: 4359 118148 6 0 5 -3 6
+i8EPOi8EN5*#nqY
+BDFChar: 4360 118149 6 0 5 -3 9
+i8EPOi8EPOi8>Rp)uos=
+BDFChar: 4361 118150 6 0 5 -3 9
+*#osVi8EPOi8>Rp)uos=
+BDFChar: 4362 118151 6 0 5 -3 9
+r;?KNi8EPOi8>Rp)uos=
+BDFChar: 4363 118152 6 0 5 -3 6
+*#oq<i8EN5*#nqY
+BDFChar: 4364 118153 6 0 5 -3 9
+i8EN5*#osVi8>Rp)uos=
+BDFChar: 4365 118154 6 0 5 -3 9
+*#oq<*#osVi8>Rp)uos=
+BDFChar: 4366 118155 6 0 5 -3 9
+r;?I4*#osVi8>Rp)uos=
+BDFChar: 4367 118156 6 0 5 -3 6
+r;?Kji8EN5*#nqY
+BDFChar: 4368 118157 6 0 5 -3 9
+i8EPkr;?KNi8>Rp)uos=
+BDFChar: 4369 118158 6 0 5 -3 9
+*#osrr;?KNi8>Rp)uos=
+BDFChar: 4370 118159 6 0 5 -3 9
+r;?Kjr;?KNi8>Rp)uos=
+BDFChar: 4371 118160 6 0 5 -3 9
+i8EMn!!!!=*#oq<)uos=
+BDFChar: 4372 118161 6 3 5 -3 9
+i8EMn!!!#Wi8EPOhuE`W
+BDFChar: 4373 118162 6 0 5 -3 9
+r;?Hm!!!!=*#oq<)uos=
+BDFChar: 4374 118163 6 0 5 -3 6
+i8EPO*#oq<*#nqY
+BDFChar: 4375 118164 6 0 5 -3 9
+*#osVi8EN5*#oq<)uos=
+BDFChar: 4376 118165 6 0 5 -3 9
+r;?KNi8EN5*#oq<)uos=
+BDFChar: 4377 118166 6 3 5 -3 6
+i8EPOi8EPOi8=S8
+BDFChar: 4378 118167 6 0 5 -3 9
+i8EN5*#oq<*#oq<)uos=
+BDFChar: 4379 118168 6 0 5 -3 9
+r;?I4*#oq<*#oq<)uos=
+BDFChar: 4380 118169 6 0 5 -3 6
+r;?Kj*#oq<*#nqY
+BDFChar: 4381 118170 6 0 5 -3 9
+i8EPkr;?I4*#oq<)uos=
+BDFChar: 4382 118171 6 0 5 -3 9
+*#osrr;?I4*#oq<)uos=
+BDFChar: 4383 118172 6 0 5 -3 2
+r;?I4*#nqY
+BDFChar: 4384 118173 6 0 5 -3 9
+i8EMn!!!#sr;7NS)uos=
+BDFChar: 4385 118174 6 0 5 -3 9
+*#opu!!!#sr;7NS)uos=
+BDFChar: 4386 118175 6 0 5 -3 9
+r;?Hm!!!#sr;7NS)uos=
+BDFChar: 4387 118176 6 0 5 -3 6
+i8EPOr;?I4*#nqY
+BDFChar: 4388 118177 6 0 5 -3 9
+i8EPOi8EPkr;7NS)uos=
+BDFChar: 4389 118178 6 0 5 -3 9
+*#osVi8EPkr;7NS)uos=
+BDFChar: 4390 118179 6 0 5 -3 9
+r;?KNi8EPkr;7NS)uos=
+BDFChar: 4391 118180 6 0 5 -3 6
+*#oq<r;?I4*#nqY
+BDFChar: 4392 118181 6 0 5 -3 9
+i8EN5*#osrr;7NS)uos=
+BDFChar: 4393 118182 6 0 5 -3 9
+*#oq<*#osrr;7NS)uos=
+BDFChar: 4394 118183 6 0 5 -3 9
+r;?I4*#osrr;7NS)uos=
+BDFChar: 4395 118184 6 0 5 -3 6
+r;?Kjr;?I4*#nqY
+BDFChar: 4396 118185 6 0 5 -3 9
+i8EPkr;?Kjr;7NS)uos=
+BDFChar: 4397 118186 6 0 5 -3 9
+*#osrr;?Kjr;7NS)uos=
+BDFChar: 4398 118187 6 0 5 -3 9
+r;?Kjr;?Kjr;7NS)uos=
+BDFChar: 4399 118188 6 0 5 -3 9
+i8EMnz!!)rpqu?]s
+BDFChar: 4400 118189 6 0 5 -3 9
+*#opuz!!)rpqu?]s
+BDFChar: 4401 118190 6 0 5 -3 9
+r;?Hmz!!)rpqu?]s
+BDFChar: 4402 118191 6 0 5 -3 6
+i8EPO!!!#sr;6Np
+BDFChar: 4403 118192 6 0 5 -3 9
+i8EPOi8EMn!!)rpqu?]s
+BDFChar: 4404 118193 6 0 5 -3 9
+*#osVi8EMn!!)rpqu?]s
+BDFChar: 4405 118194 6 0 5 -3 9
+r;?KNi8EMn!!)rpqu?]s
+BDFChar: 4406 118195 6 0 5 -3 6
+*#oq<!!!#sr;6Np
+BDFChar: 4407 118196 6 0 5 -3 9
+i8EN5*#opu!!)rpqu?]s
+BDFChar: 4408 118197 6 0 5 -3 9
+*#oq<*#opu!!)rpqu?]s
+BDFChar: 4409 118198 6 0 5 -3 9
+r;?I4*#opu!!)rpqu?]s
+BDFChar: 4410 118199 6 0 5 -3 6
+r;?Kj!!!#sr;6Np
+BDFChar: 4411 118200 6 0 5 -3 9
+i8EPkr;?Hm!!)rpqu?]s
+BDFChar: 4412 118201 6 0 5 -3 9
+*#osrr;?Hm!!)rpqu?]s
+BDFChar: 4413 118202 6 0 5 -3 9
+r;?Kjr;?Hm!!)rpqu?]s
+BDFChar: 4414 118203 6 0 5 -3 2
+i8EPkr;6Np
+BDFChar: 4415 118204 6 0 5 -3 9
+i8EMn!!!#Wi8FP2qu?]s
+BDFChar: 4416 118205 6 0 5 -3 9
+*#opu!!!#Wi8FP2qu?]s
+BDFChar: 4417 118206 6 0 5 -3 9
+r;?Hm!!!#Wi8FP2qu?]s
+BDFChar: 4418 118207 6 0 5 -3 6
+i8EPOi8EPkr;6Np
+BDFChar: 4419 118208 6 0 5 -3 9
+i8EPOi8EPOi8FP2qu?]s
+BDFChar: 4420 118209 6 0 5 -3 9
+*#osVi8EPOi8FP2qu?]s
+BDFChar: 4421 118210 6 0 5 -3 9
+r;?KNi8EPOi8FP2qu?]s
+BDFChar: 4422 118211 6 0 5 -3 6
+*#oq<i8EPkr;6Np
+BDFChar: 4423 118212 6 0 5 -3 9
+i8EN5*#osVi8FP2qu?]s
+BDFChar: 4424 118213 6 0 5 -3 9
+*#oq<*#osVi8FP2qu?]s
+BDFChar: 4425 118214 6 0 5 -3 9
+r;?I4*#osVi8FP2qu?]s
+BDFChar: 4426 118215 6 0 5 -3 6
+r;?Kji8EPkr;6Np
+BDFChar: 4427 118216 6 0 5 -3 9
+i8EPkr;?KNi8FP2qu?]s
+BDFChar: 4428 118217 6 0 5 -3 9
+*#osrr;?KNi8FP2qu?]s
+BDFChar: 4429 118218 6 0 5 -3 9
+r;?Kjr;?KNi8FP2qu?]s
+BDFChar: 4430 118219 6 0 5 -3 2
+*#osrr;6Np
+BDFChar: 4431 118220 6 0 5 -3 9
+i8EMn!!!!=*$"nSqu?]s
+BDFChar: 4432 118221 6 0 5 -3 9
+*#opu!!!!=*$"nSqu?]s
+BDFChar: 4433 118222 6 0 5 -3 9
+r;?Hm!!!!=*$"nSqu?]s
+BDFChar: 4434 118223 6 0 5 -3 6
+i8EPO*#osrr;6Np
+BDFChar: 4435 118224 6 0 5 -3 9
+i8EPOi8EN5*$"nSqu?]s
+BDFChar: 4436 118225 6 0 5 -3 9
+*#osVi8EN5*$"nSqu?]s
+BDFChar: 4437 118226 6 0 5 -3 9
+r;?KNi8EN5*$"nSqu?]s
+BDFChar: 4438 118227 6 0 5 -3 6
+*#oq<*#osrr;6Np
+BDFChar: 4439 118228 6 0 5 -3 9
+i8EN5*#oq<*$"nSqu?]s
+BDFChar: 4440 118229 6 0 5 -3 9
+*#oq<*#oq<*$"nSqu?]s
+BDFChar: 4441 118230 6 0 5 -3 9
+r;?I4*#oq<*$"nSqu?]s
+BDFChar: 4442 118231 6 0 5 -3 6
+r;?Kj*#osrr;6Np
+BDFChar: 4443 118232 6 0 5 -3 9
+i8EPkr;?I4*$"nSqu?]s
+BDFChar: 4444 118233 6 0 5 -3 9
+*#osrr;?I4*$"nSqu?]s
+BDFChar: 4445 118234 6 0 5 -3 9
+r;?Kjr;?I4*$"nSqu?]s
+BDFChar: 4446 118235 6 0 5 -3 9
+i8EMn!!!#sr;?Kjqu?]s
+BDFChar: 4447 118236 6 0 5 -3 9
+*#opu!!!#sr;?Kjqu?]s
+BDFChar: 4448 118237 6 0 5 -3 9
+r;?Hm!!!#sr;?Kjqu?]s
+BDFChar: 4449 118238 6 0 5 -3 6
+i8EPOr;?Kjr;6Np
+BDFChar: 4450 118239 6 0 5 -3 9
+*#osVi8EPkr;?Kjqu?]s
+BDFChar: 4451 118240 6 0 5 -3 9
+r;?KNi8EPkr;?Kjqu?]s
+BDFChar: 4452 118241 6 0 5 -3 6
+*#oq<r;?Kjr;6Np
+BDFChar: 4453 118242 6 0 5 -3 9
+i8EN5*#osrr;?Kjqu?]s
+BDFChar: 4454 118243 6 0 5 -3 9
+r;?I4*#osrr;?Kjqu?]s
+BDFChar: 4455 118244 6 0 5 -3 9
+i8EPkr;?Kjr;?Kjqu?]s
+BDFChar: 4456 118245 6 0 5 -3 9
+*#osrr;?Kjr;?Kjqu?]s
+BDFChar: 4457 117765 6 0 5 -3 -1
+#lFr.
+BDFChar: 4458 117766 6 3 5 -3 9
+5X7S"5X7S"5X7Tm5QCca
+BDFChar: 4459 117767 6 0 5 -3 9
+#RC\A#RC\A#RC_6#QOi)
+BDFChar: 4460 117768 6 0 6 -3 9
+P#OCP&.fBa&.fBa&-)\1
+BDFChar: 4461 117764 6 1 5 -1 6
+Leo3:p`ONp
+BDFChar: 4462 117763 6 0 6 1 5
+OB+PGO8o7\
+BDFChar: 4463 117762 6 0 6 1 5
+'%H^+&c_n3
+BDFChar: 4464 117761 6 0 6 0 6
+i(c[f6r)Y?
+BDFChar: 4465 117760 6 0 6 0 6
+7!qrFP5^%5
+BDFChar: 4466 117769 6 0 5 0 7
+5X;!8'GLfY
+BDFChar: 4467 117770 6 1 5 -2 11
++<VdlJ3Y4g#S8+$+<UXa
+BDFChar: 4468 117771 6 0 5 1 6
+3)#\N&.AO=
+BDFChar: 4469 117772 6 0 5 1 6
+pl*j%:lGAS
+BDFChar: 4470 117773 6 0 5 1 6
+i/l#J5_&h7
+BDFChar: 4471 117774 6 0 5 0 6
+LmY-bW0iA@
+BDFChar: 4472 117775 6 0 5 0 6
+6tB9@<+JAs
+BDFChar: 4473 117776 6 0 4 -3 9
+&.fD7TYQ)nW0fOM&-)\1
+BDFChar: 4474 117777 6 0 4 -3 9
+&-s\g\A3X1TTB]r&-)\1
+BDFChar: 4475 117778 6 0 5 -3 9
+J:KmM+<VXH+@&2BJ,fQL
+BDFChar: 4476 117779 6 0 5 0 6
+84Z:q84Z8O
+BDFChar: 4477 117780 6 1 5 -3 9
++<VdLp](<h+<VdL+92BA
+BDFChar: 4478 117781 6 0 6 -3 9
+^n?dF6pa4,7#6qt^]4?7
+BDFChar: 4479 117782 6 0 6 -3 9
+i0]1NJqAT+JqSfEhuE`W
+BDFChar: 4480 117783 6 0 5 -3 9
+r"L+Nz!!!uQqu?]s
+BDFChar: 4481 117784 6 0 5 2 4
+i4RtJ
+BDFChar: 4482 117785 6 0 6 0 6
+&/Z,P'GqA]
+BDFChar: 4483 117786 6 0 6 0 6
+&/]N;F;PPh
+BDFChar: 4484 117787 6 0 5 3 9
+"9\i1"9eW&
+BDFChar: 4485 117788 6 0 5 -3 3
+qud-*"9\i-
+BDFChar: 4486 117789 6 0 5 3 9
+r.'<JJ:N.M
+BDFChar: 4487 117790 6 0 5 -3 3
+J:N0#J:ROt
+BDFChar: 4488 117791 6 0 5 -3 9
+#RCtU,Uc2[OJ!^]5QCca
+BDFChar: 4489 117792 6 0 5 -3 9
+5X6HbOAJIr,SUdq#QOi)
+BDFChar: 4490 9812 12 1 10 -2 8
+$ign?&ccd!P!H?=ZTqE=It3&7s1eU7
+BDFChar: 4491 9813 12 1 10 -2 8
+$ign?s1gmM1B8$f&c`OE56/L7s1eU7
+BDFChar: 4492 9814 12 1 10 -2 8
+s1ka%J3ZAM56)i,+TNYc?@[Pks1eU7
+BDFChar: 4493 9815 12 1 10 -2 8
+$igV7,lgnp9RoBY+TN,T+TT<ns1eU7
+BDFChar: 4494 9816 12 1 10 -2 8
+'EBT_,61R@Kn,P@BYXm=&3q@'J%u$a
+BDFChar: 4495 9817 12 2 9 -2 8
+(aL@DIO$1*6@o.:
+BDFChar: 4496 9818 12 1 10 -2 8
+$ih=K*WU&-s1mL,beS(GIt7R7s1eU7
+BDFChar: 4497 9819 12 1 10 -2 8
+$ih=Ks1j,756)`)*WR5]561`!s1eU7
+BDFChar: 4498 9820 12 1 10 -2 8
+ZU"Q+s1j,756*nJ56*nJIt7R7s1eU7
+BDFChar: 4499 9821 12 1 10 -2 8
+$igb;-NJ@@It3$!56)`)561`!s1eU7
+BDFChar: 4500 9822 12 1 10 -2 8
+'EC;s0*$D#rIDV4DSQcJ+$`%UJ%u$a
+BDFChar: 4501 9823 12 2 9 -2 8
+(d'ntIQT`AIfKEJ
+BDFChar: 4502 117946 6 0 5 -3 4
+":P\ACm_<:
+BDFChar: 4503 117947 6 0 5 -3 4
+JAAsNfOWM(
+BDFChar: 4504 117948 6 0 5 2 9
+]Y%KS/:>82
+BDFChar: 4505 117949 6 0 5 2 9
+o^qA2d.e%I
+BDFChar: 4506 117950 6 1 5 -3 4
+#T+ERGW66O
+BDFChar: 4507 117951 6 0 4 -3 4
+JAAtqnDHRI
+BDFChar: 4508 117952 6 0 5 2 9
+$k*OQ*'D%7
+BDFChar: 4509 117953 6 0 5 2 9
+^qdb$i:%0Q
+BDFChar: 4510 117954 6 0 5 -3 4
+f\$-"HltO6
+BDFChar: 4511 117955 6 0 5 -3 4
+m-OZJp^lra
+BDFChar: 4512 117970 6 1 5 -3 3
+(a+(%W2Oq@
+BDFChar: 4513 117956 6 0 5 2 9
+4?P_g4FD\W
+BDFChar: 4514 117957 6 0 5 2 9
+nF5r:nG!.a
+BDFChar: 4515 117958 6 1 5 -3 4
+(`3NLi8FD*
+BDFChar: 4516 117959 6 0 4 -3 4
+JAC+4nG)eR
+BDFChar: 4517 117960 6 0 5 2 9
+4?OT'*'D%7
+BDFChar: 4518 117961 6 0 5 2 9
+nF5Aoi:%0Q
+BDFChar: 4519 117962 6 0 5 -3 4
+$k*Oa'KgcU
+BDFChar: 4520 117963 6 0 4 -3 4
+@,Tu4nBfhO
+BDFChar: 4521 117964 6 0 5 2 9
+r,`&M$lgr`
+BDFChar: 4522 117965 6 0 5 2 9
+kihC*o^iRi
+BDFChar: 4523 117966 6 3 5 -3 2
++CJS"i*ZNb
+BDFChar: 4524 117967 6 0 2 -3 2
+JAAsNi4o<m
+BDFChar: 4525 117968 6 1 5 2 9
+(`54l3-]uK
+BDFChar: 4526 117969 6 0 4 2 9
+^qemdi:%$I
+BDFChar: 4527 117971 6 0 5 -3 5
+CcmqM,a;8=li7"c
+BDFChar: 4528 117972 6 0 5 2 9
+0^R^/$j_+Q
+BDFChar: 4529 117973 6 0 5 2 9
+r&c5mKS8FY
+BDFChar: 4530 118448 6 0 5 2 3
+e>rWM
+BDFChar: 4531 118449 6 1 5 0 7
+E/9=+:f)uC
+BDFChar: 4532 118450 6 0 5 -1 7
+GXt@rGl35>qu?]s
+BDFChar: 4533 118451 6 3 5 -3 -1
+JAC(C
+BDFChar: 4534 117865 6 0 6 0 6
+&6(XW3)gFh
+BDFChar: 4535 117866 6 0 6 -1 7
+&<]um`W/u$&-)\1
+BDFChar: 4536 117867 6 0 5 0 6
+Gl0Z44T'F(
+BDFChar: 4537 117868 6 0 5 0 6
+8Bf<%r;:d>
+BDFChar: 4538 117869 6 0 5 0 6
+Gl7'HnGIM2
+BDFChar: 4539 117870 6 0 5 0 6
+Gl7K`bfiTX
+BDFChar: 4540 117859 6 1 4 0 6
+n6kbTnF0fc
+BDFChar: 4541 117857 6 1 4 0 6
+@.<[Tn6k_c
+BDFChar: 4542 117856 6 0 5 1 4
+FSu&Y
+BDFChar: 4543 117858 6 0 5 1 4
+\GZ97
+BDFChar: 4544 117860 6 0 5 -2 7
+=T&(>&-rgi&-r79
+BDFChar: 4545 117847 6 1 5 0 7
++E2:=E,bTN
+BDFChar: 4546 117849 6 1 5 0 7
+W;(=NE,]b=
+BDFChar: 4547 117846 6 0 5 1 5
+%!_\p$ig8-
+BDFChar: 4548 117848 6 0 5 1 5
+^j,d%^]4?7
+BDFChar: 4549 117861 6 0 5 1 5
+JG^r<$ig8-
+BDFChar: 4550 117863 6 0 5 1 5
+"T6X)^]4?7
+BDFChar: 4551 117862 6 1 5 1 6
+^d):(G^'2g
+BDFChar: 4552 117864 6 0 4 1 6
+nF07.&/YBI
+BDFChar: 4553 117872 6 0 5 0 6
+E7k(N*'!Ef
+BDFChar: 4554 117873 6 0 5 -3 6
+AE;gQr;:dn0JEJ,
+BDFChar: 4555 117874 6 0 5 0 6
+3,JN^i,CdY
+BDFChar: 4556 117875 6 0 5 0 9
+0JG2*r;>'7S<s9V
+BDFChar: 4557 117876 6 0 5 0 6
+0R2CNr-0mq
+BDFChar: 4558 117877 6 0 5 -3 6
+0R3N.r;:dn0JEJ,
+BDFChar: 4559 117878 6 0 5 0 6
+0R2s^r-0mq
+BDFChar: 4560 117879 6 0 5 0 9
+0JG2*r;?3bGVB*t
+BDFChar: 4561 117880 6 0 5 0 6
+*,sioi,BY9
+BDFChar: 4562 117882 6 0 5 0 6
+i&D\r*&ujV
+BDFChar: 4563 117881 6 0 5 0 7
+0R.j?r60hI
+BDFChar: 4564 117883 6 0 5 -1 6
+KS7SIr-3H?
+BDFChar: 4565 117884 6 0 6 -3 9
+^7qX-WiE)!WiEX^rVuou
+BDFChar: 4566 117885 6 0 6 -3 9
+rd__WWiE)!WiEX^rVuou
+BDFChar: 4567 117886 6 0 6 -3 9
+rdq_]WiE)!WiE(Vq>^Kq
+BDFChar: 4568 117887 6 0 6 -3 9
+rdq_]WiE)!Wf$WSrVuou
+BDFChar: 4569 117888 6 1 5 0 5
+#UlXM-jTeQ
+BDFChar: 4570 117889 6 0 5 0 4
+0E?=tqu?]s
+BDFChar: 4571 117890 6 0 4 0 5
+J=rj>TR["B
+BDFChar: 4572 117891 6 0 5 1 5
+quCsA0E;(Q
+BDFChar: 4573 117892 6 1 4 -3 9
+ORS?nn;rb$OHAsnO8o7\
+BDFChar: 4574 117893 6 0 5 1 5
+r)?Wpqu?]s
+BDFChar: 4575 117894 6 0 5 0 3
+^p&dq
+BDFChar: 4576 117895 6 0 5 0 3
+$oGp#
+BDFChar: 4577 117896 6 0 6 3 5
+m],[T
+BDFChar: 4578 117897 6 0 6 0 6
+W^NieW^Nie
+BDFChar: 4579 117898 6 0 6 -3 9
+-n%JOJq<uSJj`!T-ia5I
+BDFChar: 4580 117899 6 0 6 -3 9
+mdA*7Jq<uSK#YgumJm4e
+BDFChar: 4581 117900 6 0 6 -3 9
+recl5MTWr9U5G,.rVuou
+BDFChar: 4582 117901 6 0 6 -3 9
+rpK3o`e&eo`l@H7rVuou
+BDFChar: 4583 117902 6 0 6 -3 9
+rr.FuJ:O#SR"0^;J,fQL
+BDFChar: 4584 117903 6 0 6 -3 9
+rr2orrr2'Bk5PAZrVuou
+BDFChar: 4585 117904 6 2 4 -3 9
+i'?3ci'?3ci'?3c5QCca
+BDFChar: 4586 117905 6 0 5 2 4
+W;NRo
+BDFChar: 4587 117906 6 0 5 1 5
+@'ok(?iU0,
+BDFChar: 4588 117907 6 0 5 1 5
+(ps4R(]XO9
+BDFChar: 4589 117908 6 0 5 1 5
+@'ohg?iU0,
+BDFChar: 4590 117909 6 0 5 1 5
+(ps4F(]XO9
+BDFChar: 4591 117910 6 0 5 0 7
+&1D5)r-/c4
+BDFChar: 4592 117911 6 0 6 0 6
+mR7&Gr^?/S
+BDFChar: 4593 117912 6 0 6 0 6
+]'cRX])K8@
+BDFChar: 4594 117913 6 0 6 0 6
+mR7'Fr^?/S
+BDFChar: 4595 117914 6 0 6 0 6
+])K9#Wp[Fu
+BDFChar: 4596 117915 6 0 6 0 6
+mR7'Rr^?/S
+BDFChar: 4597 117916 6 0 6 0 6
+])K9#])K8@
+BDFChar: 4598 117917 6 0 6 0 6
+K)W>@])I9]
+BDFChar: 4599 117918 6 0 6 1 5
+r#C/t49,?]
+BDFChar: 4600 117919 6 0 6 1 5
+IW55/GQ7^D
+BDFChar: 4601 117871 6 0 5 0 6
+Gl4rHbku\c
+BDFChar: 4602 117832 6 0 6 1 5
+5bO5<HiO-H
+BDFChar: 4603 117833 6 0 6 1 5
+":>e@HiO-H
+BDFChar: 4604 117834 6 0 6 2 7
+I+E[)<2oou
+BDFChar: 4605 117835 6 0 6 3 5
+3)okW
+BDFChar: 4606 117836 6 0 5 0 7
+GdRCmr('A3
+BDFChar: 4607 117837 6 0 5 0 7
+GdRCmr('B&
+BDFChar: 4608 117838 6 0 6 0 7
+&3*YgmX/ij
+BDFChar: 4609 117839 6 0 6 0 7
+&3*YgmX/h!
+BDFChar: 4610 117840 6 0 5 1 7
+`$fl;r((W(
+BDFChar: 4611 117841 6 0 6 0 7
+7OUB&If;aZ
+BDFChar: 4612 117842 6 0 5 0 6
+0R0t38;'M6
+BDFChar: 4613 117843 6 0 5 0 6
+KX>tX0M$is
+BDFChar: 4614 117844 6 0 5 1 7
+89hLd84^r)
+BDFChar: 4615 117845 6 0 5 0 7
+89hLd0M"aY
+BDFChar: 4616 11044 6 0 5 0 6
+Gl7L;r;:d>
+BDFChar: 4617 118261 6 0 5 0 7
+0R1f4Gl4qU
+BDFChar: 4618 9992 6 0 6 0 7
++>B2^rg5A^
+BDFChar: 4619 128743 6 0 5 0 6
+0JIbLZnQ_)
+BDFChar: 4620 118264 6 0 5 0 6
+GVHN&GVCfO
+BDFChar: 4621 118265 6 0 6 0 7
+#T,>rr\>;r
+BDFChar: 4622 118266 6 1 5 0 4
++E48%:]LIq
+BDFChar: 4623 118267 6 0 5 0 6
+0`9-c8Gp[3
+BDFChar: 4624 118268 6 0 5 0 6
+bkt"&bks-p
+BDFChar: 4625 118269 6 0 5 1 6
++BW`qBF"S<
+BDFChar: 4626 118270 6 0 5 0 7
++G<jQ+D?E>
+BDFChar: 4627 118271 6 0 5 0 7
+,QNo/+G:jC
+BDFChar: 4628 117850 6 0 5 -3 4
+GSkZZGjOdU
+BDFChar: 4629 117853 6 0 5 2 9
+r;9)V84Z;(
+BDFChar: 4630 117852 6 0 5 -3 4
+G[PbMGhh)m
+BDFChar: 4631 117854 6 0 5 2 9
+r;9)V84Z:q
+BDFChar: 4632 117855 6 0 5 2 9
+r;9)V84Z9f
+BDFChar: 4633 117851 6 0 5 -3 4
+GY!'5GdOjU
+BDFChar: 4634 117920 6 0 5 0 7
+":Q84r;?Kj
+BDFChar: 4635 117921 6 0 5 0 7
+JAC+4r;?Kj
+BDFChar: 4636 117922 6 0 5 0 5
+":4paN;NYU
+BDFChar: 4637 117923 6 0 5 0 5
+J3a%N`;BT8
+BDFChar: 4638 117924 6 0 5 0 6
+$kNttr;8YW
+BDFChar: 4639 117925 6 0 5 0 6
+^`Xcpr;?$a
+BDFChar: 4640 117926 6 0 5 -3 4
+$kOOH=I=Vl
+BDFChar: 4641 117927 6 0 5 -3 4
+^`X0oBOh7!
+BDFChar: 4642 117928 6 0 5 -3 4
+$kOOH5a[(T
+BDFChar: 4643 117929 6 0 5 -3 4
+^`X0o#\4'k
+BDFChar: 4644 117930 6 0 5 2 9
+KS5F`9HXlT
+BDFChar: 4645 117931 6 0 5 2 9
+KS1U!a:KK0
+BDFChar: 4646 117932 6 0 5 2 9
+KS4k@9HXlT
+BDFChar: 4647 117933 6 0 5 2 9
+KS0I6a:KK0
+BDFChar: 4648 117934 6 0 5 2 9
+KS4kL:b3.d
+BDFChar: 4649 117935 6 0 5 2 9
+KS0KL.*s*P
+BDFChar: 4650 117936 6 0 5 2 9
+KS4kL:`p;X
+BDFChar: 4651 117937 6 0 5 2 9
+KS0KL-kIN:
+BDFChar: 4652 117938 6 0 5 -3 3
+r.(<1TV.qX
+BDFChar: 4653 117939 6 0 5 -3 3
+qul'p'GM5]
+BDFChar: 4654 117940 6 0 5 3 9
+TU^Q10JI_O
+BDFChar: 4655 117941 6 0 5 3 9
+']]Dp0JI_O
+BDFChar: 4656 117942 6 0 5 -3 1
+r.)G1qu?]s
+BDFChar: 4657 117943 6 0 5 -3 1
+r'WqPqu?]s
+BDFChar: 4658 117944 6 0 5 2 9
+J>e"*J;f$V
+BDFChar: 4659 117945 6 0 5 2 9
+"LJ;R"N1H@
+BDFChar: 4660 118262 6 -1 6 -3 4
+4An:l]`1,X
+BDFChar: 4661 118263 6 -1 6 -3 4
+4A%^:4o`1-
+BDFChar: 4662 118256 6 1 4 -3 3
+?sitBnF5oI
+BDFChar: 4663 118257 6 1 3 4 9
+i*\f85X5;L
+BDFChar: 4664 118259 6 2 4 4 9
+i4qTC5X5;L
+BDFChar: 4665 118258 6 1 4 6 9
+n6fX3
+BDFChar: 4666 118260 6 2 3 4 9
+^qdb$^q]pM
+BDFChar: 4667 118246 6 0 5 -3 3
+0JEKOr3Wg2
+BDFChar: 4668 118247 6 0 5 4 9
+G^)c4KS0=*
+BDFChar: 4669 118248 6 0 5 -3 3
+E-MA%nG)n]
+BDFChar: 4670 118252 6 0 5 -3 3
+3-YE_4FI&,
+BDFChar: 4671 118249 6 0 4 4 9
+n8Kd0?n_Q\
+BDFChar: 4672 118253 6 1 5 4 9
+G]9<`0OOk\
+BDFChar: 4673 118250 6 0 5 -3 3
+E-MA)oXq[6
+BDFChar: 4674 118254 6 0 5 -3 3
+3-YG5]_$:G
+BDFChar: 4675 118251 6 0 5 3 9
+n9d&<,f"p1
+BDFChar: 4676 118255 6 0 5 3 9
+4SZ.BO:26l
+BDFChar: 4677 9688 6 0 6 -3 9
+rr2or`e&eo`r>u:rVuou
+BDFChar: 4678 9689 6 0 6 -3 9
+rr2or`k&am`r>u:rVuou
+BDFChar: 4679 9788 6 1 5 0 6
++K083E2XlZ
+BDFChar: 4680 9644 6 0 5 0 3
+r;?Kj
+BDFChar: 4681 8616 6 1 5 0 7
++E48%W,NmS
+BDFChar: 4682 8359 6 1 5 0 7
+i/j&YOLUC>
+BDFChar: 4683 8976 6 2 5 0 3
+n:6%>
+BDFChar: 4684 9668 6 1 5 1 5
+#WVT=#QOi)
+BDFChar: 4685 9658 6 1 5 1 5
+JDg4\J,fQL
+BDFChar: 4686 8771 6 1 5 2 5
+BWqL3
+BDFChar: 4687 8772 6 1 5 0 7
+&.iNZ+S\2e
+BDFChar: 4688 9768 6 1 5 0 7
++E/Iu+<VdL
+BDFChar: 4689 127136 6 1 5 -2 8
+po)iDfVmH$fVnQF
+BDFChar: 4690 127137 6 1 5 -2 8
+pt2O$W2TLDLoC(K
+BDFChar: 4691 127138 6 1 5 -2 8
+pt2P/fSK=TLoC(K
+BDFChar: 4692 127139 6 1 5 -2 8
+pmC9tka;.tLoC(K
+BDFChar: 4693 127140 6 1 5 -2 8
+prKCikihfoLoC(K
+BDFChar: 4694 127141 6 1 5 -2 8
+pkZGIka;.tLoC(K
+BDFChar: 4695 127142 6 1 5 -2 8
+pt3*DW7^mtLoC(K
+BDFChar: 4696 127143 6 1 5 -2 8
+pk\.tf\#uOLoC(K
+BDFChar: 4697 127144 6 1 5 -2 8
+pt2OtW7^mtLoC(K
+BDFChar: 4698 127145 6 1 5 -2 8
+pt2Odkh,[_LoC(K
+BDFChar: 4699 127146 6 1 5 -2 8
+pk[STf\#uOLoC(K
+BDFChar: 4700 127147 6 1 5 -2 8
+prM[_W7^mtLoC(K
+BDFChar: 4701 127148 6 1 5 -2 8
+pt2OTW7^mtLoC(K
+BDFChar: 4702 127149 6 1 5 -2 8
+pt2ODR)o'TLoC(K
+BDFChar: 4703 127150 6 1 5 -2 8
+po(-YW2TLDLoC(K
+BDFChar: 4704 127153 6 1 5 -2 8
+pt2O$W2TKiLtMJ&
+BDFChar: 4705 127154 6 1 5 -2 8
+pt2P/fSK=$LtMJ&
+BDFChar: 4706 127155 6 1 5 -2 8
+pmC9tka;.DLtMJ&
+BDFChar: 4707 127156 6 1 5 -2 8
+prKCikihf?LtMJ&
+BDFChar: 4708 127157 6 1 5 -2 8
+pkZGIka;.DLtMJ&
+BDFChar: 4709 127158 6 1 5 -2 8
+pt3*DW7^mDLtMJ&
+BDFChar: 4710 127159 6 1 5 -2 8
+pk\.tf\#ttLtMJ&
+BDFChar: 4711 127160 6 1 5 -2 8
+pt2OtW7^mDLtMJ&
+BDFChar: 4712 127161 6 1 5 -2 8
+pt2Odkh,[/LtMJ&
+BDFChar: 4713 127162 6 1 5 -2 8
+pk[STf\#ttLtMJ&
+BDFChar: 4714 127163 6 1 5 -2 8
+prM[_W7^mDLtMJ&
+BDFChar: 4715 127164 6 1 5 -2 8
+pt2OTW7^mDLtMJ&
+BDFChar: 4716 127165 6 1 5 -2 8
+pt2ODR)o'$LtMJ&
+BDFChar: 4717 127166 6 1 5 -2 8
+po(-YW2TKiLtMJ&
+BDFChar: 4718 127167 6 1 5 -2 8
+q"XXZfSJ1Yq"XUa
+BDFChar: 4719 127169 6 1 5 -2 8
+pt2O$W2TLDLtMJ&
+BDFChar: 4720 127170 6 1 5 -2 8
+pt2P/fSK=TLtMJ&
+BDFChar: 4721 127171 6 1 5 -2 8
+pmC9tka;.tLtMJ&
+BDFChar: 4722 127172 6 1 5 -2 8
+prKCikihfoLtMJ&
+BDFChar: 4723 127173 6 1 5 -2 8
+pkZGIka;.tLtMJ&
+BDFChar: 4724 127174 6 1 5 -2 8
+pt3*DW7^mtLtMJ&
+BDFChar: 4725 127175 6 1 5 -2 8
+pk\.tf\#uOLtMJ&
+BDFChar: 4726 127176 6 1 5 -2 8
+pt2OtW7^mtLtMJ&
+BDFChar: 4727 127177 6 1 5 -2 8
+pt2Odkh,[_LtMJ&
+BDFChar: 4728 127178 6 1 5 -2 8
+pk[STf\#uOLtMJ&
+BDFChar: 4729 127179 6 1 5 -2 8
+prM[_W7^mtLtMJ&
+BDFChar: 4730 127180 6 1 5 -2 8
+pt2OTW7^mtLtMJ&
+BDFChar: 4731 127181 6 1 5 -2 8
+pt2ODR)o'TLtMJ&
+BDFChar: 4732 127182 6 1 5 -2 8
+po(-YW2TLDLtMJ&
+BDFChar: 4733 127183 12 3 9 -2 8
+rdo`RP.HgVJqEt%
+BDFChar: 4734 127185 6 1 5 -2 8
+pt2O$W2TLDW7^kF
+BDFChar: 4735 127186 6 1 5 -2 8
+pt2P/fSK=TW7^kF
+BDFChar: 4736 127187 6 1 5 -2 8
+pmC9tka;.tW7^kF
+BDFChar: 4737 127188 6 1 5 -2 8
+prKCikihfoW7^kF
+BDFChar: 4738 127189 6 1 5 -2 8
+pkZGIka;.tW7^kF
+BDFChar: 4739 127190 6 1 5 -2 8
+pt3*DW7^mtW7^kF
+BDFChar: 4740 127191 6 1 5 -2 8
+pk\.tf\#uOW7^kF
+BDFChar: 4741 127192 6 1 5 -2 8
+pt2OtW7^mtW7^kF
+BDFChar: 4742 127193 6 1 5 -2 8
+pt2Odkh,[_W7^kF
+BDFChar: 4743 127194 6 1 5 -2 8
+pk[STf\#uOW7^kF
+BDFChar: 4744 127195 6 1 5 -2 8
+prM[_W7^mtW7^kF
+BDFChar: 4745 127196 6 1 5 -2 8
+pt2OTW7^mtW7^kF
+BDFChar: 4746 127197 6 1 5 -2 8
+pt2ODR)o'TW7^kF
+BDFChar: 4747 127198 6 1 5 -2 8
+po(-YW2TLDW7^kF
+BDFChar: 4748 127199 6 1 5 -2 8
+q"XXZfSJ1Yq"XUa
+BDFChar: 4749 8462 6 1 5 0 7
+?m%^2BLn5P
+BDFChar: 4750 8463 6 1 5 0 7
+?nfAmBLn5P
+BDFChar: 4751 8495 6 1 5 0 5
+0M%;`Li<=o
+BDFChar: 4752 8550 6 0 6 0 7
+WiE)!WiAZ`
+BDFChar: 4753 8551 6 0 6 0 7
+Y-+q1Y-(Mp
+BDFChar: 4754 8555 6 0 6 0 7
+WiE'kWiE)!
+BDFChar: 4755 8556 6 1 5 0 7
+J:N0#J:N1F
+BDFChar: 4756 8557 6 1 5 0 7
+E/9$pJ:NGp
+BDFChar: 4757 8558 6 1 5 0 7
+i/ibNLkq/N
+BDFChar: 4758 8559 6 1 5 0 7
+LtJZ)LkpkC
+BDFChar: 4759 8572 6 3 3 0 7
+J:N0#J:N0#
+BDFChar: 4760 8573 6 1 5 0 4
+E/9%#Du]k<
+BDFChar: 4761 8574 6 1 5 0 7
+#RC]\Lkpk3
+BDFChar: 4762 8575 6 1 5 0 4
+d&<nAVuQet
+BDFChar: 4763 8528 6 1 5 0 8
+Lld^k+BV0rO8o7\
+BDFChar: 4764 8529 6 1 5 0 8
+Lld^k0PFREO8o7\
+BDFChar: 4765 8585 6 1 5 0 8
+8?f=+3(Ql%QiI*d
+BDFChar: 4766 8530 6 1 6 0 8
+Lld^k+D>l(VuQet
+BDFChar: 4767 8531 6 1 5 0 8
+Lld^k3(Ql%QiI*d
+BDFChar: 4768 8532 6 1 5 0 8
+Les2k3(Ql%QiI*d
+BDFChar: 4769 8533 6 1 5 0 8
+Lld^k+BVHrO8o7\
+BDFChar: 4770 8534 6 1 5 0 8
+Les2k+BVHrO8o7\
+BDFChar: 4771 8535 6 1 5 0 8
+aA@t+i)ig3O8o7\
+BDFChar: 4772 8536 6 0 5 0 8
+,\ZBq&1f4t8,rVi
+BDFChar: 4773 8537 6 1 6 0 8
+Lld^k-r=$1L]@DT
+BDFChar: 4774 8543 6 1 5 0 8
+Lld^k+@&2BJ,fQL
+BDFChar: 4775 8538 6 1 6 0 8
+aH05k-r=$1L]@DT
+BDFChar: 4776 8539 6 1 5 0 8
+Lld^k0PF:]O8o7\
+BDFChar: 4777 8540 6 1 5 0 8
+aA@t+n7YXsO8o7\
+BDFChar: 4778 8541 6 1 5 0 8
+aH05k0PF:]O8o7\
+BDFChar: 4779 8542 6 1 5 0 8
+aA@tk0PF:]O8o7\
+BDFChar: 4780 8576 6 1 5 0 7
+E2]_6W2QY6
+BDFChar: 4781 8577 6 1 5 0 7
+i/l$YW5t(Y
+BDFChar: 4782 8579 6 1 5 0 7
+E/4c*#RH6*
+BDFChar: 4783 8580 6 1 5 0 4
+E/4dUDu]k<
+BDFChar: 4784 8586 6 1 5 0 7
+p]qER5_+Z0
+BDFChar: 4785 8587 6 1 5 0 7
+E/9$p@"=&P
+BDFChar: 4786 8486 6 1 5 0 7
+E/9=+LtGPV
+BDFChar: 4787 8487 6 1 5 0 7
+fML4VLkpk+
+BDFChar: 4788 8451 6 0 5 0 7
+8@22)&.fN]
+BDFChar: 4789 8457 6 0 5 0 7
+>d.$E&.fBa
+BDFChar: 4790 128163 12 1 11 -2 9
+"s=5&#Tu<]4og'4s+(&urIFouHN650
+BDFChar: 4791 127918 12 1 10 0 7
+1B;oT?@\##hSB0,s1i&n
+BDFChar: 4792 128190 12 1 11 -2 8
+s+'W)nR1ios5<q8^gOrchdF6-s53kW
+BDFChar: 4793 128191 12 1 11 -2 8
+%KJA:6pO/UO!'<&SfhQ/6pNV[%KHJ/
+BDFChar: 4794 128192 12 1 11 -2 8
+%KJA:6pO/UO!'<&SfhQ/6pNV[%KHJ/
+BDFChar: 4795 128164 12 1 11 -2 8
+!T3r#!'gO7*<69$#QW3O>QB9S^]4?7
+BDFChar: 4796 128193 12 1 11 -1 7
+GQ<BsK>@C-J09@bJ09@bJ%u$a
+BDFChar: 4797 128194 12 1 11 -1 7
+DubmuJH2>#O<C2]TKp;CIfKHK
+BDFChar: 4798 128153 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4799 128154 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4800 128155 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4801 128156 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4802 128150 12 1 11 -2 7
+EPVHZrZL*+hr%kWa+-AS/c[-s
+BDFChar: 4803 128151 12 1 11 -2 7
+EPT_)[@k.)^S"q!/q=Z:$312/
+BDFChar: 4804 128148 12 1 11 -2 7
+EPVJ0rS[S2pY^D64b+IO$312/
+BDFChar: 4805 128140 12 1 11 0 7
+s5:\#Wh>t,T-1;0`*iW'
+BDFChar: 4806 129293 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4807 129294 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4808 129505 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4809 128157 12 1 11 -2 7
+EPVV4PMgs66m.]/It/U@%KHV3
+BDFChar: 4810 128147 12 1 11 -2 9
+EPR)I0n;MS4+MgrJ&$QL5CagU%KHV3
+BDFChar: 4811 128149 12 1 11 -2 8
+!C-bF"5j3qCk2KbrW)otHiQ,+&-)\1
+BDFChar: 4812 128152 12 1 11 -2 8
+huJi=]7>CHJ&$QL4b+T(%q#Ou!5JR7
+BDFChar: 4813 128158 12 1 11 -2 8
+!C/a)6f<O2Ck2L-rZM2*I=O9W&-)\1
+BDFChar: 4814 128420 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4815 127892 12 2 10 -1 7
+G6%Yns+(-"IfMY4)upfU0E;(Q
+BDFChar: 4816 128189 12 1 11 -2 8
+s5<G*^gP(<NZa3%NZc6t^gQ]js53kW
+BDFChar: 4817 129653 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4818 129654 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4819 129655 12 1 11 -2 7
+EPVJ0s5<q8s58CB5CagU%KHV3
+BDFChar: 4820 128386 12 1 11 0 7
+s5:\#TV.DiRinN"^gR3#
+BDFChar: 4821 128387 12 1 11 0 7
+s58DMJY9]LJ0;QKJ0=mM
+BDFChar: 4822 9993 12 1 11 0 7
+s5:\#TV.DiRinN"^gR3#
+BDFChar: 4823 8987 12 3 9 -1 8
+rdo`L3&jm#rr)lt
+BDFChar: 4824 65532 6 1 5 -2 8
+fSBN`L]E6e!/T8-
+BDFChar: 4825 65533 6 0 6 -2 8
+&3)Xc<;(-U-o_b<
+BDFChar: 4826 128336 12 1 11 -2 8
+%KJ566pO4,L*2-lJ07*B5X7&S%KHJ/
+BDFChar: 4827 128337 12 1 11 -2 8
+%KJ566pO.*Kcl*mJ07*B5X7&S%KHJ/
+BDFChar: 4828 128338 12 1 11 -2 8
+%KJ566pO.*KHQ$mJ07*B5X7&S%KHJ/
+BDFChar: 4829 128339 12 1 11 -2 8
+%KJ566pO.*KHQ!lJKR3C5X7&S%KHJ/
+BDFChar: 4830 128340 12 1 11 -2 8
+%KJ566pO.*KHPpjJfmBF5X7&S%KHJ/
+BDFChar: 4831 128341 12 1 11 -2 8
+%KJ566pO.*KHPpjKHNZJ5X7&S%KHJ/
+BDFChar: 4832 128342 12 1 11 -2 8
+%KJ566pO.*KHPpjL`f5R5X7&S%KHJ/
+BDFChar: 4833 128343 12 1 11 -2 8
+%KJ566pO.*KHQ3rO<?eR5X7&S%KHJ/
+BDFChar: 4834 128344 12 1 11 -2 8
+%KJ566pO.*KHQd-J07*B5X7&S%KHJ/
+BDFChar: 4835 128345 12 1 11 -2 8
+%KJ566pO.*PTYo-J07*B5X7&S%KHJ/
+BDFChar: 4836 128346 12 1 11 -2 8
+%KJ566pOF2N$*crJ07*B5X7&S%KHJ/
+BDFChar: 4837 128347 12 1 11 -2 8
+%KJ566pO.*KHPpjJ07*B5X7&S%KHJ/
+BDFChar: 4838 128348 12 1 11 -2 8
+%KJ565X7Y$Jfo^hKHNZJ6pNJW%KHJ/
+BDFChar: 4839 128349 12 1 11 -2 8
+%KJ565X7S"JKT[iKHNZJ6pNJW%KHJ/
+BDFChar: 4840 128350 12 1 11 -2 8
+%KJ565X7S"J09UiKHNZJ6pNJW%KHJ/
+BDFChar: 4841 128351 12 1 11 -2 8
+%KJ565X7S"J09RhKcicK6pNJW%KHJ/
+BDFChar: 4842 128352 12 1 11 -2 8
+%KJ565X7S"J09LfL*/rN6pNJW%KHJ/
+BDFChar: 4843 128353 12 1 11 -2 8
+%KJ565X7S"J09LfKHNZJ6pNJW%KHJ/
+BDFChar: 4844 128354 12 1 11 -2 8
+%KJ565X7S"J09LfN$(eZ6pNJW%KHJ/
+BDFChar: 4845 128355 12 1 11 -2 8
+%KJ565X7S"J09dnPTW@Z6pNJW%KHJ/
+BDFChar: 4846 128356 12 1 11 -2 8
+%KJ565X7S"J0:@)KHNZJ6pNJW%KHJ/
+BDFChar: 4847 128357 12 1 11 -2 8
+%KJ565X7S"O<BK)KHNZJ6pNJW%KHJ/
+BDFChar: 4848 128358 12 1 11 -2 8
+%KJ565X7k*L`h?nKHNZJ6pNJW%KHJ/
+BDFChar: 4849 128359 12 1 11 -2 8
+%KJ565X7_&KHPpjKHNZJ6pNJW%KHJ/
+BDFChar: 4850 9733 6 1 5 1 6
++<^GuE/4Jo
+BDFChar: 4851 9734 6 1 5 1 6
++<^GUE/4Jo
+BDFChar: 4852 9312 12 1 11 -2 8
+*ro]a5X9uFN$*crKHQ9t5X8_m*rl9@
+BDFChar: 4853 9313 12 1 11 -2 8
+*ro]a5X:8NJfo^hL`h^#5X8_m*rl9@
+BDFChar: 4854 9314 12 1 11 -2 8
+*ro]a5X:8NJfo^hJfp!p5X8_m*rl9@
+BDFChar: 4855 9315 12 1 11 -2 8
+*ro]a5X:&HMBIp%JfoXf5X8_m*rl9@
+BDFChar: 4856 9316 12 1 11 -2 8
+*ro]a5X:>PL`hX!Jfp!p5X8_m*rl9@
+BDFChar: 4857 9317 12 1 11 -2 8
+*ro]a5X9uFL`hX!MBIQp5X8_m*rl9@
+BDFChar: 4858 9318 12 1 11 -2 8
+*ro]a5X:>PJfoXfKHPpj5X8_m*rl9@
+BDFChar: 4859 9319 12 1 11 -2 8
+*ro]a5X9uFMBIQpMBIQp5X8_m*rl9@
+BDFChar: 4860 9320 12 1 11 -2 8
+*ro]a5X9uFMBIWrJfo^h5X8_m*rl9@
+BDFChar: 4861 9321 12 1 11 -2 8
+*ro]a5X:GSZCmARP+]?.5X8_m*rl9@
+BDFChar: 4862 9322 12 1 11 -2 8
+*ro]a5X:GSZQPAQOW_9/5X8_m*rl9@
+BDFChar: 4863 9323 12 1 11 -2 8
+*ro]a5X:MUYb7+$Os%B05X8_m*rl9@
+BDFChar: 4864 9324 12 1 11 -2 8
+*ro]a5X:MUYb7+$OJ'3.5X8_m*rl9@
+BDFChar: 4865 9325 12 1 11 -2 8
+*ro]a5X:I)ZCmDSOJ'+V5X8_m*rl9@
+BDFChar: 4866 9326 12 1 11 -2 8
+*ro]a5X:O+Z65>ROJ'3.5X8_m*rl9@
+BDFChar: 4867 9327 12 1 11 -2 8
+*ro]a5X:GSZ65>RP+]?.5X8_m*rl9@
+BDFChar: 4868 9328 12 1 11 -2 8
+*ro]a5X:O+Yb7)NOW_1W5X8_m*rl9@
+BDFChar: 4869 9329 12 1 11 -2 8
+*ro]a5X:GSZCm=&P+]?.5X8_m*rl9@
+BDFChar: 4870 9330 12 1 11 -2 8
+*ro]a5X:GSZCm>QOJ'-,5X8_m*rl9@
+BDFChar: 4871 9331 12 1 11 -2 8
+*ro]a5X;RsMP--*U7f%>5X8_m*rl9@
+BDFChar: 4872 9450 12 1 11 -2 8
+*ro]a5X9uFMBId!MBIQp5X8_m*rl9@
+BDFChar: 4873 9470 12 1 11 -2 8
+*rpf+@).mIZCmARP+]?.@).9-*rl9@
+BDFChar: 4874 9461 12 1 11 -2 8
+*rpf+@).F<N$*crKHQ9t@).9-*rl9@
+BDFChar: 4875 9462 12 1 11 -2 8
+*rpf+@).^DJfo^hL`h^#@).9-*rl9@
+BDFChar: 4876 9463 12 1 11 -2 8
+*rpf+@).^DJfo^hJfp!p@).9-*rl9@
+BDFChar: 4877 9464 12 1 11 -2 8
+*rpf+@).L>MBIp%JfoXf@).9-*rl9@
+BDFChar: 4878 9465 12 1 11 -2 8
+*rpf+@).dFL`hX!Jfp!p@).9-*rl9@
+BDFChar: 4879 9466 12 1 11 -2 8
+*rpf+@).F<L`hX!MBIQp@).9-*rl9@
+BDFChar: 4880 9467 12 1 11 -2 8
+*rpf+@).dFJfoXfKHPpj@).9-*rl9@
+BDFChar: 4881 9468 12 1 11 -2 8
+*rpf+@).F<MBIQpMBIQp@).9-*rl9@
+BDFChar: 4882 9469 12 1 11 -2 8
+*rpf+@).F<MBIWrJfo^h@).9-*rl9@
+BDFChar: 4883 9460 12 2 10 -1 7
+4og'4SUg!Ug46bbNIZKY4obQ_
+BDFChar: 4884 9459 12 2 10 -1 7
+4og'4h11rEgjn73NIZKY4obQ_
+BDFChar: 4885 9458 12 2 10 -1 7
+4og'4h11rEh1440NIZKY4obQ_
+BDFChar: 4886 9457 12 2 10 -1 7
+4og'4fRTQDhLOF4NIZKY4obQ_
+BDFChar: 4887 9456 12 2 10 -1 7
+4og'4h11uFfmqe,NIZKY4obQ_
+BDFChar: 4888 9455 12 2 10 -1 7
+4og'4fRTHAfmqq0M1C'U4obQ_
+BDFChar: 4889 9454 12 2 10 -1 7
+4og'4gjkiDfRVh/NduTZ4obQ_
+BDFChar: 4890 9453 12 2 10 -1 7
+4og'4fmoZEh14@4M1C'U4obQ_
+BDFChar: 4891 9452 12 2 10 -1 7
+4og'4fmoZEh1471Lk'sT4obQ_
+BDFChar: 4892 9451 12 2 10 -1 7
+4og'4h11oDh14=3Lk'sT4obQ_
+BDFChar: 4893 9471 12 2 10 -1 7
+4og'4pOMR[l[\;OpOI_n4obQ_
+BDFChar: 4894 10102 12 2 10 -1 7
+4og'4pOMFWpON!gj+)UZ4obQ_
+BDFChar: 4895 10103 12 2 10 -1 7
+4og'4kCEG[pOM^_j+)UZ4obQ_
+BDFChar: 4896 10104 12 2 10 -1 7
+4og'4kCEG[pON-kkCA$^4obQ_
+BDFChar: 4897 10105 12 2 10 -1 7
+4og'4o76.Wj+.#Wqga.r4obQ_
+BDFChar: 4898 10106 12 2 10 -1 7
+4og'4j+-TKkCEG[kCA$^4obQ_
+BDFChar: 4899 10107 12 2 10 -1 7
+4og'4pOM^_kCDlKpOI_n4obQ_
+BDFChar: 4900 10108 12 2 10 -1 7
+4og'4j+.#WqgeEkpOI_n4obQ_
+BDFChar: 4901 10109 12 2 10 -1 7
+4og'4pOMR[pOMR[pOI_n4obQ_
+BDFChar: 4902 10110 12 2 10 -1 7
+4og'4pOMR[o76^gpOI_n4obQ_
+BDFChar: 4903 10111 12 2 10 -1 7
+4og'4h11rEg47n-NIZKY4obQ_
+BDFChar: 4904 10122 12 2 10 -1 7
+4og'4pOMFWpON!gj+)UZ4obQ_
+BDFChar: 4905 10123 12 2 10 -1 7
+4og'4kCEG[pOM^_j+)UZ4obQ_
+BDFChar: 4906 10124 12 2 10 -1 7
+4og'4kCEG[pON-kkCA$^4obQ_
+BDFChar: 4907 10125 12 2 10 -1 7
+4og'4o76.Wj+.#Wqga.r4obQ_
+BDFChar: 4908 10126 12 2 10 -1 7
+4og'4j+-TKkCEG[kCA$^4obQ_
+BDFChar: 4909 10127 12 2 10 -1 7
+4og'4pOM^_kCDlKpOI_n4obQ_
+BDFChar: 4910 10128 12 2 10 -1 7
+4og'4j+.#WqgeEkpOI_n4obQ_
+BDFChar: 4911 10129 12 2 10 -1 7
+4og'4pOMR[pOMR[pOI_n4obQ_
+BDFChar: 4912 10130 12 2 10 -1 7
+4og'4pOMR[o76^gpOI_n4obQ_
+BDFChar: 4913 10131 12 2 10 -1 7
+4og'4h11rEg47n-NIZKY4obQ_
+BDFChar: 4914 10112 12 1 11 -2 8
+*ro]a5X9uFN$*crKHQ9t5X8_m*rl9@
+BDFChar: 4915 10113 12 1 11 -2 8
+*ro]a5X:8NJfo^hL`h^#5X8_m*rl9@
+BDFChar: 4916 10114 12 1 11 -2 8
+*ro]a5X:8NJfo^hJfp!p5X8_m*rl9@
+BDFChar: 4917 10115 12 1 11 -2 8
+*ro]a5X:&HMBIp%JfoXf5X8_m*rl9@
+BDFChar: 4918 10116 12 1 11 -2 8
+*ro]a5X:>PL`hX!Jfp!p5X8_m*rl9@
+BDFChar: 4919 10117 12 1 11 -2 8
+*ro]a5X9uFL`hX!MBIQp5X8_m*rl9@
+BDFChar: 4920 10118 12 1 11 -2 8
+*ro]a5X:>PJfoXfKHPpj5X8_m*rl9@
+BDFChar: 4921 10119 12 1 11 -2 8
+*ro]a5X9uFMBIQpMBIQp5X8_m*rl9@
+BDFChar: 4922 10120 12 1 11 -2 8
+*ro]a5X9uFMBIWrJfo^h5X8_m*rl9@
+BDFChar: 4923 10121 12 1 11 -2 8
+*ro]a5X:GSZCmARP+]?.5X8_m*rl9@
+BDFChar: 4924 12881 12 1 11 -2 8
+*ro]a5X;RsM]e-)Tcgt?5X8_m*rl9@
+BDFChar: 4925 12882 12 1 11 -2 8
+*ro]a5X;XuLnKkQU*.(@5X8_m*rl9@
+BDFChar: 4926 12883 12 1 11 -2 8
+*ro]a5X;XuLnKkQTV/n>5X8_m*rl9@
+BDFChar: 4927 12884 12 1 11 -2 8
+*ro]a5X;TIMP-0+TV/ff5X8_m*rl9@
+BDFChar: 4928 12885 12 1 11 -2 8
+*ro]a5X;ZKMBJ**TV/n>5X8_m*rl9@
+BDFChar: 4929 12886 12 1 11 -2 8
+*ro]a5X;RsMBJ**U7f%>5X8_m*rl9@
+BDFChar: 4930 12887 12 1 11 -2 8
+*ro]a5X;ZKLnKj&Tcglg5X8_m*rl9@
+BDFChar: 4931 12888 12 1 11 -2 8
+*ro]a5X;RsMP-(SU7f%>5X8_m*rl9@
+BDFChar: 4932 12889 12 1 11 -2 8
+*ro]a5X;RsMP-*)TV/h<5X8_m*rl9@
+BDFChar: 4933 12890 12 1 11 -2 8
+*ro]a5X;RsMP--*MP.3s5X8_m*rl9@
+BDFChar: 4934 12891 12 1 11 -2 8
+*ro]a5X;RsM]e-)M'0-t5X8_m*rl9@
+BDFChar: 4935 12892 12 1 11 -2 8
+*ro]a5X;XuLnKkQMBK6u5X8_m*rl9@
+BDFChar: 4936 12893 12 1 11 -2 8
+*ro]a5X;XuLnKkQLnM's5X8_m*rl9@
+BDFChar: 4937 12894 12 1 11 -2 8
+*ro]a5X;TIMP-0+LnLuF5X8_m*rl9@
+BDFChar: 4938 12895 12 1 11 -2 8
+*ro]a5X;ZKMBJ**LnM's5X8_m*rl9@
+BDFChar: 4939 12977 12 1 11 -2 8
+*ro]a5X;RsMBJ**MP.3s5X8_m*rl9@
+BDFChar: 4940 12978 12 1 11 -2 8
+*ro]a5X;ZKLnKj&M'0&G5X8_m*rl9@
+BDFChar: 4941 12979 12 1 11 -2 8
+*ro]a5X;RsMP-(SMP.3s5X8_m*rl9@
+BDFChar: 4942 12980 12 1 11 -2 8
+*ro]a5X;RsMP-*)LnM!q5X8_m*rl9@
+BDFChar: 4943 12981 12 1 11 -2 8
+*ro]a5X:_[Wh?qrMP,eK5X8_m*rl9@
+BDFChar: 4944 12982 12 1 11 -2 8
+*ro]a5X:_[X!"qqM'._L5X8_m*rl9@
+BDFChar: 4945 12983 12 1 11 -2 8
+*ro]a5X:e]W1^[DMBIhM5X8_m*rl9@
+BDFChar: 4946 12984 12 1 11 -2 8
+*ro]a5X:e]W1^[DLnKYK5X8_m*rl9@
+BDFChar: 4947 12985 12 1 11 -2 8
+*ro]a5X:a1Wh?tsLnKQs5X8_m*rl9@
+BDFChar: 4948 12986 12 1 11 -2 8
+*ro]a5X:g3WZ\nrLnKYK5X8_m*rl9@
+BDFChar: 4949 12987 12 1 11 -2 8
+*ro]a5X:_[WZ\nrMP,eK5X8_m*rl9@
+BDFChar: 4950 12988 12 1 11 -2 8
+*ro]a5X:g3W1^YnM'.Wt5X8_m*rl9@
+BDFChar: 4951 12989 12 1 11 -2 8
+*ro]a5X:_[Wh?mFMP,eK5X8_m*rl9@
+BDFChar: 4952 12990 12 1 11 -2 8
+*ro]a5X:_[Wh?nqLnKSI5X8_m*rl9@
+BDFChar: 4953 12991 12 1 11 -2 8
+*ro]a5X;k&U7efbMP.3s5X8_m*rl9@
+BDFChar: 4954 12964 12 1 11 -2 8
+*ro]a6pQDJLEM6mKHQm05X8_m*rl9@
+BDFChar: 4955 12965 12 1 11 -2 8
+*ro]a6pSM[UnFNV^S$6&6pP.q*rl9@
+BDFChar: 4956 12966 12 1 11 -2 8
+*ro]a5X:qaKHQ!lKcl$k6pP.q*rl9@
+BDFChar: 4957 12967 12 1 11 -2 8
+*ro]a83idiL`ha$Os$)65X8_m*rl9@
+BDFChar: 4958 12968 12 1 11 -2 8
+*ro]a83idiL`ha$PouD95X8_m*rl9@
+BDFChar: 4959 12963 12 1 11 -2 8
+*ro]a5X<)WKHQU(PT[`65X8_m*rl9@
+BDFChar: 4960 12928 12 1 11 -2 8
+*ro]a5X9iBJ0:I,J09@b5X8_m*rl9@
+BDFChar: 4961 12929 12 1 11 -2 8
+*ro]a5X:>PJ09@bJ0:I,5X8_m*rl9@
+BDFChar: 4962 12930 12 1 11 -2 8
+*ro]a5X:qaJ09jpJ0:I,5X8_m*rl9@
+BDFChar: 4963 12931 12 1 11 -2 8
+*ro]a5X<)WWh?\kTV0&m5X8_m*rl9@
+BDFChar: 4964 12932 12 1 11 -2 8
+*ro]a?U08eT-/t5M'0R+5X8_m*rl9@
+BDFChar: 4965 12933 12 1 11 -2 8
+*ro]a6pR@eJ09^lMBJ$(5X8_m*rl9@
+BDFChar: 4966 12934 12 1 11 -2 8
+*ro]a83i(U]HE"QM'.j%5X8_m*rl9@
+BDFChar: 4967 12935 12 1 11 -2 8
+*ro]a:-aCRMBId!OW]c/5X8_m*rl9@
+BDFChar: 4968 12936 12 1 11 -2 8
+*ro]a83htRSfin5MP-.U5X8_m*rl9@
+BDFChar: 4969 12937 12 1 11 -2 8
+*ro]a6pQDJKHS%&KHPpj6pP.q*rl9@
+BDFChar: 4970 12938 12 1 11 -2 8
+*ro]a:I'aZO!'9%O!'9%;a=a+*rl9@
+BDFChar: 4971 12939 12 1 11 -2 8
+*ro]a6pR"[Pot`&MBJ$(5X8_m*rl9@
+BDFChar: 4972 12940 12 1 11 -2 8
+*ro]a6pQGK^*&FYPoukF9L*"$*rl9@
+BDFChar: 4973 12941 12 1 11 -2 8
+*ro]a6pQDJT-/e0NZaT06pP.q*rl9@
+BDFChar: 4974 12942 12 1 11 -2 8
+*ro]a:-apaY+UFj^S$i7J&#I-*rl9@
+BDFChar: 4975 12943 12 1 11 -2 8
+*ro]a6pQDJT-/e0KHS%&5X8_m*rl9@
+BDFChar: 4976 12944 12 1 11 -2 8
+*ro]a?U0_rOW^8=OW]c/?U/#7*rl9@
+BDFChar: 4977 13008 12 1 11 -2 8
+*ro]a5X:qaKcl*mKHPpj83gRu*rl9@
+BDFChar: 4978 13009 12 1 11 -2 8
+*ro]a5X9oDKHQd-KHPpj5X8_m*rl9@
+BDFChar: 4979 13010 12 1 11 -2 8
+*ro]a6pR@eOW]c/Jfo^h5X8_m*rl9@
+BDFChar: 4980 13011 12 1 11 -2 8
+*ro]a5X:>PKHPpjKHQm05X8_m*rl9@
+BDFChar: 4981 13012 12 1 11 -2 8
+*ro]a5X9oDT-/k2MBJ')5X8_m*rl9@
+BDFChar: 4982 13013 12 1 11 -2 8
+*ro]a5X:,JT-/t5M'/!)5X8_m*rl9@
+BDFChar: 4983 13014 12 1 11 -2 8
+*ro]a5X9uFT-/e0T-/e05X8_m*rl9@
+BDFChar: 4984 13015 12 1 11 -2 8
+*ro]a83i4YOW]2tJfp!p5X8_m*rl9@
+BDFChar: 4985 13016 12 1 11 -2 8
+*ro]a83i4YPTYW%KHQ'n5X8_m*rl9@
+BDFChar: 4986 13017 12 1 11 -2 8
+*ro]a5X:qaJKTLdJKUR-5X8_m*rl9@
+BDFChar: 4987 13018 12 1 11 -2 8
+*ro]a8jJ7VT-0"6MBIKn6pP.q*rl9@
+BDFChar: 4988 13019 12 1 11 -2 8
+*ro]a5X:_[JKU@'JfpR+5X8_m*rl9@
+BDFChar: 4989 13020 12 1 11 -2 8
+*ro]a5X:qaJKTOeL*2m,5X8_m*rl9@
+BDFChar: 4990 13021 12 1 11 -2 8
+*ro]a83htRT-0"6L`ha$5X8_m*rl9@
+BDFChar: 4991 13022 12 1 11 -2 8
+*ro]a5X:GSOW]K'Jfp!p5X8_m*rl9@
+BDFChar: 4992 13023 12 1 11 -2 8
+*ro]a83i4YOW]?#Jfp$q5X8_m*rl9@
+BDFChar: 4993 13024 12 1 11 -2 8
+*ro]a69pJPKHQm0KHPpj83gRu*rl9@
+BDFChar: 4994 13025 12 1 11 -2 8
+*ro]a5X:SWPotW#Jfp!p5X8_m*rl9@
+BDFChar: 4995 13026 12 1 11 -2 8
+*ro]a5X:>PJ0:I,KHPpj83gRu*rl9@
+BDFChar: 4996 13027 12 1 11 -2 8
+*ro]a6pQDJL*20mKHPpj5X8_m*rl9@
+BDFChar: 4997 13028 12 1 11 -2 8
+*ro]a6pQDJT-/e0KHPpj83gRu*rl9@
+BDFChar: 4998 13029 12 1 11 -2 8
+*ro]a5X:>PJ09@bJ0:I,5X8_m*rl9@
+BDFChar: 4999 13030 12 1 11 -2 8
+*ro]a5X:qaJKTXhJfpU,5X8_m*rl9@
+BDFChar: 5000 13031 12 1 11 -2 8
+*ro]a6pR@eJKT[iSKNS.6pP.q*rl9@
+BDFChar: 5001 13032 12 1 11 -2 8
+*ro]a5X9oDJfoXfKHQX)5X8_m*rl9@
+BDFChar: 5002 13033 12 1 11 -2 8
+*ro]a5X:2LMBI`uOW]c/5X8_m*rl9@
+BDFChar: 5003 13034 12 1 11 -2 8
+*ro]a5X:DRP9?A<O<BW-:I&='*rl9@
+BDFChar: 5004 13035 12 1 11 -2 8
+*ro]a5X:qaJKTLdJfp!p5X8_m*rl9@
+BDFChar: 5005 13036 12 1 11 -2 8
+*ro]a5X:8NOs$G@J=qE85X8_m*rl9@
+BDFChar: 5006 13037 12 1 11 -2 8
+*ro]a6pR@eKHQO&Pot`&5X8_m*rl9@
+BDFChar: 5007 13038 12 1 11 -2 8
+*ro]a5X:qaJKTgmKHPjh5X8_m*rl9@
+BDFChar: 5008 13039 12 1 11 -2 8
+*ro]a5X:>PJKTmoJfpR+6U5%p*rl9@
+BDFChar: 5009 13040 12 1 11 -2 8
+*ro]a6pQDJL`hKrOs$;<5X8_m*rl9@
+BDFChar: 5010 13041 12 1 11 -2 8
+*ro]a5X9lCM'.NqL*2m,5X8_m*rl9@
+BDFChar: 5011 13042 12 1 11 -2 8
+*ro]a5X:n`L`i<4L`h^#5X8_m*rl9@
+BDFChar: 5012 13043 12 1 11 -2 8
+*ro]a83htRO!'i5KHPpj6pP.q*rl9@
+BDFChar: 5013 13044 12 1 11 -2 8
+*ro]a5X:>PJfoXfJfp[.5X8_m*rl9@
+BDFChar: 5014 13045 12 1 11 -2 8
+*ro]a5X:n`JfpX-JfpX-5X8_m*rl9@
+BDFChar: 5015 13046 12 1 11 -2 8
+*ro]a5X:n`J0:I,JKTOe9L*"$*rl9@
+BDFChar: 5016 13047 12 1 11 -2 8
+*ro]a5X:2LMBId!Jfo^h83gRu*rl9@
+BDFChar: 5017 13048 12 1 11 -2 8
+*ro]a5X:2LMBId!MP-.U5X8_m*rl9@
+BDFChar: 5018 13049 12 1 11 -2 8
+*ro]a5X:,JL`hNsMBIj#5X8_m*rl9@
+BDFChar: 5019 13050 12 1 11 -2 8
+*ro]a5X:qaOW]c/OW^8=5X8_m*rl9@
+BDFChar: 5020 13051 12 1 11 -2 8
+*ro]a5X:qaOW]2tJfp!p5X8_m*rl9@
+BDFChar: 5021 13052 12 1 11 -2 8
+*ro]a5X9oDT-0"6T-/_.5X8_m*rl9@
+BDFChar: 5022 13053 12 1 11 -2 8
+*ro]a5X:qaJKT[iKHQm05X8_m*rl9@
+BDFChar: 5023 13054 12 1 11 -2 8
+*ro]a5X:qaJKUR-JKTOe9L*"$*rl9@
+BDFChar: 5024 9398 12 1 11 -2 8
+*ro]a5X9uFMBId!T-07=5X8_m*rl9@
+BDFChar: 5025 9399 12 1 11 -2 8
+*ro]a5X:n`OW^5<OW^5<5X8_m*rl9@
+BDFChar: 5026 9400 12 1 11 -2 8
+*ro]a5X:>POW]`.OW]Z,5X8_m*rl9@
+BDFChar: 5027 9401 12 1 11 -2 8
+*ro]a5X:n`OW]c/OW^5<5X8_m*rl9@
+BDFChar: 5028 9402 12 1 11 -2 8
+*ro]a5X:qaO<C,;O<C/<5X8_m*rl9@
+BDFChar: 5029 9403 12 1 11 -2 8
+*ro]a5X:qaO<C,;O<BW-5X8_m*rl9@
+BDFChar: 5030 9404 12 1 11 -2 8
+*ro]a5X:AQO<B`0OW]]-5X8_m*rl9@
+BDFChar: 5031 9405 12 1 11 -2 8
+*ro]a5X:GSOW^8=OW]c/5X8_m*rl9@
+BDFChar: 5032 9424 12 1 11 -2 8
+*ro]a5X:8NJfp'rOs#c-5X8_m*rl9@
+BDFChar: 5033 9425 12 1 11 -2 8
+*ro]a83htRNZa0$M'.g$5X8_m*rl9@
+BDFChar: 5034 9426 12 1 11 -2 8
+*ro]a5X:>POW]`.OW]Z,5X8_m*rl9@
+BDFChar: 5035 9427 12 1 11 -2 8
+*ro]a69p,FNZaK-Os#c-5X8_m*rl9@
+BDFChar: 5036 9428 12 1 11 -2 8
+*ro]a5X:8NOs$>=O<BQ+5X8_m*rl9@
+BDFChar: 5037 9429 12 1 11 -2 8
+*ro]a69p2HNZ`utKHPpj5X8_m*rl9@
+BDFChar: 5038 9430 12 1 11 -2 8
+*ro]a5X:>POs#o1NZ`or9L*"$*rl9@
+BDFChar: 5039 9431 12 1 11 -2 8
+*ro]a83htRN$+!#MBId!5X8_m*rl9@
+BDFChar: 5040 9432 12 1 11 -2 8
+*ro]a6pQ8FKHPpjKHPpj5X8_m*rl9@
+BDFChar: 5041 9433 12 1 11 -2 8
+*ro]a69p&DJfoXfJfoXf9L*"$*rl9@
+BDFChar: 5042 9434 12 1 11 -2 8
+*ro]a83htRMBIj#MBId!5X8_m*rl9@
+BDFChar: 5043 9435 12 1 11 -2 8
+*ro]a6pQDJKHPpjKHPpj5X8_m*rl9@
+BDFChar: 5044 9436 12 1 11 -2 8
+*ro]a5X:b\Pou>7Pou>75X8_m*rl9@
+BDFChar: 5045 9437 12 1 11 -2 8
+*ro]a5X:8NMBId!MBId!5X8_m*rl9@
+BDFChar: 5046 9438 12 1 11 -2 8
+*ro]a5X:>POW]c/OW]Z,5X8_m*rl9@
+BDFChar: 5047 9439 12 1 11 -2 8
+*ro]a5X:>PM'.WtNZa-#83gRu*rl9@
+BDFChar: 5048 9440 12 1 11 -2 8
+*ro]a5X:>POs#o1NZ`or69nqo*rl9@
+BDFChar: 5049 9441 12 1 11 -2 8
+*ro]a5X:2LN$*p!L`hKr5X8_m*rl9@
+BDFChar: 5050 9442 12 1 11 -2 8
+*ro]a5X:&HL`h?nJfp!p5X8_m*rl9@
+BDFChar: 5051 9443 12 1 11 -2 8
+*ro]a6pQDJNZ`utKHPjh5X8_m*rl9@
+BDFChar: 5052 9444 12 1 11 -2 8
+*ro]a5X:2LMBId!MBIWr5X8_m*rl9@
+BDFChar: 5053 9445 12 1 11 -2 8
+*ro]a5X:2LMBId!KHPpj5X8_m*rl9@
+BDFChar: 5054 9446 12 1 11 -2 8
+*ro]a5X:SWPou>7MBId!5X8_m*rl9@
+BDFChar: 5055 9447 12 1 11 -2 8
+*ro]a5X:2LMBIQpMBId!5X8_m*rl9@
+BDFChar: 5056 9448 12 1 11 -2 8
+*ro]a5X:2LMBId!L*2'j9L*"$*rl9@
+BDFChar: 5057 9449 12 1 11 -2 8
+*ro]a5X:>PJfo^hL`h^#5X8_m*rl9@
+BDFChar: 5058 9406 12 1 11 -2 8
+*ro]a5X9uFKHPpjKHPpj5X8_m*rl9@
+BDFChar: 5059 9407 12 1 11 -2 8
+*ro]a5X9oDJfoXfOs#]+5X8_m*rl9@
+BDFChar: 5060 9408 12 1 11 -2 8
+*ro]a5X:GSOs$8;Os#l05X8_m*rl9@
+BDFChar: 5061 9409 12 1 11 -2 8
+*ro]a5X:,JL`hKrL`ha$5X8_m*rl9@
+BDFChar: 5062 9410 12 1 11 -2 8
+*ro]a5X:GSRimt=Pou235X8_m*rl9@
+BDFChar: 5063 9411 12 1 11 -2 8
+*ro]a5X:GSR37b;P9>u15X8_m*rl9@
+BDFChar: 5064 9412 12 1 11 -2 8
+*ro]a5X:>POW]c/OW]Z,5X8_m*rl9@
+BDFChar: 5065 9413 12 1 11 -2 8
+*ro]a5X:>PM'.g$L`hKr5X8_m*rl9@
+BDFChar: 5066 9414 12 1 11 -2 8
+*ro]a5X:>POW]c/Pou)06U5%p*rl9@
+BDFChar: 5067 9415 12 1 11 -2 8
+*ro]a5X:>PM'.g$MBI`u5X8_m*rl9@
+BDFChar: 5068 9416 12 1 11 -2 8
+*ro]a5X:>PO<BQ+JKTsq5X8_m*rl9@
+BDFChar: 5069 9417 12 1 11 -2 8
+*ro]a5X:qaKHPpjKHPpj5X8_m*rl9@
+BDFChar: 5070 9418 12 1 11 -2 8
+*ro]a5X:GSOW]c/OW]Z,5X8_m*rl9@
+BDFChar: 5071 9419 12 1 11 -2 8
+*ro]a5X:GSOW]N(MBIQp5X8_m*rl9@
+BDFChar: 5072 9420 12 1 11 -2 8
+*ro]a5X:SWPou>7MBId!5X8_m*rl9@
+BDFChar: 5073 9421 12 1 11 -2 8
+*ro]a5X:GSMBIQpMBJ$(5X8_m*rl9@
+BDFChar: 5074 9422 12 1 11 -2 8
+*ro]a5X:GSMBIQpKHPpj5X8_m*rl9@
+BDFChar: 5075 9423 12 1 11 -2 8
+*ro]a5X:qaJfo^hL`i<45X8_m*rl9@
+BDFChar: 5076 894 6 2 3 -2 5
+^q]pM^q`3c
+BDFChar: 5077 900 6 3 4 6 7
+5_&h7
+BDFChar: 5078 901 6 2 4 6 9
++@#q"
+BDFChar: 5079 903 6 2 4 3 5
+5i=m-
+BDFChar: 5080 8355 6 1 5 0 7
+GX+N55k%$(
+BDFChar: 5081 9674 6 1 5 -1 7
++<XKWLepnj+92BA
+BDFChar: 5082 64258 6 1 5 0 8
+0MkU8:f'tb=9&=$
+BDFChar: 5083 9711 12 1 11 -2 8
+*ro]a5X9iBJ09@bJ09@b5X8_m*rl9@
+BDFChar: 5084 127921 12 1 11 -2 8
+%KJ_DJ&$3BlJUa]lJQg#J&":!%KHJ/
+BDFChar: 5085 126980 12 2 11 -2 8
+IfP"LLqpa?Wkc?aLqnh^JAD3#It.M!
+BDFChar: 5086 128174 12 1 11 -2 8
+%KI4DEPTt0MBG/L21T)M6pPY*4+I;2
+BDFChar: 5087 128175 12 1 11 -2 8
+!'g\F/tcsPlJO9[,QK"G/cYpf*WQ0?
+BDFChar: 5088 128187 12 1 11 -2 8
+J&"<75X7S"5X7S"J&#g7eR5&Cs53kW
+BDFChar: 5089 128197 12 1 11 -2 8
+s5<q8s58DMUnE5\UnE5\UnE5\s53kW
+BDFChar: 5090 128198 12 1 11 -2 8
++Fr?Ws58DMUnE5\UnE5\UnE6Gs1eU7
+BDFChar: 5091 128231 12 1 11 0 7
+s5;11]:b9/QQWo5c=$\1
+BDFChar: 5092 128425 12 3 9 -2 8
+rdob$ri5stri5qt
+BDFChar: 5093 128426 12 1 11 -2 8
+s5:ZMs5<e4p#,`*s5<BSnR1lPs*t(L
+BDFChar: 5094 128427 12 1 11 -2 8
+s5:\#hdF6-^gR3#s5:`OdGRm[5MuMA
+BDFChar: 5095 128428 12 1 11 -2 8
+s58FcJAD3Cqr%#&qr%M4qr%A0s53kW
+BDFChar: 5096 128429 12 1 11 -1 7
+s58DM\KIoF\KHDF^S%6ms53kW
+BDFChar: 5097 128435 12 1 11 -2 8
+IfMb75la1N5lcB7+ohTCIitbas*t(L
+BDFChar: 5098 128440 12 1 11 -2 8
+%KJA:6pO/UO!'<&SfhQ/6pNV[%KHJ/
+BDFChar: 5099 128126 12 1 11 -1 8
++Fk%(*rs'KY+Y4@J&":!0n:2C
+BDFChar: 5100 127800 12 1 11 -2 8
+%KIRNJ&(s>lJQZt4+MIhJ&$QL4+I;2
+BDFChar: 5101 128039 12 1 11 -2 8
+%KI4D&HEOG0n=8Z@)1^YZ(N_"4+I;2
+BDFChar: 5102 119558 12 3 10 0 6
+rrE'!rrE'!
+BDFChar: 5103 119559 12 3 10 0 6
+rrE'!rrD3^
+BDFChar: 5104 119560 12 3 10 0 6
+rrE'!rrCdR
+BDFChar: 5105 119561 12 3 10 0 6
+rrE'!k5bM^
+BDFChar: 5106 119562 12 3 10 0 6
+rrE'!k5aZF
+BDFChar: 5107 119563 12 3 10 0 6
+rrE'!k5a6:
+BDFChar: 5108 119564 12 3 10 0 6
+rrE'!gAq6R
+BDFChar: 5109 119565 12 3 10 0 6
+rrE'!gApC:
+BDFChar: 5110 119566 12 3 10 0 6
+rrE'!gAot.
+BDFChar: 5111 119567 12 3 10 0 6
+rrD3^rrE'!
+BDFChar: 5112 119568 12 3 10 0 6
+rrD3^rrD3^
+BDFChar: 5113 119569 12 3 10 0 6
+rrD3^rrCdR
+BDFChar: 5114 119570 12 3 10 0 6
+rrD3^k5bM^
+BDFChar: 5115 119571 12 3 10 0 6
+rrD3^k5aZF
+BDFChar: 5116 119572 12 3 10 0 6
+rrD3^k5a6:
+BDFChar: 5117 119573 12 3 10 0 6
+rrD3^gAq6R
+BDFChar: 5118 119574 12 3 10 0 6
+rrD3^gApC:
+BDFChar: 5119 119575 12 3 10 0 6
+rrD3^gAot.
+BDFChar: 5120 119576 12 3 10 0 6
+rrCdRrrE'!
+BDFChar: 5121 119577 12 3 10 0 6
+rrCdRrrD3^
+BDFChar: 5122 119578 12 3 10 0 6
+rrCdRrrCdR
+BDFChar: 5123 119579 12 3 10 0 6
+rrCdRk5bM^
+BDFChar: 5124 119580 12 3 10 0 6
+rrCdRk5aZF
+BDFChar: 5125 119581 12 3 10 0 6
+rrCdRk5a6:
+BDFChar: 5126 119582 12 3 10 0 6
+rrCdRgAq6R
+BDFChar: 5127 119583 12 3 10 0 6
+rrCdRgApC:
+BDFChar: 5128 119638 12 3 10 0 6
+gAot.gAot.
+BDFChar: 5129 119637 12 3 10 0 6
+gAot.gApC:
+BDFChar: 5130 119636 12 3 10 0 6
+gAot.gAq6R
+BDFChar: 5131 119635 12 3 10 0 6
+gAot.k5a6:
+BDFChar: 5132 119634 12 3 10 0 6
+gAot.k5aZF
+BDFChar: 5133 119633 12 3 10 0 6
+gAot.k5bM^
+BDFChar: 5134 119632 12 3 10 0 6
+gAot.rrCdR
+BDFChar: 5135 119584 12 3 10 0 6
+rrCdRgAot.
+BDFChar: 5136 119585 12 3 10 0 6
+k5bM^rrE'!
+BDFChar: 5137 119586 12 3 10 0 6
+k5bM^rrD3^
+BDFChar: 5138 119587 12 3 10 0 6
+k5bM^rrCdR
+BDFChar: 5139 119588 12 3 10 0 6
+k5bM^k5bM^
+BDFChar: 5140 119589 12 3 10 0 6
+k5bM^k5aZF
+BDFChar: 5141 119590 12 3 10 0 6
+k5bM^k5a6:
+BDFChar: 5142 119591 12 3 10 0 6
+k5bM^gAq6R
+BDFChar: 5143 119592 12 3 10 0 6
+k5bM^gApC:
+BDFChar: 5144 119593 12 3 10 0 6
+k5bM^gAot.
+BDFChar: 5145 119594 12 3 10 0 6
+k5aZFrrE'!
+BDFChar: 5146 119595 12 3 10 0 6
+k5aZFrrD3^
+BDFChar: 5147 119596 12 3 10 0 6
+k5aZFrrCdR
+BDFChar: 5148 119597 12 3 10 0 6
+k5aZFk5bM^
+BDFChar: 5149 119598 12 3 10 0 6
+k5aZFk5aZF
+BDFChar: 5150 119599 12 3 10 0 6
+k5aZFk5a6:
+BDFChar: 5151 119600 12 3 10 0 6
+k5aZFgAq6R
+BDFChar: 5152 119601 12 3 10 0 6
+k5aZFgApC:
+BDFChar: 5153 119602 12 3 10 0 6
+k5aZFgAot.
+BDFChar: 5154 119603 12 3 10 0 6
+k5a6:rrE'!
+BDFChar: 5155 119604 12 3 10 0 6
+k5a6:rrD3^
+BDFChar: 5156 119605 12 3 10 0 6
+k5a6:rrCdR
+BDFChar: 5157 119606 12 3 10 0 6
+k5a6:k5bM^
+BDFChar: 5158 119607 12 3 10 0 6
+k5a6:k5aZF
+BDFChar: 5159 119608 12 3 10 0 6
+k5a6:k5a6:
+BDFChar: 5160 119609 12 3 10 0 6
+k5a6:gAq6R
+BDFChar: 5161 119610 12 3 10 0 6
+k5a6:gApC:
+BDFChar: 5162 119611 12 3 10 0 6
+k5a6:gAot.
+BDFChar: 5163 119612 12 3 10 0 6
+gAq6RrrE'!
+BDFChar: 5164 119613 12 3 10 0 6
+gAq6RrrD3^
+BDFChar: 5165 119614 12 3 10 0 6
+gAq6RrrCdR
+BDFChar: 5166 119615 12 3 10 0 6
+gAq6Rk5bM^
+BDFChar: 5167 119616 12 3 10 0 6
+gAq6Rk5aZF
+BDFChar: 5168 119617 12 3 10 0 6
+gAq6Rk5a6:
+BDFChar: 5169 119618 12 3 10 0 6
+gAq6RgAq6R
+BDFChar: 5170 119619 12 3 10 0 6
+gAq6RgApC:
+BDFChar: 5171 119620 12 3 10 0 6
+gAq6RgAot.
+BDFChar: 5172 119621 12 3 10 0 6
+gApC:rrE'!
+BDFChar: 5173 119622 12 3 10 0 6
+gApC:rrD3^
+BDFChar: 5174 119623 12 3 10 0 6
+gApC:rrCdR
+BDFChar: 5175 119624 12 3 10 0 6
+gApC:k5bM^
+BDFChar: 5176 119625 12 3 10 0 6
+gApC:k5aZF
+BDFChar: 5177 119626 12 3 10 0 6
+gApC:k5a6:
+BDFChar: 5178 119627 12 3 10 0 6
+gApC:gAq6R
+BDFChar: 5179 119628 12 3 10 0 6
+gApC:gApC:
+BDFChar: 5180 119629 12 3 10 0 6
+gApC:gAot.
+BDFChar: 5181 119630 12 3 10 0 6
+gAot.rrE'!
+BDFChar: 5182 119631 12 3 10 0 6
+gAot.rrD3^
+BDFChar: 5183 9332 12 1 11 -2 8
++FljF9L+gbKHPpjKHPpj?U-kA+FjFl
+BDFChar: 5184 9333 12 1 11 -2 8
++Fm3P;*][TJfo^hL`hd%?U-kA+FjFl
+BDFChar: 5185 9334 12 1 11 -2 8
++Fm3P;*][TL*2$iJKU't:-_'0+FjFl
+BDFChar: 5186 9335 12 1 11 -2 8
++FldD7R2hROs$JA^EA+N69me$+FjFl
+BDFChar: 5187 9336 12 1 11 -2 8
++Fmfa:dC*bSfiS,JKU't:-_'0+FjFl
+BDFChar: 5188 9337 12 1 11 -2 8
++FlpH83i7ZSfj.<OW]c/:-_'0+FjFl
+BDFChar: 5189 9338 12 1 11 -2 8
++Fmfa5sU#EJfo^hKHQ'n83fF*+FjFl
+BDFChar: 5190 9339 12 1 11 -2 8
++Fm3P;*^6dNZaH,OW]c/:-_'0+FjFl
+BDFChar: 5191 9340 12 1 11 -2 8
++Fm3P;*^6dOW]]-JKTOe9L(j.+FjFl
+BDFChar: 5192 9341 12 1 11 -2 8
++Fm'L9gG6lN?F3'N?F3'?9gb@+FjFl
+BDFChar: 5193 9342 12 1 11 -2 8
++Fm'L8jJsjMBId!MBId!?U-kA+FjFl
+BDFChar: 5194 9343 12 1 11 -2 8
++Fm'L9gG*hM'.ZuN$+'%?U-kA+FjFl
+BDFChar: 5195 9344 12 1 11 -2 8
++Fm'L9gG*hMBI`uM'.d#?9gb@+FjFl
+BDFChar: 5196 9345 12 1 11 -2 8
++Fm$K90eshN?F3'O._=P>sLY?+FjFl
+BDFChar: 5197 9346 12 1 11 -2 8
++Fm6Q9L,*jNZa0$M'.d#?9gb@+FjFl
+BDFChar: 5198 9347 12 1 11 -2 8
++Fm'L9L,*jNZa<(N?F3'?9gb@+FjFl
+BDFChar: 5199 9348 12 1 11 -2 8
++Fm6Q8O/[dM'.ZuMBId!?9gb@+FjFl
+BDFChar: 5200 9349 12 1 11 -2 8
++Fm'L9gG6lMBIm$N?F3'?9gb@+FjFl
+BDFChar: 5201 9350 12 1 11 -2 8
++Fm'L9gG6lN?F-%M'.Wt?9gb@+FjFl
+BDFChar: 5202 9351 12 1 11 -2 8
++Fm'L<Bu6\N?F3'Pou>7?9gb@+FjFl
+BDFChar: 5203 9372 12 1 11 -2 8
++Fl^B5X:AQOW]c/OW]i19gCs/+FjFl
+BDFChar: 5204 9373 12 1 11 -2 8
++Fm9R:dC*bSfj.<OW]c/;*\GQ+FjFl
+BDFChar: 5205 9374 12 1 11 -2 8
++Fl^B5X:>POW]`.O<BZ.:-_'0+FjFl
+BDFChar: 5206 9375 12 1 11 -2 8
++FlaC5sTuDO!'Q-OW]c/;*[oB+FjFl
+BDFChar: 5207 9376 12 1 11 -2 8
++Fl^B5X:>POW^8=O<BZ.:-_'0+FjFl
+BDFChar: 5208 9377 12 1 11 -2 8
++FlsI83htRSfih3L`hKr83f^2+FjFl
+BDFChar: 5209 9378 12 1 11 -2 8
++Fl^B:I($bOW]c/OW]]-5sR_$/q<p%
+BDFChar: 5210 9379 12 1 11 -2 8
++Fm9R:dC*bSfj.<OW]c/;*[uD+FjFl
+BDFChar: 5211 9380 12 1 11 -2 8
++FljF5X:8NKHPpjKHPpj6U3n%+FjFl
+BDFChar: 5212 9381 12 1 11 -2 8
++FldD5X:&HJfoXfJfoXf69n..,_,jp
+BDFChar: 5213 9382 12 1 11 -2 8
++Fm9R:dC*bOW]f0PTZJ=;F")E+FjFl
+BDFChar: 5214 9383 12 1 11 -2 8
++Fm-N6pQDJKHPpjKHPpj6pO4,+FjFl
+BDFChar: 5215 9384 12 1 11 -2 8
++Fl^B5X:b\Pou>7Pou>7<Brf7+FjFl
+BDFChar: 5216 9385 12 1 11 -2 8
++Fl^B5X:n`OW]c/OW]c/;*[B3+FjFl
+BDFChar: 5217 9386 12 1 11 -2 8
++Fl^B5X:>POW]c/OW]c/:-_'0+FjFl
+BDFChar: 5218 9387 12 1 11 -2 8
++Fl^B?9jVqOW]c/OW^5<:d@iB0Rs-'
+BDFChar: 5219 9388 12 1 11 -2 8
++Fl^B:I($bOW]c/OW]]-5sR_$+b0Om
+BDFChar: 5220 9389 12 1 11 -2 8
++Fl^B5X:n`OW]`.O<BW-:d@92+FjFl
+BDFChar: 5221 9390 12 1 11 -2 8
++Fl^B5X:AQO<BQ+JKTLd?9gb@+FjFl
+BDFChar: 5222 9391 12 1 11 -2 8
++Fm!J83iahL`hKrL`hKr7mK=)+FjFl
+BDFChar: 5223 9392 12 1 11 -2 8
++Fl^B5X:GSOW]c/OW]c/:I%01+FjFl
+BDFChar: 5224 9393 12 1 11 -2 8
++Fl^B5X:GSOW]N(MBIQp6pO"&+FjFl
+BDFChar: 5225 9394 12 1 11 -2 8
++Fl^B5X:GSOW]o3Potr,8jGX,+FjFl
+BDFChar: 5226 9395 12 1 11 -2 8
++Fl^B5X:GSMBIQpKHQ-p;*[B3+FjFl
+BDFChar: 5227 9396 12 1 11 -2 8
++Fl^B;*^6dOW]c/OW]]-5sR_$/q<p%
+BDFChar: 5228 9397 12 1 11 -2 8
++Fl^B5X:qaJfo^hL`hd%?U-kA+FjFl
+BDFChar: 5229 9352 12 2 9 0 7
++CLib+<Vp+
+BDFChar: 5230 9353 12 2 9 0 7
+E/4c2+@(SV
+BDFChar: 5231 9354 12 2 9 0 7
+E/4cR#RH?0
+BDFChar: 5232 9355 12 2 9 0 7
+#T+s\M#7Vg
+BDFChar: 5233 9356 12 2 9 0 7
+pjdna#RH?0
+BDFChar: 5234 9357 12 2 9 0 7
+0L10XLkpt1
+BDFChar: 5235 9358 12 2 9 0 7
+p]qEB+<X$=
+BDFChar: 5236 9359 12 2 9 0 7
+E/9<hLkpt1
+BDFChar: 5237 9360 12 2 9 0 7
+E/9=+GR+sm
+BDFChar: 5238 9361 12 1 10 0 7
+6i]gZaoG$68cVH`9#0N'
+BDFChar: 5239 9362 12 1 10 0 7
+6i]UTbQ($26i]UT7)86+
+BDFChar: 5240 9363 12 1 10 0 7
+6i]gZ_>ln&6i]UT8AOZ/
+BDFChar: 5241 9364 12 1 10 0 7
+6i]gZ_>lt(63'=P9#0N'
+BDFChar: 5242 9366 12 1 10 0 7
+:&mfba8em663'=P9#0N'
+BDFChar: 5243 9365 12 1 10 0 7
+6i]m\bQ(TB;ug5)7)7m!
+BDFChar: 5244 9367 12 1 10 0 7
+6i]aXa8em68cVH`9#0N'
+BDFChar: 5245 9368 12 1 10 0 7
+:&mT\_>ln&6i]UT7)7m!
+BDFChar: 5246 9369 12 1 10 0 7
+6i]gZaoFg08cVH`9#0N'
+BDFChar: 5247 9370 12 1 10 0 7
+6i]gZaoG$67K>aT6GVZt
+BDFChar: 5248 9371 12 1 10 0 7
+6ia4e.KCpu8cVH`MSS;g
+BDFChar: 5249 8967 6 2 4 -2 8
+J3Y5BJ3Y5BJ3Y4W
+BDFChar: 5250 9086 6 1 5 0 5
+E/9>F:tPaJ
+BDFChar: 5251 8478 6 1 5 0 7
+n;)niTW!sN
+BDFChar: 5252 8448 6 0 5 0 8
+A>lGG&1fM39E5%m
+BDFChar: 5253 8449 6 0 5 0 8
+A>lGG&1fe7=9&=$
+BDFChar: 5254 8453 6 1 5 0 8
+8<Ap@+AcaMO8o7\
+BDFChar: 5255 8454 6 1 5 0 8
+8<Ap@+@'V=QiI*d
+BDFChar: 5256 8750 6 1 5 -2 8
+(apMGW2QY6+J?LM
+BDFChar: 5257 8751 6 0 6 -2 8
+(+L_[WiE(H.&bJm
+BDFChar: 5258 8752 6 -1 7 -2 8
+'n@ca.KFquWdq+"WdoR!.KHIKe,TIK
+BDFChar: 5259 8481 12 1 11 0 7
+p])E:+94$E."Ek!."Er.
+BDFChar: 5260 8786 6 1 5 0 6
+J,o?Ep](R"
+BDFChar: 5261 8784 6 1 5 2 6
++9;0:p](9o
+BDFChar: 5262 8785 6 1 5 0 6
++9;0:p])E:
+BDFChar: 5263 8787 6 1 5 0 6
+#QXW"p],gE
+BDFChar: 5264 8895 6 1 5 1 5
+#T+s\p](9o
+BDFChar: 5265 8491 6 1 5 0 9
++Aa2":f)uCLkl$2
+BDFChar: 5266 8810 6 1 6 0 6
+'IZeN:ad"X
+BDFChar: 5267 8811 6 1 6 0 6
+TMR$N-r?Q:
+BDFChar: 5268 8803 6 1 5 0 6
+p]1'hp]1'h
+BDFChar: 5269 8806 6 1 5 -1 7
+(gql%(]a=2p](9o
+BDFChar: 5270 8807 6 1 5 -1 7
+^b?$J^]=-0p](9o
+BDFChar: 5271 65504 12 4 8 -1 6
++E49PTVufP
+BDFChar: 5272 65505 12 4 8 0 7
+0L.nm5X7TE
+BDFChar: 5273 65506 12 3 9 0 3
+rW3-&
+BDFChar: 5274 65507 12 0 11 9 9
+s6p!g
+BDFChar: 5275 65508 12 6 6 -2 8
+J:N0#!!!"LJ:N.M
+BDFChar: 5276 65509 12 4 8 0 8
+Lkpj`+S[)S+92BA
+BDFChar: 5277 65510 12 3 9 0 7
+6pt#R<;n9o
+BDFChar: 5278 8361 6 0 6 0 7
+6pt#R<;n9o
+BDFChar: 5279 12307 12 2 10 0 8
+s+(-"s*t(Lzs+(-"s*t(L
+BDFChar: 5280 12317 12 6 10 6 9
+f[r_c
+BDFChar: 5281 12318 12 2 6 6 9
+f[u:I
+BDFChar: 5282 12319 12 2 6 -2 1
+OHA,I
+BDFChar: 5283 12342 12 1 11 -2 8
+*ro]a5X<)WJ0;V"KHPpj6pP.q*rl9@
+BDFChar: 5284 13059 12 2 10 -2 8
+n,Q8bB7N5IJ,fQL:]O;l=9)G'O8o7\
+BDFChar: 5285 13069 12 2 10 -2 8
+5QLP/<.Iqu[t"GYO8t@BQ[fVI?iU0,
+BDFChar: 5286 13076 12 2 9 -1 8
++S[)S+92oY#nI"9
+BDFChar: 5287 13080 12 2 10 -2 9
+&-,4NDuc5T&:e6j!!",A+94Y,:]T\Z
+BDFChar: 5288 13090 12 2 10 -2 8
+5QLM.:k1h3FoVdJDu_!\p])E:5QCca
+BDFChar: 5289 13091 12 2 10 -2 8
+5QLM.:k1h3FoVLB5QF%L?iX"'5QCca
+BDFChar: 5290 13094 12 3 9 -2 8
+TRahNJ,g8t()A.q
+BDFChar: 5291 13095 12 3 9 -2 8
+J:PG.J,fQf!X'>?
+BDFChar: 5292 13099 12 0 12 -2 8
+.KCjs.GuTS6i[2e5Tocn:p<56Fs$bb
+BDFChar: 5293 13110 12 0 11 -2 8
+!.Z3M;'6,e!5JR75bN(hf!$j4@3>OM
+BDFChar: 5294 13115 12 2 10 -2 8
+&-+rqVgo<Yze,U$[ci>0g^]4?7
+BDFChar: 5295 13129 12 2 10 -2 8
+?iU`<?iU`<^]6%g"FpW*"FpK&!rr<$
+BDFChar: 5296 13130 12 0 11 -2 9
+(]X^^)'B)*0H^e>!!#uk:nUjn:p>d!
+BDFChar: 5297 13133 12 2 10 -2 8
+&-,N,2h3"Nci=%GK`Hf,`IOe8M#[MU
+BDFChar: 5298 13137 12 2 10 -2 8
+O8tRHQ@KNsB)ho3K`Hf,`IOe8M#[MU
+BDFChar: 5299 13143 12 2 10 -2 8
+n,SaS(4ZsHB)ho35QF%L?iX"'5QCca
+BDFChar: 5300 12351 6 1 5 0 8
+pkXaYW7Zo^p](9o
+BDFChar: 5301 8525 6 0 5 0 8
+7&]=R&1fe7=9&=$
+BDFChar: 5302 8507 12 1 11 0 7
+n,Rt=KV7V'MEm1eMP,j"
+BDFChar: 5303 65514 6 1 5 0 6
++E48%+<Vd,
+BDFChar: 5304 65515 6 1 5 1 5
++;";Z+92BA
+BDFChar: 5305 65512 6 3 3 -3 9
+J:N0#J:N0#J:N0#J,fQL
+BDFChar: 5306 65513 6 1 5 1 5
++@,]e+92BA
+BDFChar: 5307 65516 6 1 5 0 6
++<VdLW,NjZ
+BDFChar: 5308 65517 6 0 5 0 6
+r;?Kjr;?Hm
+BDFChar: 5309 65518 6 0 5 1 6
+0M$kM82(#D
+BDFChar: 5310 8765 6 1 5 2 4
+OJk\M
+BDFChar: 5311 13198 12 1 11 -3 5
+dGV#IWZ\;aWZ\;!!$D7a!Pe[8
+BDFChar: 5312 13199 12 1 11 -3 8
+J,k*"J,kGaOs$JAiZOC,M;S@V!$D<X
+BDFChar: 5313 13212 12 1 11 0 5
+dm0q+Wh?AbWh?Ab
+BDFChar: 5314 13213 12 1 11 0 5
+F$PVUJtR^gMP,!_
+BDFChar: 5315 13214 12 1 11 0 8
+J,k*"J,kKmP+\PBih2I-MP'qL
+BDFChar: 5316 13215 12 1 11 0 9
+!5JRW!'gPB!!(J5Wh?AbWh?Ab
+BDFChar: 5317 13217 12 2 11 0 9
+!It/8!.Y*cli<1KOoUXFOoUXF
+BDFChar: 5318 13252 12 1 11 0 5
+EPRGSJcLB&MBHoS
+BDFChar: 5319 20189 12 2 10 0 8
+#QPP=+ooH04obig#QP,1s*t(L
+BDFChar: 5320 13055 12 1 11 -1 8
++TPR$MP,!_#GCpd:S:LV>2V^I
+BDFChar: 5321 13179 12 1 11 0 8
+pn/a[YMcL4-_UE',sWtG.%gP?
+BDFChar: 5322 13180 12 1 11 -1 8
+3<8L*Wh?qrkFfDZYFt?W3oC&>
+BDFChar: 5323 13181 12 1 10 0 8
+-bpl*q#D]@-,<L\<</!YO2(_q
+BDFChar: 5324 13182 12 1 10 0 8
+4Fl^I\NoPtWW9TFlTcsc?,-F?
+BDFChar: 5325 8978 12 1 11 7 9
+*ro]aJ04gl
+BDFChar: 5326 12849 12 1 11 -2 8
+0n<7hGJK=`Z_4iOe"Dnt;*[B3+FjFl
+BDFChar: 5327 12850 12 1 11 -2 8
+."Hf_83if?OJ'@]d%I#(:r#=]+FjFl
+BDFChar: 5328 12857 12 1 11 -2 8
+.Y(/W;F$SAZ65;QOs#l0;8>F^+FjFl
+BDFChar: 5329 13261 12 1 11 0 7
+U4Atg_Z7RS_Z6E]U4B8:
+BDFChar: 5330 10186 6 2 4 -3 9
+5X7S"5X=6m5X7S"5QCca
+BDFChar: 5331 9702 6 1 5 1 5
+E/9=+Du]k<
+BDFChar: 5332 128528 12 1 11 -2 8
+*rmF65X:GSOW]/sJ0:I,5X6HB*rl9@
+BDFChar: 5333 128760 12 1 11 1 6
+%KI(@J&'TBJ&!dh
+BDFChar: 5334 8857 6 1 5 1 5
+E/:HKDu]k<
+BDFChar: 5335 8609 6 1 5 0 7
++<[V%+K06%
+BDFChar: 5336 10710 6 1 5 0 6
+pkV`h:l+lH
+BDFChar: 5337 9083 6 1 6 0 7
+#RCuh&<L9B
+BDFChar: 5338 9101 6 1 5 0 6
+E)9A-:f,dE
+BDFChar: 5339 9723 6 1 5 1 5
+pkX`^p](9o
+BDFChar: 5340 9724 6 1 5 1 5
+q"XXZp](9o
+BDFChar: 5341 9150 6 3 5 0 8
+i.-?.J:N0#J,fQL
+BDFChar: 5342 9151 6 3 5 0 8
+J:N0#J:N0#huE`W
+BDFChar: 5343 9161 6 1 5 0 8
+p`L\%+<VdL+92BA
+BDFChar: 5344 9162 6 1 5 0 8
++<VdL+<VdLp](9o
+BDFChar: 5345 9163 6 1 3 0 8
+i#j-b+<VdL+92BA
+BDFChar: 5346 9164 6 1 3 0 8
++<VdL+<VdLhuE`W
+BDFChar: 5347 127344 6 0 6 -1 7
+rl2O\K"AP)rVuou
+BDFChar: 5348 127345 6 0 6 -1 7
+reA"qL:XsNrVuou
+BDFChar: 5349 127346 6 0 6 -1 7
+rl2O`^:q1urVuou
+BDFChar: 5350 127347 6 0 6 -1 7
+rf4Fu]"5>1rVuou
+BDFChar: 5351 127348 6 0 6 -1 7
+rdqkuL;(BRrVuou
+BDFChar: 5352 127349 6 0 6 -1 7
+rdqkuL;(C9rVuou
+BDFChar: 5353 127350 6 0 6 -1 7
+rl2O`ZF[WerVuou
+BDFChar: 5354 127351 6 0 6 -1 7
+rjo\PK"AP)rVuou
+BDFChar: 5355 127352 6 0 6 -1 7
+rl4BomdBM_rVuou
+BDFChar: 5356 127353 6 0 6 -1 7
+rpop^qRX8XrVuou
+BDFChar: 5357 127354 6 0 6 -1 7
+rjoP@NjcC-rVuou
+BDFChar: 5358 127355 6 0 6 -1 7
+rk?+\^:q=5rVuou
+BDFChar: 5359 127356 6 0 6 -1 7
+rjn8mWk,dQrVuou
+BDFChar: 5360 127357 6 0 6 -1 7
+rjnPeWj8qArVuou
+BDFChar: 5361 127358 6 0 6 -1 7
+rl2O\]"5JmrVuou
+BDFChar: 5362 127359 6 0 6 -1 7
+reA"qL;(C9rVuou
+BDFChar: 5363 127360 6 0 6 -1 7
+rl2O\]"5>mrVuou
+BDFChar: 5364 127361 6 0 6 -1 7
+reA"qL:4\)rVuou
+BDFChar: 5365 127362 6 0 6 -1 7
+rl2O``qm9drVuou
+BDFChar: 5366 127363 6 0 6 -1 7
+rdsS+mdBN2rVuou
+BDFChar: 5367 127364 6 0 6 -1 7
+rjo\P]"5JmrVuou
+BDFChar: 5368 127365 6 0 6 -1 7
+rjo\lf%09WrVuou
+BDFChar: 5369 127366 6 0 6 -1 7
+rjo\@WlEW@rVuou
+BDFChar: 5370 127367 6 0 6 -1 7
+rjo\lmaet\rVuou
+BDFChar: 5371 127368 6 0 6 -1 7
+rjo\lmdBN2rVuou
+BDFChar: 5372 127369 6 0 6 -1 7
+rdt"?mbY[0rVuou
+BDFChar: 5373 127312 12 2 10 -1 7
+4og'4pOMR[l[Zg%h10tT4obQ_
+BDFChar: 5374 127313 12 2 10 -1 7
+4og'4_gpQn_gpQn_gm4:4obQ_
+BDFChar: 5375 127314 12 2 10 -1 7
+4og'4j+,s9hgjO5j+)UZ4obQ_
+BDFChar: 5376 127315 12 2 10 -1 7
+4og'4_gpQnh14=3_gm4:4obQ_
+BDFChar: 5377 127316 12 2 10 -1 7
+4og'4_1:En_gpWp_17"84obQ_
+BDFChar: 5378 127317 12 2 10 -1 7
+4og'4_1:En_gpWphgg1V4obQ_
+BDFChar: 5379 127318 12 2 10 -1 7
+4og'4iIKg9fmqn/iIHCX4obQ_
+BDFChar: 5380 127319 12 2 10 -1 7
+4og'4h14=3_1:?lh10tT4obQ_
+BDFChar: 5381 127320 12 2 10 -1 7
+4og'4pON!gpON!gpOI_n4obQ_
+BDFChar: 5382 127321 12 2 10 -1 7
+4og'4qgeQoqgdFOkCA$^4obQ_
+BDFChar: 5383 127322 12 2 10 -1 7
+4og'4h1471a+2oph10tT4obQ_
+BDFChar: 5384 127323 12 2 10 -1 7
+4og'4msskWmsskWiIHCX4obQ_
+BDFChar: 5385 127324 12 2 10 -1 7
+4og'4h13UteUZ2#h10tT4obQ_
+BDFChar: 5386 127325 12 2 10 -1 7
+4og'4h13b#eUZ>'h10tT4obQ_
+BDFChar: 5387 127326 12 2 10 -1 7
+4og'4j+,s9h14=3j+)UZ4obQ_
+BDFChar: 5388 127327 12 2 10 -1 7
+4og'4j+-NIj+-TKmsolf4obQ_
+BDFChar: 5389 127328 12 2 10 -1 7
+4og'4j+,s9h14%+j+)IV4obQ_
+BDFChar: 5390 127329 12 2 10 -1 7
+4og'4j+-NIj+-HGm=9Zd4obQ_
+BDFChar: 5391 127330 12 2 10 -1 7
+4og'4j+-$;j+.)Yj+)UZ4obQ_
+BDFChar: 5392 127331 12 2 10 -1 7
+4og'4_1;91pON!gpOI_n4obQ_
+BDFChar: 5393 127332 12 2 10 -1 7
+4og'4h14=3h14=3j+)UZ4obQ_
+BDFChar: 5394 127333 12 2 10 -1 7
+4og'4h14=3l[\;OpOI_n4obQ_
+BDFChar: 5395 127334 12 2 10 -1 7
+4og'4eUZ2#eUZt9l[XHb4obQ_
+BDFChar: 5396 127335 12 2 10 -1 7
+4og'4h14gApOMR[h10tT4obQ_
+BDFChar: 5397 127336 12 2 10 -1 7
+4og'4h14gApON!gpOI_n4obQ_
+BDFChar: 5398 127337 12 2 10 -1 7
+4og'4_1;E5pOM^__17"84obQ_
+BDFChar: 5399 127243 12 1 11 -2 8
+*ro]a5X9uFMBId!MBIQp5X8_m*rl9@
+BDFChar: 5400 127244 12 2 10 -1 7
+4og'4pOMR[l[\;OpOI_n4obQ_
+BDFChar: 5401 127245 12 1 11 -2 8
+*ro]a5X:>PP9?,5R37M45X8_m*rl9@
+BDFChar: 5402 127248 12 1 11 -2 8
++Fm3P;*^6dOW^8=OW]c/;*[B3+FjFl
+BDFChar: 5403 127249 12 1 11 -2 8
++Fmc`;*^6dSfj.<OW]c/?9gb@+FjFl
+BDFChar: 5404 127250 12 1 11 -2 8
++Fm3P;*^3cO<BW-O<BZ.:-_'0+FjFl
+BDFChar: 5405 127251 12 1 11 -2 8
++Fm]^;F$?eOW]c/OW]f0>X1P>+FjFl
+BDFChar: 5406 127252 12 1 11 -2 8
++Fmfa:dC*bSfj+;O<BW-?U-kA+FjFl
+BDFChar: 5407 127253 12 1 11 -2 8
++Fmfa:dC*bSfj+;O<BW-:d@92+FjFl
+BDFChar: 5408 127254 12 1 11 -2 8
++Fm3P;*^3cO<B`0OW]c/:-_'0+FjFl
+BDFChar: 5409 127255 12 1 11 -2 8
++Fm<S;*^6dT-07=OW]c/;*[B3+FjFl
+BDFChar: 5410 127256 12 1 11 -2 8
++Fm3P6pQDJKHPpjKHPpj:-_'0+FjFl
+BDFChar: 5411 127257 12 1 11 -2 8
++FlsI5sTuDJKTLdOW]c/:-_'0+FjFl
+BDFChar: 5412 127258 12 1 11 -2 8
++Fm<S;F$HhS03t;Os#l0;*[B3+FjFl
+BDFChar: 5413 127259 12 1 11 -2 8
++Fm9R:dC*bO<BW-O<BW-?U-kA+FjFl
+BDFChar: 5414 127260 12 1 11 -2 8
++Fm<S><nGrPou23OW]c/;*[B3+FjFl
+BDFChar: 5415 127261 12 1 11 -2 8
++Fm<S=[8AtPou>7P9?&3;*[B3+FjFl
+BDFChar: 5416 127262 12 1 11 -2 8
++Fm3P;*^6dOW]c/OW]c/:-_'0+FjFl
+BDFChar: 5417 127263 12 1 11 -2 8
++Fmc`;*^6dOW^5<O<BW-:d@92+FjFl
+BDFChar: 5418 127264 12 1 11 -2 8
++Fm3P;*^6dOW]c/OW]f09gD!0+FjFl
+BDFChar: 5419 127265 12 1 11 -2 8
++Fmc`;*^6dSfj1=OW]c/;*[B3+FjFl
+BDFChar: 5420 127266 12 1 11 -2 8
++Fm3P;*^3cNZ`lqJKU't:-_'0+FjFl
+BDFChar: 5421 127267 12 1 11 -2 8
++Fmfa6pQDJKHPpjKHPpj6pO"&+FjFl
+BDFChar: 5422 127268 12 1 11 -2 8
++Fm<S;*^6dOW]c/OW]c/:-_'0+FjFl
+BDFChar: 5423 127269 12 1 11 -2 8
++Fm<S;*^6dMBId!MBIQp6pO"&+FjFl
+BDFChar: 5424 127270 12 1 11 -2 8
++Fm<S;*^6dPou>7NZa3%8jGX,+FjFl
+BDFChar: 5425 127271 12 1 11 -2 8
++Fm<S;*^!]KHPpjMBJ$(;*[B3+FjFl
+BDFChar: 5426 127272 12 1 11 -2 8
++Fm<S;*^6dMBIQpKHPpj6pO"&+FjFl
+BDFChar: 5427 127273 12 1 11 -2 8
++Fmfa69p2HKHQ'nL`hd%?U-kA+FjFl
+BDFChar: 5428 13003 12 1 11 -1 7
+8`3Sk`Sa0-8`3/_;'>f[!al!.
+BDFChar: 5429 12992 12 2 10 -1 7
+7t=!Xa+-R.7t=!X7"FKO$%N!U
+BDFChar: 5430 12993 12 1 10 -1 7
+A&+6m'>P5G,JZW2JjArn"Mb!;
+BDFChar: 5431 12994 12 1 10 -1 7
+A&+6m'>S'B'>P5GP!EPC"Mb!;
+BDFChar: 5432 12995 12 1 10 -1 7
+'>Q@g;nu9rPJI#[&jR-r"Mb!;
+BDFChar: 5433 12996 12 1 10 -1 7
+o>#rCK>?J3'>P5GP!EPC"Mb!;
+BDFChar: 5434 12997 12 1 10 -1 7
+,JZW2K>?J3PJE>HP!EPC"Mb!;
+BDFChar: 5435 12998 12 1 10 -1 7
+o=tu('>PeW,JZW269mq("Mb!;
+BDFChar: 5436 12999 12 1 10 -1 7
+A&+6mPJCWmPJE>HP!EPC"Mb!;
+BDFChar: 5437 13000 12 1 10 -1 7
+A&+6mPJE>HF2/DR,!\O]"Mb!;
+BDFChar: 5438 13001 12 1 11 -1 7
+8`3Ske_jFM<T$k"<?UNK!al!.
+BDFChar: 5439 13002 12 1 11 -1 7
+8`3/_g#,FE8`3/_8KdsS!al!.
+BDFChar: 5440 13145 12 2 11 -1 8
+!WYT<63,&V7"@[U7t<i)kC<q*
+BDFChar: 5441 13146 12 1 11 -1 8
+!<?QDOT6'1&jRX+6bn3Po=tO&
+BDFChar: 5442 13144 12 1 11 -1 8
+!<?QDOT:T\P!G0qPJE7[A&&8@
+BDFChar: 5443 13147 12 1 11 -1 8
+!<?QDOT6'1@R(Pk'>T\0A&&8@
+BDFChar: 5444 13148 12 1 11 -1 8
+!<<_I0`Y.f;F$C1qnNaC'>OdE
+BDFChar: 5445 13149 12 1 11 -1 8
+!<DZ*JH1><i]n,A'>T\0A&&8@
+BDFChar: 5446 13150 12 1 11 -1 8
+!<=:Y5lcPQi]rYlPJE7[A&&8@
+BDFChar: 5447 13151 12 1 11 -1 8
+!<DZ*&HEK[,![>;6bkqe6biku
+BDFChar: 5448 13152 12 1 11 -1 8
+!<?QDOT:T\@R-)APJE7[A&&8@
+BDFChar: 5449 13153 12 1 11 -1 8
+!<?QDOT:T\P!F%Q'>P^j6biku
+BDFChar: 5450 13154 12 1 11 -1 8
+!.[VU<.NN7<BsPL<PVQ6ks,<C
+BDFChar: 5451 13155 12 1 11 -1 8
+!.[VU8:]C/8O,j48\djsrBLFW
+BDFChar: 5452 13156 12 1 11 -1 8
+!.[VU<.Ms'76jF08\e.&rBLFW
+BDFChar: 5453 13157 12 1 11 -1 8
+!.[VU<.Ms'8O,^07DMk&ks,<C
+BDFChar: 5454 13158 12 1 11 -1 8
+!.[JQ9RtC'<BsPL?bf&0jZim?
+BDFChar: 5455 13159 12 1 11 -1 8
+!.\=i:k6s/=[5D@7DMk&ks,<C
+BDFChar: 5456 13160 12 1 11 -1 8
+!.[VU:k6s/=[5tP<PVQ6ks,<C
+BDFChar: 5457 13161 12 1 11 -1 8
+!.\=i7"E7l76jF08\djsks,<C
+BDFChar: 5458 13162 12 1 11 -1 8
+!.[VU<.NN78O-9@<PVQ6ks,<C
+BDFChar: 5459 13163 12 1 11 -1 8
+!.[VU<.NN7<Bs8D7DM:kks,<C
+BDFChar: 5460 13164 12 1 11 -1 8
+!.[VU["($L2*b/,<PXh!ks,<C
+BDFChar: 5461 13165 12 1 11 -1 8
+!.[VUW.6nD.6pHi8\g,^rBLFW
+BDFChar: 5462 13166 12 1 11 -1 8
+!.[VU["'I<,sY$e8\gDfrBLFW
+BDFChar: 5463 13167 12 1 11 -1 8
+!.[VU["'I<.6p<e7DP,fks,<C
+BDFChar: 5464 13168 12 1 11 -1 8
+!.[JQXFMn<2*b/,?bh<pjZim?
+BDFChar: 5465 13280 12 2 10 0 7
+:OkudaFI':8:X6]:OqYZ
+BDFChar: 5466 13281 12 1 10 0 7
+B>B`s'L3JM,X=a_LVWOI
+BDFChar: 5467 13282 12 1 10 0 7
+B>B`s'L6<H'L3?tQb[,s
+BDFChar: 5468 13283 12 1 10 0 7
+(Vhjm<'XO#PX,.3(Vg_M
+BDFChar: 5469 13284 12 1 10 0 7
+pV;GIKL"_9'L3?tQb[,s
+BDFChar: 5470 13285 12 1 10 0 7
+-br,8KL"_9PX(HuQb[,s
+BDFChar: 5471 13286 12 1 10 0 7
+pV7J.'L4%],X=a_8&.MX
+BDFChar: 5472 13287 12 1 10 0 7
+B>B`sPX&lsPX(HuQb[,s
+BDFChar: 5473 13288 12 1 10 0 7
+B>B`sPX(SNF?gO*-br,8
+BDFChar: 5474 13289 12 1 11 0 7
+8`3SkeK@lM<?P9a<T**a
+BDFChar: 5475 13290 12 1 11 0 7
+8`3/_fcWlE8K^SI8`9Oi
+BDFChar: 5476 13291 12 1 11 0 7
+8`3Sk`?7V-8K^SI;;hBq
+BDFChar: 5477 13292 12 1 11 0 7
+8`3Sk`?7b173G#A<T**a
+BDFChar: 5478 13293 12 1 11 0 7
+7Gpl_bog$E<?PWk7H!8M
+BDFChar: 5479 13294 12 1 11 0 7
+?/SR&d3)TM73G#A<T**a
+BDFChar: 5480 13295 12 1 11 0 7
+8`3Ggd3)TM<?P9a<T**a
+BDFChar: 5481 13296 12 1 11 0 7
+?/S-o`?7V-8K^SI8`8hU
+BDFChar: 5482 13297 12 1 11 0 7
+8`3SkeK@HA<?P9a<T**a
+BDFChar: 5483 13298 12 1 11 0 7
+8`3SkeK@lM9cukI7H!DQ
+BDFChar: 5484 13299 12 1 11 0 7
+8`7!!2'=d7<?P9aQ/LmL
+BDFChar: 5485 13300 12 1 11 0 7
+8`6Qj3?Td/8K^SIM;\=T
+BDFChar: 5486 13301 12 1 11 0 7
+8`7!!,p4Ml8K^SIOl60\
+BDFChar: 5487 13302 12 1 11 0 7
+8`7!!,p4Yp73G#AQ/LmL
+BDFChar: 5488 13303 12 1 11 0 7
+7Gt9j/Kcq/<?PWkL#D&8
+BDFChar: 5489 13304 12 1 11 0 7
+?/Vt10d&L773G#AQ/LmL
+BDFChar: 5490 13305 12 1 11 0 7
+8`6ir0d&L7<?P9aQ/LmL
+BDFChar: 5491 13306 12 1 11 0 7
+?/VP%,p4Ml8K^SIM;[V@
+BDFChar: 5492 13307 12 1 11 0 7
+8`7!!2'=@+<?P9aQ/LmL
+BDFChar: 5493 13308 12 1 11 0 7
+8`7!!2'=d79cukIL#D2<
+BDFChar: 5494 13309 12 1 11 0 7
+8`7!!2'>oW2'=b![GXV!
+BDFChar: 5495 13310 12 1 11 0 7
+8`6Qj3?UoO.3L&^WSh&)
+BDFChar: 5496 12343 12 1 11 -1 8
+MBId!;*[uD+FkSb;*[uDMBId!
+BDFChar: 5497 12832 12 1 11 -2 8
++Fl^B5X9iBJ0;V"J09@b5X7S"+FjFl
+BDFChar: 5498 12833 12 1 11 -2 8
++Fl^B?U0,aJ09@bJ09@b?U-kA+FjFl
+BDFChar: 5499 12834 12 1 11 -2 8
++Fl^B?U0,aJ09jpJ09@b?U-kA+FjFl
+BDFChar: 5500 12835 12 1 11 -2 8
++Fl^BJ&&(WWh?DcYb7Y^J&"<7+FjFl
+BDFChar: 5501 12836 12 1 11 -2 8
++Fl^BJ&$^[KHS#PM'.WtJ&"<7+FjFl
+BDFChar: 5502 12837 12 1 11 -2 8
++FljF6pSM[J09^lMBJ$(;*[B3+FjFl
+BDFChar: 5503 12838 12 1 11 -2 8
++Fm!J83i4Y\0-SML`hNs:I%01+FjFl
+BDFChar: 5504 12839 12 1 11 -2 8
++Fl^B:-aCRMBId!M'.p';*[B3+FjFl
+BDFChar: 5505 12840 12 1 11 -2 8
+."FiR83jp4M'.WtOW]co@DG,n+FjFl
+BDFChar: 5506 12841 12 1 11 -2 8
++Fl^B6pQDJKHQm0KHPpj6pO"&+FjFl
+BDFChar: 5507 12842 12 1 11 -2 8
++Fm6Q8O/=ZM'.j%M'.p';a<T5+FjFl
+BDFChar: 5508 12843 12 1 11 -2 8
++FljF6pR"[Pot`&MBId!;*[B3+FjFl
+BDFChar: 5509 12844 12 1 11 -2 8
++FljF6pS2RQQVS:V'(Ga9L(j.+FjFl
+BDFChar: 5510 12845 12 1 11 -2 8
++FljF6pSM[KHQ9tPoulq6pO"&+FjFl
+BDFChar: 5511 12846 12 1 11 -2 8
+,_/KP;*_:WKHS%&KHQO&J&"<7+FjFl
+BDFChar: 5512 12847 12 1 11 -2 8
++FljF6pQDJT-/e0KHPpjJ&"<7+FjFl
+BDFChar: 5513 12848 12 1 11 -2 8
++Fl^B?U0_rOW^8=OW]c/?U.IR+FjFl
+BDFChar: 5514 8263 6 1 5 0 7
+:oGd=:f%-g
+BDFChar: 5515 8264 6 1 5 0 7
+8>mq-84W_O
+BDFChar: 5516 8265 6 1 5 0 7
+OJmtsOH9I(
+BDFChar: 5517 8352 6 1 5 0 6
+@">b[E$.+?
+BDFChar: 5518 8770 6 1 5 2 5
+p],!3
+BDFChar: 5519 8774 6 1 5 -1 6
+BWqL3+S\2e
+BDFChar: 5520 8775 6 1 5 -1 8
+&.iNZ+S[)S5X5;L
+BDFChar: 5521 8778 6 1 5 0 6
+BWqJMYQ4Fu
+BDFChar: 5522 8779 6 1 5 0 7
+BWqJMYQ/@@
+BDFChar: 5523 8780 6 1 5 1 6
+Y\4%3!;HNo
+BDFChar: 5524 8769 6 1 5 1 6
+&.iNZ5X5;L
+BDFChar: 5525 8764 6 1 5 3 4
+BWqI:
+BDFChar: 5526 8763 6 1 5 1 6
++96)Z!$D7A
+BDFChar: 5527 8858 6 0 6 0 6
+3(/q0P!h80
+BDFChar: 5528 10746 6 1 5 1 5
+:f-p`:]LIq
+BDFChar: 5529 128178 12 3 8 -3 9
+0JIbLbi!^cbku]>0E;(Q
+BDFChar: 5530 8607 6 1 5 0 7
++E48%E2Xm%
+BDFChar: 5531 8909 6 1 5 2 5
+Y\4%3
+BDFChar: 5532 8767 6 1 5 1 5
+5bP&(&-)\1
+BDFChar: 5533 8760 6 1 5 3 5
++9;0:
+BDFChar: 5534 8761 6 1 5 1 5
+#QX>o#QOi)
+BDFChar: 5535 8753 6 1 5 -2 8
+(apM?\@<Y(+J?LM
+BDFChar: 5536 8754 6 1 5 -2 8
+(apM?\@A2N+J?LM
+BDFChar: 5537 8755 6 1 5 -2 8
+(apMGTX_LF+J?LM
+BDFChar: 5538 8768 6 2 4 0 7
+5Th175_+AM
+BDFChar: 5539 8782 6 1 5 1 5
++P6\H+92BA
+BDFChar: 5540 8783 6 1 5 2 5
++P6\h
+BDFChar: 5541 8808 6 1 5 -2 7
+(gql%(_HHbpcnfZ
+BDFChar: 5542 8809 6 1 5 -2 7
+^b?$J^_$8`pcnfZ
+BDFChar: 5543 8813 6 1 5 -1 7
+&.kdZ+E48E5QCca
+BDFChar: 5544 8812 6 2 4 0 6
+TKo0CTKo.M
+BDFChar: 5545 9153 6 1 5 0 8
+p`OOSW2OYX+92BA
+BDFChar: 5546 9154 6 1 5 0 8
++<YX%W2OYXp](9o
+BDFChar: 5547 9152 6 1 5 0 8
++<YX%W2OYX+92BA
+BDFChar: 5548 9155 6 1 5 0 8
++<VeGE2`OS+92BA
+BDFChar: 5549 9156 6 1 5 0 8
+p`L\uE2`OS+92BA
+BDFChar: 5550 9157 6 1 5 0 8
++<VeGE2`OSp](9o
+BDFChar: 5551 9158 6 1 5 0 8
++<Ve?YTP&2+92BA
+BDFChar: 5552 9159 6 1 5 0 8
+p`L\%BWrU%+92BA
+BDFChar: 5553 9160 6 1 5 0 8
++<Ve?YTP&2p](9o
+BDFChar: 5554 8471 6 0 6 0 6
+3(1?hU-ps@
+BDFChar: 5555 8814 6 2 5 -1 7
+&.gO'TO;/(5QCca
+BDFChar: 5556 8815 6 1 4 -1 7
++J<+M:gh(hJ,fQL
+BDFChar: 5557 8816 6 1 5 -2 8
+&.f[tTO9`%pcq(E
+BDFChar: 5558 8817 6 1 5 -2 8
+&.m2B-nsR%pcq(E
+BDFChar: 5559 8818 6 1 5 0 7
+(gql%(]\6R
+BDFChar: 5560 8819 6 1 5 0 7
+^b?$J^]8&P
+BDFChar: 5561 8820 6 1 5 -2 8
+&/]AZ?oT9BYWtGR
+BDFChar: 5562 8821 6 1 5 -2 8
+&C<*Z0]4'eYWtGR
+BDFChar: 5563 8822 6 1 5 -1 8
+(gql%(r.g20YdYg
+BDFChar: 5564 8823 6 1 5 -1 8
+^b?$J^_gI0?l/kD
+BDFChar: 5565 8824 6 1 5 -2 9
++?3c%?o['u-nsR%
+BDFChar: 5566 8825 6 1 5 -2 9
++Q+q%0]4ouTO9`%
+BDFChar: 5567 8826 6 1 5 1 5
+#Va%J#QOi)
+BDFChar: 5568 8827 6 1 5 1 5
+J7'4%J,fQL
+BDFChar: 5569 8828 6 1 5 0 6
+#Va%Ja=ml"
+BDFChar: 5570 8829 6 1 5 0 6
+J7'4%QsbFE
+BDFChar: 5571 8830 6 1 5 0 7
+#Va%J#QSPB
+BDFChar: 5572 8831 6 1 5 0 7
+J7'4%J,j8e
+BDFChar: 5573 8832 6 1 5 -1 7
+&.g6Di%QQE5QCca
+BDFChar: 5574 8833 6 1 5 -1 7
+&.kLB3+/CE5QCca
+BDFChar: 5575 8928 6 1 5 -2 8
+&.g6Di%X@K-pU#t
+BDFChar: 5576 8929 6 1 5 -2 8
+&.kLB3+07(TKkaB
+BDFChar: 5577 8926 6 1 5 0 6
+#Va=R^b?#o
+BDFChar: 5578 8927 6 1 5 0 6
+J7+aP(gqjo
+BDFChar: 5579 8924 6 1 5 0 6
+p]).=J7'2o
+BDFChar: 5580 8925 6 1 5 0 6
+p]/)`#Va$o
+BDFChar: 5581 8986 12 3 9 -2 8
+3&ilcP+$tj3&ikt
+BDFChar: 5582 128275 12 1 10 -1 8
+"+UM>"@*)TrW)otrW)otrW)ot
+BDFChar: 5583 128232 12 1 11 0 6
+5N)$=.%oZE.\O"R5MuMA
+BDFChar: 5584 128229 12 1 11 -2 8
+%KHh9)Z]Edb$`.q^gQ]jNZ`ips53kW
+BDFChar: 5585 128228 12 1 11 -2 8
+"98c/&HM^db$`M&^gQ]jNZ`ips53kW
+BDFChar: 5586 128128 12 1 11 -2 8
+*ro]a5X:e]]:cF%KHP0J+Fkql*rl9@
+BDFChar: 5587 128123 12 1 11 -2 8
+%KI(@+Frb8J07TPAACGq5X8=7C;9fL
+BDFChar: 5588 129695 12 1 11 -2 8
+s58PQKHPpjKHU<QKHPpjKHPpjs53kW
+BDFChar: 5589 127822 12 1 11 -2 9
+2ujou$ii/8J&)*Bs5<q8s58CBJ&"-r
+BDFChar: 5590 127823 12 1 11 -2 9
+2ujou$ii/8:-a=PJ09@bJ07*B6pNha
+BDFChar: 5591 129302 12 1 11 -2 8
+KHS%&s5:\#OW_GIs5<q8EPR(>5C`_6
+BDFChar: 5592 128203 12 2 10 -2 8
+*!#_`U4Bt.J:P@aJ:P.[K7JQ(s*t(L
+BDFChar: 5593 128220 12 1 11 -2 8
+IK71am!p4//q>'p/q>'p-f>ga&&8/F
+BDFChar: 5594 128195 12 2 11 -2 8
+rr@TM]`<T`]`<T`\H%0\T>4i"5C`_6
+BDFChar: 5595 128199 12 1 11 -2 8
+J&"<75X<_)s5<q8d9sat^gR3#s53kW
+BDFChar: 5596 128222 12 1 11 -2 8
+5QK^Bn,VqXhuM[8Dub065JSB!#J^<>
+BDFChar: 5597 128224 12 1 11 -2 8
+5JSC,.mP4BD*Yko^Yl,"^YnBbs53kW
+BDFChar: 5598 128240 12 1 11 -2 8
+s1j.m^L2S"^L2S"]3r-V]3p.3J%u$a
+BDFChar: 5599 128176 12 1 11 -2 8
+"onf,%"Juk/:^hf9L+IXS01'^5C`_6
+BDFChar: 5600 8911 6 1 5 1 5
++<XKWL]@DT
+BDFChar: 5601 8910 6 1 5 1 5
+Lepnj+92BA
+BDFChar: 5602 8917 6 1 5 0 6
+:f-p`peXce
+BDFChar: 5603 8918 6 1 5 1 5
+(gr/-(]XO9
+BDFChar: 5604 8930 6 1 5 -2 8
+&.nW0TV2'&pcq(E
+BDFChar: 5605 8931 6 1 5 -2 8
+&.nUb-n+j5pcq(E
+BDFChar: 5606 8932 6 1 5 -1 6
+pjdmFp^m3c
+BDFChar: 5607 8933 6 1 5 -1 6
+p]q-2p^m3c
+BDFChar: 5608 8934 6 1 5 -2 7
+(gql%(a*Lr5X5;L
+BDFChar: 5609 8935 6 1 5 -2 7
+^b?$J^`[<p5X5;L
+BDFChar: 5610 8936 6 1 5 -2 7
+#Va%J#U!fb5X5;L
+BDFChar: 5611 8937 6 1 5 -2 7
+J7'4%J08O05X5;L
+BDFChar: 5612 8938 6 1 5 0 8
+&.f[lW+]9u5QCca
+BDFChar: 5613 8939 6 1 5 0 8
+&.m3mW3F'&5QCca
+BDFChar: 5614 8940 6 1 5 -2 8
+&.f[lW+\.5pcq(E
+BDFChar: 5615 8941 6 1 5 -2 8
+&.m3mW3G2&pcq(E
+BDFChar: 5616 8922 6 1 5 -3 9
+(gql%(]a=2^b?$J^]4?7
+BDFChar: 5617 8923 6 1 5 -3 9
+^b?$J^]=-0(gql%(]XO9
+BDFChar: 5618 8894 6 1 5 1 5
+JDcNNp](9o
+BDFChar: 5619 8919 6 1 5 1 5
+^bCQu^]4?7
+BDFChar: 5620 8920 6 0 6 1 5
+.TE?G.KBGK
+BDFChar: 5621 8921 6 0 6 1 5
+W)P6GVuQet
+BDFChar: 5622 8892 6 1 5 0 6
+p])F5:l'o-
+BDFChar: 5623 8893 6 1 5 0 6
+p]-,+:f&87
+BDFChar: 5624 8891 6 1 5 0 6
+Lknl(+9;0:
+BDFChar: 5625 8905 6 1 5 1 5
+LsVgAL]@DT
+BDFChar: 5626 8906 6 1 5 1 5
+Lfc'-L]@DT
+BDFChar: 5627 8907 6 1 5 1 5
+J3Y5RL]@DT
+BDFChar: 5628 8908 6 1 5 1 5
+#S8+TL]@DT
+BDFChar: 5629 8903 6 1 5 0 6
++G`kh:l$4o
+BDFChar: 5630 9200 12 2 10 -2 8
+G6$ZRh125M8H;Hb5l`)/4of?u8H8_j
+BDFChar: 5631 9100 6 1 5 0 5
+YfQ#.f[p0(
+BDFChar: 5632 9213 6 3 3 1 5
+J:N0#J,fQL
+BDFChar: 5633 9214 6 0 6 0 6
++@*`Xid<]c
+BDFChar: 5634 8258 6 0 6 -1 7
+&3(4L!(?6CWW3#!
+BDFChar: 5635 8273 6 2 4 -1 7
+5i=o#!'oI-TE"rl
+BDFChar: 5636 8353 6 1 5 -1 8
+:iP(6d*U.lE)6N7
+BDFChar: 5637 8354 6 1 5 0 7
+E/9%CYb7q6
+BDFChar: 5638 8357 6 1 5 -2 7
+&.n?0W2QYn5X5;L
+BDFChar: 5639 8358 6 0 6 0 7
+6tBj-<;oQZ
+BDFChar: 5640 8360 6 1 5 0 7
+^n@@9aKVVI
+BDFChar: 5641 8363 6 1 5 -2 8
+&9nb*OH>QcDufA-
+BDFChar: 5642 8365 6 1 5 0 7
+85N^h?r0Bb
+BDFChar: 5643 8366 6 1 5 0 7
+p`Lt=BWtm;
+BDFChar: 5644 8367 6 0 6 -3 7
+3)gS;-qID($kNsM
+BDFChar: 5645 8368 6 1 6 -1 8
+&1AqD(fYV<U^-r#
+BDFChar: 5646 8369 6 0 5 0 7
+E;W9)E'QZR
+BDFChar: 5647 8450 6 1 5 0 7
+E6,i1^qe$1
+BDFChar: 5648 8452 6 1 5 0 7
++E4!HTPu#5
+BDFChar: 5649 8455 6 1 5 0 7
+E0,ThJ:NGp
+BDFChar: 5650 8456 6 1 5 0 7
+E/4cZ#RH6*
+BDFChar: 5651 8458 6 1 5 -3 5
+-s2:eE%#[u^]4?7
+BDFChar: 5652 8459 6 0 6 0 7
+2HCMSBW0E_
+BDFChar: 5653 8460 6 0 6 0 7
+Au)4b,U=XI
+BDFChar: 5654 8461 6 1 5 0 7
+f\"jOf\"j/
+BDFChar: 5655 8464 6 1 5 0 7
+G`Y`5+E48E
+BDFChar: 5656 8465 6 1 5 0 7
+G_f0-&.")2
+BDFChar: 5657 8466 6 0 5 0 7
+85qP[+CM-E
+BDFChar: 5658 8467 6 1 4 0 7
++AcI]5_+r(
+BDFChar: 5659 8468 6 0 5 0 7
+;#!jh<)ch!
+BDFChar: 5660 8469 6 1 5 0 7
+aN3T/\@@on
+BDFChar: 5661 8473 6 1 5 0 7
+nCZCGnA)iT
+BDFChar: 5662 8474 6 1 5 -1 7
+E7igqf\"hq2uipY
+BDFChar: 5663 8477 6 1 5 0 7
+nCZC_nCZCG
+BDFChar: 5664 8484 6 1 5 0 7
+p_Y\=?speF
+BDFChar: 5665 8480 6 0 6 5 7
+IU:G&
+BDFChar: 5666 8578 6 -1 7 0 7
+4oe.SS:IViWdpUi8H:pS
+BDFChar: 5667 8494 6 1 6 0 6
+0M'Fc^dp-Z
+BDFChar: 5668 8498 6 1 5 0 7
+#RC\AGR+TM
+BDFChar: 5669 8526 6 1 4 0 5
+&.idl&F]Z"
+BDFChar: 5670 8662 6 1 5 2 6
+n=\.,&-)\1
+BDFChar: 5671 8663 6 1 5 2 6
+GUQ[m5QCca
+BDFChar: 5672 8664 6 1 5 0 4
+5c@d5GQ7^D
+BDFChar: 5673 8665 6 1 5 0 4
+&?*sKn,NFg
+BDFChar: 5674 8670 6 1 5 0 7
++E48%p`T>S
+BDFChar: 5675 8671 6 1 5 0 7
++S[)S+K06%
+BDFChar: 5676 8676 6 1 5 1 5
+OJ)BAO8o7\
+BDFChar: 5677 8677 6 1 5 1 5
+81=6]8,rVi
+BDFChar: 5678 8678 6 1 5 1 5
++F(tP+92BA
+BDFChar: 5679 8679 6 1 5 0 6
++E5t0:f)*2
+BDFChar: 5680 8680 6 1 5 1 5
++Rkcf+92BA
+BDFChar: 5681 8681 6 1 5 0 6
+E)9A-fPhr5
+BDFChar: 5682 8682 6 1 5 0 6
++E5t0E):KR
+BDFChar: 5683 8606 6 1 6 1 5
+-rBh<-ia5I
+BDFChar: 5684 8608 6 0 5 1 5
+:al5i:]LIq
+BDFChar: 5685 8965 6 1 5 0 5
+p`NC0Lkl$2
+BDFChar: 5686 8966 6 1 5 0 7
+p]1(3:f)t(
+BDFChar: 5687 8604 6 1 6 2 5
+i4u9*
+BDFChar: 5688 8605 6 1 6 2 5
+*"5f>
+BDFChar: 5689 8622 6 1 5 1 5
+#Z1:mJ,fQL
+BDFChar: 5690 8644 6 1 5 0 5
+&GQf%pcnfZ
+BDFChar: 5691 8646 6 1 5 0 5
+5kmSUp^dE*
+BDFChar: 5692 8647 6 1 5 0 5
+5kmT0pcnfZ
+BDFChar: 5693 8649 6 1 5 0 5
+&GQeJp^dE*
+BDFChar: 5694 8645 6 1 5 0 6
+;".:X:j>e:
+BDFChar: 5695 8648 6 1 5 0 6
+;#!j`:f'sg
+BDFChar: 5696 8650 6 1 5 0 6
+:f'tb;#!ie
+BDFChar: 5697 8653 6 1 5 -1 7
+&.gO?TQjj05QCca
+BDFChar: 5698 8655 6 1 5 -1 7
+&.gPb..CV05QCca
+BDFChar: 5699 8654 6 0 6 -1 7
+#RDi+epJkg+92BA
+BDFChar: 5700 8666 6 0 5 0 6
+&3O@u?p"u#
+BDFChar: 5701 8667 6 1 6 0 6
++Rg6G)"8XJ
+BDFChar: 5702 8683 6 1 5 0 6
++E5t0fSK;&
+BDFChar: 5703 8684 6 1 5 0 6
++Ahi0fSK;&
+BDFChar: 5704 8686 6 1 5 0 7
++Af"5Lepoe
+BDFChar: 5705 8685 6 1 5 0 6
++E7*ppo*rf
+BDFChar: 5706 8688 6 0 6 1 5
+ke)Y_kPtS_
+BDFChar: 5707 8691 6 1 5 0 6
++E5t0fPhr5
+BDFChar: 5708 8693 6 1 5 0 6
+:j>f5;".9]
+BDFChar: 5709 8694 6 1 5 -1 7
+&GQeJp^e#3&-)\1
+BDFChar: 5710 9735 6 1 5 0 7
+&0O5g5U[I/
+BDFChar: 5711 9736 6 0 5 0 7
+pkY$)TTkD*
+BDFChar: 5712 9636 6 0 6 0 6
+rdt-$rdt+L
+BDFChar: 5713 9637 6 0 6 0 6
+ri2uuWiH$u
+BDFChar: 5714 9639 6 0 6 0 6
+rfYF$P03b(
+BDFChar: 5715 9638 6 0 6 0 6
+ri5stri5qt
+BDFChar: 5716 9640 6 0 6 0 6
+rfX/$P,A3Y
+BDFChar: 5717 9641 6 0 6 0 6
+ri4PLeuJ]L
+BDFChar: 5718 9703 6 0 6 0 6
+rpoXNo()b[
+BDFChar: 5719 9704 6 0 6 0 6
+rgo^QSt>o]
+BDFChar: 5720 9705 6 0 6 0 6
+rr2cbikkZp
+BDFChar: 5721 9706 6 0 6 0 6
+re?H)^Ae*3
+BDFChar: 5722 9645 6 0 5 0 3
+r.Kb$
+BDFChar: 5723 9686 6 0 3 0 6
+0Q?ONn8L&]
+BDFChar: 5724 9687 6 3 6 0 6
+^u4_OnDM(^
+BDFChar: 5725 9677 6 0 6 0 6
+3,GUpWbaWp
+BDFChar: 5726 9676 6 0 6 0 6
+&4?MM!(7@u
+BDFChar: 5727 9696 6 0 6 3 6
+3(/@M
+BDFChar: 5728 9697 6 0 6 0 3
+Jq?BM
+BDFChar: 5729 9692 6 0 3 3 6
+0L1/=
+BDFChar: 5730 9693 6 3 6 3 6
+^`X1"
+BDFChar: 5731 9694 6 3 6 0 3
+&.fu"
+BDFChar: 5732 9695 6 0 3 0 3
+J:Km=
+BDFChar: 5733 9708 6 0 6 0 6
+&1Aqp<.b)L
+BDFChar: 5734 9709 6 0 6 0 6
+&3)XkFRoD2
+BDFChar: 5735 9710 6 0 6 0 6
+&3)XS>b:op
+BDFChar: 5736 9690 6 0 6 3 9
+rr2or`k&_]
+BDFChar: 5737 9691 6 0 6 -3 3
+]"5o\rr2ls
+BDFChar: 5738 9720 6 0 6 0 6
+re-)hTYQ'X
+BDFChar: 5739 9721 6 0 6 0 6
+r^%eA$3gP3
+BDFChar: 5740 9722 6 0 6 0 6
+JA@h>LkPa-
+BDFChar: 5741 9655 6 1 5 -1 7
+JA@h>Lle:FJ,fQL
+BDFChar: 5742 9659 6 1 5 1 5
+JDdrqJ,fQL
+BDFChar: 5743 9665 6 1 5 -1 7
+#T+s\Le&p2#QOi)
+BDFChar: 5744 9669 6 1 5 1 5
+#WV$-#QOi)
+BDFChar: 5745 9652 6 1 5 1 5
++E2;pp](9o
+BDFChar: 5746 9653 6 1 5 1 5
++Abmjp](9o
+BDFChar: 5747 9662 6 1 5 1 5
+q"SfI+92BA
+BDFChar: 5748 9663 6 1 5 1 5
+pkVaC+92BA
+BDFChar: 5749 9656 6 2 4 1 5
+JAC*YJ,fQL
+BDFChar: 5750 9657 6 2 4 1 5
+JA@hnJ,fQL
+BDFChar: 5751 9666 6 2 4 1 5
++CO,8+92BA
+BDFChar: 5752 9667 6 2 4 1 5
++CLjM+92BA
+BDFChar: 5753 9862 6 0 6 0 6
+3(/@UJj_Qu
+BDFChar: 5754 9864 6 0 6 0 6
+3.1`!rd6[*
+BDFChar: 5755 9865 6 0 6 0 6
+3.1_Vrd6[*
+BDFChar: 5756 8687 6 1 5 -1 7
++Af"5Leu`[p](9o
+BDFChar: 5757 11029 6 0 6 0 6
+rkd[cqYpHo
+BDFChar: 5758 11028 6 0 6 0 6
+rr0X'Ne[N5
+BDFChar: 5759 11027 6 0 6 0 6
+rdob$rr2ls
+BDFChar: 5760 11026 6 0 6 0 6
+rr2orJqEt%
+BDFChar: 5761 11034 6 0 6 0 6
+WW7VNJcMeN
+BDFChar: 5762 11057 6 1 5 -1 7
+5kmT0pcq+>5QCca
+BDFChar: 5763 11192 6 1 5 0 6
++Ahi0E):KR
+BDFChar: 5764 10629 6 1 4 -2 8
+0MkT=TV.sN:f&hG
+BDFChar: 5765 10630 6 2 5 -2 8
+^n@>s:f'tbTV0(#
+BDFChar: 5766 9760 12 1 11 -2 8
+@)/q<n_bO?.Y&dp&HFG6n_gRC@))aB
+BDFChar: 5767 9762 12 1 11 -2 8
+%KJ56EPQq:s5<e4KHO#T?U-i+%KHJ/
+BDFChar: 5768 9763 12 1 11 -1 8
+$31Y<21RE35Ce*rhdEU[*rp;r
+BDFChar: 5769 9765 6 1 5 0 7
++AblWp`L\%
+BDFChar: 5770 9766 6 1 5 0 7
++E/Iu+CHlG
+BDFChar: 5771 9767 6 0 5 0 7
+3$]b/+K07X
+BDFChar: 5772 9769 6 0 6 0 6
+3"V8POq9SQ
+BDFChar: 5773 9764 6 0 6 -1 7
+&FNLW<&di:;ucmu
+BDFChar: 5774 9770 6 0 6 0 7
+4CZCeaOFZ]
+BDFChar: 5775 9771 6 -1 7 -1 7
+#QRj)Lk)LUWdq+"S:F02)uos=
+BDFChar: 5776 9772 6 -1 7 -1 7
+>l^mTWdq+"h14gA^49Jh#QOi)
+BDFChar: 5777 9773 6 0 5 0 7
+0F.dq1^J2R
+BDFChar: 5778 9774 12 1 11 -2 8
+%KJA:6pO.*KHPpjNZ_=eAAC'Q%KHJ/
+BDFChar: 5779 9775 12 1 11 -2 8
+%KJ565X9QZp`SrHr*Y#iJ&":!%KHJ/
+BDFChar: 5780 9789 6 0 5 -1 8
+i&DPn$k+*m38ac:
+BDFChar: 5781 9790 6 1 6 -1 8
+*,o<D^qel9E#\iX
+BDFChar: 5782 9761 6 1 5 0 7
+n/)ur@)0R&
+BDFChar: 5783 3647 6 1 5 -1 8
++Rl>.n>N:an/q]2
+BDFChar: 5784 8241 6 1 8 0 8
+5bLXZ+@)r,.KBGK
+BDFChar: 5785 8490 6 1 5 0 7
+Lle:fOH>9S
+BDFChar: 5786 9743 12 1 11 -2 8
+J&$RWT-3[^/q?ea<BsDHNZ`ips53kW
+BDFChar: 5787 9742 12 1 11 -2 8
+J&)*Bi8E!j5CbJ=AADrqjP]Rds53kW
+BDFChar: 5788 9750 6 0 6 0 7
+3,CuNJqAUR
+BDFChar: 5789 9751 6 0 6 0 7
+3.-+$rr2or
+BDFChar: 5790 9832 12 1 11 0 8
+$@iik'`\SkC;?)W^gR3#5C`_6
+BDFChar: 5791 10016 6 0 8 -1 7
+4ocQ&Lk*Tts+&4ALk$HF4obQ_
+BDFChar: 5792 9646 6 1 4 0 7
+nF5r:nF5r:
+BDFChar: 5793 9647 6 1 4 0 7
+n;r`nOH>Rn
+BDFChar: 5794 9648 6 0 5 0 3
+I!k_a
+BDFChar: 5795 9649 6 0 5 0 3
+Hpiec
+BDFChar: 5796 9747 6 1 5 -1 8
+Lknl(+<XKWLkl$2
+BDFChar: 5797 8880 6 1 5 0 6
+&-su*0F/3i
+BDFChar: 5798 8881 6 1 5 0 6
+5_*5Z@":KB
+BDFChar: 5799 8889 6 1 5 0 6
++<U[:!$EBa
+BDFChar: 5800 8890 6 2 4 0 6
+i'9Om5X7R7
+BDFChar: 5801 8912 6 1 5 0 6
+3'b!H\3N"R
+BDFChar: 5802 8913 6 1 5 0 6
+i"5*#kRcYP
+BDFChar: 5803 8914 6 0 6 0 6
+3(1?XWiE'!
+BDFChar: 5804 8915 6 0 6 0 6
+WiE)!\jSLX
+BDFChar: 5805 8916 6 1 5 0 7
++<YX%W2QYn
+BDFChar: 5806 10013 6 1 5 0 7
++<^G%+<VdL
+BDFChar: 5807 10014 6 1 5 0 7
+E7g!!:f'u-
+BDFChar: 5808 10015 6 1 6 0 7
+0JNG&0JG17
+BDFChar: 5809 10017 6 0 6 0 7
+&1ING7/eSG
+BDFChar: 5810 10018 6 0 6 0 6
+&.fEP&.fBQ
+BDFChar: 5811 10019 6 0 6 -1 7
+&3(5#r_sFg&-)\1
+BDFChar: 5812 10020 6 0 6 0 6
+3&oLgei5Vh
+BDFChar: 5813 10021 6 0 6 -1 7
+&3(5#r_sFg&-)\1
+BDFChar: 5814 10023 6 0 6 0 6
+&.g80-kHpi
+BDFChar: 5815 10027 6 1 5 1 6
++<^GUE/4Jo
+BDFChar: 5816 10028 6 1 5 1 6
++<^GuE/4Jo
+BDFChar: 5817 10031 6 1 5 1 6
++<^GuE/4Jo
+BDFChar: 5818 10025 6 1 5 1 6
++<^GUE/4Jo
+BDFChar: 5819 10032 6 1 5 1 6
++<^GUE/4Jo
+BDFChar: 5820 10026 6 0 6 0 7
+3,J#7`fb^/
+BDFChar: 5821 10033 6 0 6 0 6
+&Cu4gI+Ai/
+BDFChar: 5822 10034 6 1 5 0 5
++K/+5W#u'?
+BDFChar: 5823 10035 6 0 6 0 6
+&6(Xg3)gFh
+BDFChar: 5824 10036 6 0 6 0 6
+&6(Xg3)gFh
+BDFChar: 5825 10037 6 0 6 0 6
+&6(Xg3)gFh
+BDFChar: 5826 10070 6 0 6 0 6
+&3*YW<&bEh
+BDFChar: 5827 11030 6 0 6 0 6
+&3+e&F>sg3
+BDFChar: 5828 11031 6 0 6 0 6
+&3*pd>W<8p
+BDFChar: 5829 11032 6 0 6 0 6
+&3,(:6mrTH
+BDFChar: 5830 11033 6 0 6 0 6
+&1BsGHoMZ;
+BDFChar: 5831 11210 6 0 6 3 6
+3.1`)
+BDFChar: 5832 11211 6 0 6 0 3
+rr.:)
+BDFChar: 5833 9753 6 0 5 0 7
++=n'@A9;eK
+BDFChar: 5834 10087 6 1 6 0 7
+&C;P-R(,*q
+BDFChar: 5835 10086 6 0 5 0 6
+A@N1aG]5VB
+BDFChar: 5836 10085 6 0 5 0 6
+@.<r=q!_Yk
+BDFChar: 5837 10083 6 1 5 -1 8
+;#'g)+<UY,E$,,\
+BDFChar: 5838 10082 6 1 5 -1 8
+E;93I+<UY,E$,,\
+BDFChar: 5839 10068 12 3 8 -2 8
+Gl5bo*&oW+!&-),
+BDFChar: 5840 10069 12 5 6 -2 8
+^qdb$^qdb$!5QAM
+BDFChar: 5841 10071 12 5 6 -2 8
+^qdb$^qdb$!5QAM
+BDFChar: 5842 10799 6 1 5 1 5
+Leo3jL]@DT
+BDFChar: 5843 9135 6 0 5 3 3
+qu?]s
+BDFChar: 5844 11373 6 1 5 0 7
+BUFU3LkqF3
+BDFChar: 5845 11362 6 0 5 0 7
++<Ve?YTP&N
+BDFChar: 5846 581 6 1 5 0 7
++<XKW:l'p`
+BDFChar: 5847 573 6 1 5 0 7
+5X7Tm5X7SZ
+BDFChar: 5848 574 6 1 5 0 7
+p`Lt=+CLib
+BDFChar: 5849 571 6 1 5 -1 8
+&9+#0TV.t!E'OC'
+BDFChar: 5850 570 6 1 5 -1 8
+&9+#8W;*=4a?T_*
+BDFChar: 5851 572 6 1 5 -1 6
+&9+#0TZD(;
+BDFChar: 5852 579 6 1 5 0 7
+E(EN=8E`T`
+BDFChar: 5853 696 6 2 4 3 7
+TV,[8^]4?7
+BDFChar: 5854 7611 6 2 4 4 8
+i#k:8huE`W
+BDFChar: 5855 7615 6 2 4 4 8
+5bR&.5QCca
+BDFChar: 5856 8370 6 1 5 -1 8
++E49PTX^r!E$,,\
+BDFChar: 5857 8372 6 0 5 0 8
+0LuKI0`41,0E;(Q
+BDFChar: 5858 8373 6 1 5 -1 8
++E49PTV.sVE$,,\
+BDFChar: 5859 8376 6 1 5 0 7
+p]1(3+<VdL
+BDFChar: 5860 8377 6 1 5 0 7
+p^m33i#iRB
+BDFChar: 5861 8378 6 1 5 0 7
+5Ytk8@)tlX
+BDFChar: 5862 8380 6 1 5 0 7
++<YX%W2QYn
+BDFChar: 5863 8382 6 1 5 0 8
+:iP(>J:N/8p](9o
+BDFChar: 5864 567 6 2 4 -2 5
+?m$R7+<[=B
+BDFChar: 5865 10761 6 0 6 0 6
+Jj_!u-q&Xe
+BDFChar: 5866 975 6 1 5 -2 7
+Lle:F^n?dF&0LrQ
+BDFChar: 5867 983 6 1 5 -2 5
+Lle:fOGFGj
+BDFChar: 5868 10096 6 1 5 -1 7
+3&kkri,EWp2uipY
+BDFChar: 5869 10097 6 1 5 -1 7
+i8AQn3,iiphuE`W
+BDFChar: 5870 10100 6 1 4 -2 8
+0OS9r@)-/X?skYg
+BDFChar: 5871 10101 6 2 5 -2 8
+^gLPX?nbtr?spbM
+BDFChar: 5872 10098 6 2 4 -2 8
++@(I-J:N0#J3Y4W
+BDFChar: 5873 10099 6 2 4 -2 8
+J3Y5"+<VdL+@(GW
+BDFChar: 5874 9752 6 0 6 -1 7
+-oa3;rmhVl+92BA
+BDFChar: 5875 127808 12 2 10 -2 8
+@fZ7RpOI_n)utHgs+(-"CB+V?"98E%
+BDFChar: 5876 884 6 2 3 6 8
+5X9i"
+BDFChar: 5877 885 6 2 3 -1 1
+5X9i"
+BDFChar: 5878 11037 6 2 4 2 4
+i8EMn
+BDFChar: 5879 11038 6 2 4 2 4
+i1T!.
+BDFChar: 5880 9725 12 4 8 1 5
+pkX`^p](9o
+BDFChar: 5881 11035 12 2 10 -1 7
+s+(-"s+(-"s+(-"s+(-"s*t(L
+BDFChar: 5882 11036 12 2 10 -1 7
+s+#WMJ:N0#J:N0#J:N0#s*t(L
+BDFChar: 5883 9726 12 4 8 1 5
+q"XXZp](9o
+BDFChar: 5884 11039 6 1 5 1 6
++E7,NE,YdW
+BDFChar: 5885 11040 6 1 5 1 6
++AdlM:iHC7
+BDFChar: 5886 11041 6 1 5 0 6
++AdlMLeo2o
+BDFChar: 5887 11043 6 0 5 1 5
+0R3M?0E;(Q
+BDFChar: 5888 11045 6 1 5 1 5
++E7*p+92BA
+BDFChar: 5889 11046 6 1 5 1 5
++Adkj+92BA
+BDFChar: 5890 11047 6 1 5 0 6
++E2;pE,Zp"
+BDFChar: 5891 11048 6 1 5 0 6
++Abmj:f&87
+BDFChar: 5892 11049 6 2 4 2 4
+5i=m-
+BDFChar: 5893 11050 6 2 4 1 5
+5X=6m5QCca
+BDFChar: 5894 11051 6 2 4 1 5
+5X:u-5QCca
+BDFChar: 5895 11052 6 0 5 1 5
+Gl7L;GQ7^D
+BDFChar: 5896 11053 6 0 5 1 5
+G_Ca'GQ7^D
+BDFChar: 5897 11054 6 1 5 0 6
+E;95'q"Se.
+BDFChar: 5898 11055 6 1 5 0 6
+E/9=+Lkp!M
+BDFChar: 5899 11205 6 1 5 1 5
++<YWBp](9o
+BDFChar: 5900 11206 6 1 5 1 5
+pi(0p+92BA
+BDFChar: 5901 11207 6 1 5 1 5
+#WVT=#QOi)
+BDFChar: 5902 11208 6 1 5 1 5
+JDg4\J,fQL
+BDFChar: 5903 8232 6 0 0 0 0
+z
+BDFChar: 5904 11091 6 1 6 1 5
 0_kS@0E;(Q
-BDFChar: 5906 11092 6 1 6 1 5
+BDFChar: 5905 11092 6 1 6 1 5
 0Z\pg0E;(Q
-BDFChar: 5907 11089 6 2 4 2 5
+BDFChar: 5906 11089 6 2 4 2 5
 5i=o#
-BDFChar: 5908 11090 6 2 4 2 5
+BDFChar: 5907 11090 6 2 4 2 5
 5bLB8
-BDFChar: 5909 11140 6 1 6 1 6
+BDFChar: 5908 11140 6 1 6 1 6
 5l<l4r'15^
-BDFChar: 5910 11141 6 1 6 1 6
+BDFChar: 5909 11141 6 1 6 1 6
 8Gl"L84W^\
-BDFChar: 5911 11142 6 1 6 1 6
+BDFChar: 5910 11142 6 1 6 1 6
 #lFr6r!39&
-BDFChar: 5912 11143 6 1 6 1 6
+BDFChar: 5911 11143 6 1 6 1 6
 84Z9Br($ef
-BDFChar: 5913 9929 6 0 6 0 7
+BDFChar: 5912 9929 6 0 6 0 7
 rdo`R6ptiN
-BDFChar: 5914 9930 6 0 6 0 7
+BDFChar: 5913 9930 6 0 6 0 7
 rr2orI!g<$
-BDFChar: 5915 8483 6 1 5 -1 9
+BDFChar: 5914 8483 6 1 5 -1 9
 ^`]SSaA>^[TV-f8
-BDFChar: 5916 8488 6 1 5 -1 7
+BDFChar: 5915 8488 6 1 5 -1 7
 pdbZ=0IR3_Du]k<
-BDFChar: 5917 8485 6 1 5 -2 8
+BDFChar: 5916 8485 6 1 5 -2 8
 p^eSC&0Pot#`*F"
-BDFChar: 5918 8476 6 0 5 0 7
+BDFChar: 5917 8476 6 0 5 0 7
 BXFQ`0IS>c
-BDFChar: 5919 8493 6 1 5 0 7
+BDFChar: 5918 8493 6 1 5 0 7
 8?ebKOJ%DK
-BDFChar: 5920 8472 6 1 5 -1 7
+BDFChar: 5919 8472 6 1 5 -1 7
 OD%0U8>rbCJ,fQL
-BDFChar: 5921 8475 6 0 6 0 7
+BDFChar: 5920 8475 6 0 6 0 7
 4Ale3-n))h
-BDFChar: 5922 8479 6 1 5 -1 9
+BDFChar: 5921 8479 6 1 5 -1 9
 ?kDh+W:7$iaN-UH
-BDFChar: 5923 8489 6 2 4 0 5
+BDFChar: 5922 8489 6 2 4 0 5
 J3Z@b5[XQl
-BDFChar: 5924 8492 6 0 6 0 7
+BDFChar: 5923 8492 6 0 6 0 7
 4Ale3+sO<t
-BDFChar: 5925 8497 6 0 6 0 7
+BDFChar: 5924 8497 6 0 6 0 7
 5#;eQ&0RW2
-BDFChar: 5926 8499 6 -1 7 0 7
+BDFChar: 5925 8499 6 -1 7 0 7
 $31D5*WR5]4od&4WW5Wk
-BDFChar: 5927 8500 6 0 6 0 5
+BDFChar: 5926 8500 6 0 6 0 5
 (c4uU8?`'o
-BDFChar: 5928 8505 6 1 4 0 7
+BDFChar: 5927 8505 6 1 4 0 7
 ?sium?smC3
-BDFChar: 5929 8524 6 0 5 -1 7
+BDFChar: 5928 8524 6 0 5 -1 7
 Lf@>QpeXd`+92BA
-BDFChar: 5930 8523 6 1 5 -1 7
+BDFChar: 5929 8523 6 1 5 -1 7
 YXh;UYTQb=+92BA
-BDFChar: 5931 8522 6 0 5 0 7
+BDFChar: 5930 8522 6 0 5 0 7
 +S_b.3$9Jo
-BDFChar: 5932 8516 6 1 5 0 7
+BDFChar: 5931 8516 6 1 5 0 7
 +<VdL:l'p`
-BDFChar: 5933 8515 6 1 5 0 7
+BDFChar: 5932 8515 6 1 5 0 7
 #RC\A#RC_2
-BDFChar: 5934 8514 6 1 5 0 7
+BDFChar: 5933 8514 6 1 5 0 7
 p]q-2#RC\A
-BDFChar: 5935 8513 6 1 5 0 7
+BDFChar: 5934 8513 6 1 5 0 7
 E/9=k#RH6*
-BDFChar: 5936 8527 6 0 6 0 5
+BDFChar: 5935 8527 6 0 6 0 5
 <2usu<2oou
-BDFChar: 5937 127462 6 1 5 0 5
+BDFChar: 5936 127462 6 1 5 0 5
 E/9>FLkl$2
-BDFChar: 5938 127463 6 1 5 0 5
+BDFChar: 5937 127463 6 1 5 0 5
 n;-RiM!tBE
-BDFChar: 5939 127464 6 1 5 0 5
+BDFChar: 5938 127464 6 1 5 0 5
 E/9$pLi<=o
-BDFChar: 5940 127465 6 1 5 0 5
+BDFChar: 5939 127465 6 1 5 0 5
 i/ibNOPg*=
-BDFChar: 5941 127466 6 1 5 0 5
+BDFChar: 5940 127466 6 1 5 0 5
 pjhjaJG9*E
-BDFChar: 5942 127467 6 1 5 0 5
+BDFChar: 5941 127467 6 1 5 0 5
 pjhjaJ:IV"
-BDFChar: 5943 127468 6 1 5 0 5
+BDFChar: 5942 127468 6 1 5 0 5
 E/9%3Lj/n"
-BDFChar: 5944 127469 6 1 5 0 5
+BDFChar: 5943 127469 6 1 5 0 5
 Lkth^Lkl$2
-BDFChar: 5945 127470 6 2 4 0 5
+BDFChar: 5944 127470 6 2 4 0 5
 i'9Om5i;VB
-BDFChar: 5946 127471 6 1 5 0 5
+BDFChar: 5945 127471 6 1 5 0 5
 (^LBQLi<=o
-BDFChar: 5947 127472 6 1 5 0 5
+BDFChar: 5946 127472 6 1 5 0 5
 LlgPVOGEl:
-BDFChar: 5948 127473 6 1 5 0 5
+BDFChar: 5947 127473 6 1 5 0 5
 J:N0#JG9*E
-BDFChar: 5949 127474 6 1 5 0 5
+BDFChar: 5948 127474 6 1 5 0 5
 LtJY^Lkl$2
-BDFChar: 5950 127475 6 1 5 0 5
+BDFChar: 5949 127475 6 1 5 0 5
 LrcNnR"t_B
-BDFChar: 5951 127476 6 1 5 0 5
+BDFChar: 5950 127476 6 1 5 0 5
 E/9=+Li<=o
-BDFChar: 5952 127477 6 1 5 0 5
+BDFChar: 5951 127477 6 1 5 0 5
 n;)niJ:IV"
-BDFChar: 5953 127478 6 1 5 0 5
+BDFChar: 5952 127478 6 1 5 0 5
 E/9=+OD"Uo
-BDFChar: 5954 127479 6 1 5 0 5
+BDFChar: 5953 127479 6 1 5 0 5
 n;)niOGEl:
-BDFChar: 5955 127480 6 1 5 0 5
+BDFChar: 5954 127480 6 1 5 0 5
 E/7m5Li<=o
-BDFChar: 5956 127481 6 1 5 0 5
+BDFChar: 5955 127481 6 1 5 0 5
 p`L\%+<UXa
-BDFChar: 5957 127482 6 1 5 0 5
+BDFChar: 5956 127482 6 1 5 0 5
 LkpkCLi<=o
-BDFChar: 5958 127483 6 1 5 0 5
+BDFChar: 5957 127483 6 1 5 0 5
 Lknl(+<UXa
-BDFChar: 5959 127484 6 1 5 0 5
+BDFChar: 5958 127484 6 1 5 0 5
 Lkr".:f%,l
-BDFChar: 5960 127485 6 1 5 0 5
+BDFChar: 5959 127485 6 1 5 0 5
 Leo3::l#)O
-BDFChar: 5961 127486 6 1 5 0 5
+BDFChar: 5960 127486 6 1 5 0 5
 Leo3:+<UXa
-BDFChar: 5962 127487 6 1 5 0 5
+BDFChar: 5961 127487 6 1 5 0 5
 p^eQ5JG9*E
-BDFChar: 5963 9124 6 1 3 -3 8
+BDFChar: 5962 9124 6 1 3 -3 8
 i#j-b+<VdL+<VdL
-BDFChar: 5964 9123 6 2 4 -2 9
+BDFChar: 5963 9123 6 2 4 -2 9
 J:N0#J:N0#J:N1.
-BDFChar: 5965 9126 6 1 3 -2 9
+BDFChar: 5964 9126 6 1 3 -2 9
 +<VdL+<VdL+<Vfb
-BDFChar: 5966 9125 6 3 3 -3 9
+BDFChar: 5965 9125 6 3 3 -3 9
 J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5967 9122 6 2 2 -3 9
+BDFChar: 5966 9122 6 2 2 -3 9
 J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5968 9121 6 2 4 -3 8
+BDFChar: 5967 9121 6 2 4 -3 8
 i.-?.J:N0#J:N0#
-BDFChar: 5969 9119 6 3 3 -3 9
+BDFChar: 5968 9119 6 3 3 -3 9
 J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5970 9116 6 2 2 -3 9
+BDFChar: 5969 9116 6 2 2 -3 9
 J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5971 9130 6 3 3 -3 9
+BDFChar: 5970 9130 6 3 3 -3 9
 J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5972 9134 6 3 3 -3 9
+BDFChar: 5971 9134 6 3 3 -3 9
 J:N0#J:N0#J:N0#J,fQL
-BDFChar: 5973 9115 6 2 4 -3 9
+BDFChar: 5972 9115 6 2 4 -3 9
 +@&1W5_+B8J:N0#J,fQL
-BDFChar: 5974 9117 6 2 4 -3 9
+BDFChar: 5973 9117 6 2 4 -3 9
 J:N0#J:N0#5X7S"+92BA
-BDFChar: 5975 9118 6 1 3 -3 9
+BDFChar: 5974 9118 6 1 3 -3 9
 J3Z@b5Th0l+<VdL+92BA
-BDFChar: 5976 9120 6 1 3 -3 9
+BDFChar: 5975 9120 6 1 3 -3 9
 +<VdL+<VdL5X7S"J,fQL
-BDFChar: 5977 9127 6 3 6 -3 9
+BDFChar: 5976 9127 6 3 6 -3 9
 E.EIhJ:N0#J:N0#J,fQL
-BDFChar: 5978 9129 6 3 6 -3 9
+BDFChar: 5977 9129 6 3 6 -3 9
 J:N0#J:N0#J:N0#Du]k<
-BDFChar: 5979 9131 6 0 3 -3 9
+BDFChar: 5978 9131 6 0 3 -3 9
 i"-G2&.fBa&.fBa&-)\1
-BDFChar: 5980 9133 6 0 3 -3 9
+BDFChar: 5979 9133 6 0 3 -3 9
 &.fBa&.fBa&.fBahuE`W
-BDFChar: 5981 9128 6 1 3 -3 9
+BDFChar: 5980 9128 6 1 3 -3 9
 +<VdL+<\HB+<VdL+92BA
-BDFChar: 5982 9132 6 3 5 -3 9
+BDFChar: 5981 9132 6 3 5 -3 9
 J:N0#J:M$XJ:N0#J,fQL
 BDFRefChar: 1999 1944 0 0 N
 BDFRefChar: 2000 1943 0 0 N
 BDFRefChar: 2001 1941 0 0 N
 BDFRefChar: 2002 1958 0 0 N
+BDFRefChar: 3247 3246 0 0 N
+BDFRefChar: 3249 3248 0 0 N
+BDFRefChar: 3251 3250 0 0 N
+BDFRefChar: 3253 3252 0 0 N
+BDFRefChar: 3255 3254 0 0 N
+BDFRefChar: 3257 3256 0 0 N
+BDFRefChar: 3259 3258 0 0 N
+BDFRefChar: 3261 3260 0 0 N
+BDFRefChar: 3263 3262 0 0 N
+BDFRefChar: 3265 3264 0 0 N
+BDFRefChar: 3267 3266 0 0 N
+BDFRefChar: 3269 3268 0 0 N
+BDFRefChar: 3272 3271 0 0 N
+BDFRefChar: 3274 3273 0 0 N
+BDFRefChar: 3276 3275 0 0 N
+BDFRefChar: 3283 3282 0 0 N
+BDFRefChar: 3284 3282 0 0 N
+BDFRefChar: 3285 3287 0 0 N
+BDFRefChar: 3286 3287 0 0 N
+BDFRefChar: 3289 3288 0 0 N
+BDFRefChar: 3291 3288 0 0 N
+BDFRefChar: 3292 3290 0 0 N
+BDFRefChar: 3294 3290 0 0 N
+BDFRefChar: 3295 3293 0 0 N
+BDFRefChar: 3296 3293 0 0 N
+BDFRefChar: 3319 3241 0 0 N
+BDFRefChar: 3325 3324 0 0 N
+BDFRefChar: 3339 3338 0 0 N
+BDFRefChar: 3341 3340 0 0 N
+BDFRefChar: 3343 3342 0 0 N
+BDFRefChar: 3345 3344 0 0 N
+BDFRefChar: 3347 3346 0 0 N
+BDFRefChar: 3349 3348 0 0 N
+BDFRefChar: 3351 3350 0 0 N
+BDFRefChar: 3353 3352 0 0 N
+BDFRefChar: 3355 3354 0 0 N
+BDFRefChar: 3357 3356 0 0 N
+BDFRefChar: 3359 3358 0 0 N
+BDFRefChar: 3361 3360 0 0 N
+BDFRefChar: 3364 3363 0 0 N
+BDFRefChar: 3366 3365 0 0 N
+BDFRefChar: 3368 3367 0 0 N
+BDFRefChar: 3375 3374 0 0 N
+BDFRefChar: 3376 3374 0 0 N
+BDFRefChar: 3378 3377 0 0 N
+BDFRefChar: 3379 3377 0 0 N
+BDFRefChar: 3381 3380 0 0 N
+BDFRefChar: 3382 3380 0 0 N
+BDFRefChar: 3383 3293 0 0 N
+BDFRefChar: 3384 3295 0 0 N
+BDFRefChar: 3385 3296 0 0 N
+BDFRefChar: 3387 3386 0 0 N
+BDFRefChar: 3388 3386 0 0 N
+BDFRefChar: 3411 3333 0 0 N
+BDFRefChar: 3414 3406 0 0 N
+BDFRefChar: 3415 3407 0 0 N
+BDFRefChar: 3416 3408 0 0 N
+BDFRefChar: 3417 3409 0 0 N
+BDFRefChar: 3421 3420 0 0 N
 EndBitmapFont
 EndSplineFont


### PR DESCRIPTION
Back at it again! Very excited to finally start on this :]

This PR will include once finished:
- [x] using references for dakuten/handakuten kana in FontForge
- [ ] more kana redesigns because i can't leave anything alone
- [ ] the following 80 kanji, which are the ones considered necessary for the N5 Japanese Language Learning Proficiency test, the metric I have decided to use for which kanji to include when. (A few of these are already in the font from my last PR):
``日一国人年大十二本中長出三時行見月分後前生五間上東四今金九入学高円子外八六下来気小七山話女北午百書先名川千水半男西電校語土木聞食車何南万毎白天母火右読友左休父雨``
- [ ] probably some other stuff

**References:** Kana characters with dakuten/handakuten (``゛゜``) now make use of FontForge's reference feature. This has no effect on the look of the font but will make it much easier to make edits to them, as well as keeping any kanji based on them consistent in the future.

This PR is a work in progress :3