### PR TITLE
Media and blackboard math characters, migrate deprecated `nf-mdi` glyphs to `nf-md`

### DIFF
--- a/Cozette/Cozette.sfd
+++ b/Cozette/Cozette.sfd
@@ -121,11 +121,11 @@ DisplaySize: 13
 AntiAlias: 1
 FitToEm: 0
 WidthSeparation: 307
-WinInfo: 3108 37 14
+WinInfo: 1665 37 14
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 524288 262144 174762 0 -1048576 174762 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 1114112 6123
+BeginChars: 1114112 6122
 
 StartChar: uni0000
 Encoding: 0 0 0
@@ -50184,421 +50184,414 @@ Flags: HW
 LayerCount: 2
 EndChar
 
-StartChar: uni2145
-Encoding: 8517 8517 6046
-Width: 1024
-Flags: HW
-LayerCount: 2
-EndChar
-
 StartChar: uni27EF
-Encoding: 10223 10223 6047
+Encoding: 10223 10223 6046
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni27EE
-Encoding: 10222 10222 6048
+Encoding: 10222 10222 6047
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D538
-Encoding: 120120 120120 6049
+Encoding: 120120 120120 6048
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D539
-Encoding: 120121 120121 6050
+Encoding: 120121 120121 6049
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D53B
-Encoding: 120123 120123 6051
+Encoding: 120123 120123 6050
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D53C
-Encoding: 120124 120124 6052
+Encoding: 120124 120124 6051
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D540
-Encoding: 120128 120128 6053
+Encoding: 120128 120128 6052
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D541
-Encoding: 120129 120129 6054
+Encoding: 120129 120129 6053
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D542
-Encoding: 120130 120130 6055
+Encoding: 120130 120130 6054
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D543
-Encoding: 120131 120131 6056
+Encoding: 120131 120131 6055
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D544
-Encoding: 120132 120132 6057
+Encoding: 120132 120132 6056
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D546
-Encoding: 120134 120134 6058
+Encoding: 120134 120134 6057
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D54B
-Encoding: 120139 120139 6059
+Encoding: 120139 120139 6058
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D54C
-Encoding: 120140 120140 6060
+Encoding: 120140 120140 6059
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D54D
-Encoding: 120141 120141 6061
+Encoding: 120141 120141 6060
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1D550
-Encoding: 120144 120144 6062
+Encoding: 120144 120144 6061
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni228C
-Encoding: 8844 8844 6063
+Encoding: 8844 8844 6062
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni228D
-Encoding: 8845 8845 6064
+Encoding: 8845 8845 6063
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uni228E
-Encoding: 8846 8846 6065
+Encoding: 8846 8846 6064
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1F500
-Encoding: 128256 128256 6066
+Encoding: 128256 128256 6065
 Width: 1890
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1F501
-Encoding: 128257 128257 6067
+Encoding: 128257 128257 6066
 Width: 1890
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: u1F502
-Encoding: 128258 128258 6068
+Encoding: 128258 128258 6067
 Width: 1890
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF02DA
-Encoding: 983770 983770 6069
+Encoding: 983770 983770 6068
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00AF
-Encoding: 983215 983215 6070
+Encoding: 983215 983215 6069
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00B0
-Encoding: 983216 983216 6071
+Encoding: 983216 983216 6070
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00B1
-Encoding: 983217 983217 6072
+Encoding: 983217 983217 6071
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00B2
-Encoding: 983218 983218 6073
+Encoding: 983218 983218 6072
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00BD
-Encoding: 983229 983229 6074
+Encoding: 983229 983229 6073
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00BE
-Encoding: 983230 983230 6075
+Encoding: 983230 983230 6074
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF00EC
-Encoding: 983276 983276 6076
+Encoding: 983276 983276 6075
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0132
-Encoding: 983346 983346 6077
+Encoding: 983346 983346 6076
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0133
-Encoding: 983347 983347 6078
+Encoding: 983347 983347 6077
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0159
-Encoding: 983385 983385 6079
+Encoding: 983385 983385 6078
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF015A
-Encoding: 983386 983386 6080
+Encoding: 983386 983386 6079
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0169
-Encoding: 983401 983401 6081
+Encoding: 983401 983401 6080
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF016A
-Encoding: 983402 983402 6082
+Encoding: 983402 983402 6081
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0174
-Encoding: 983412 983412 6083
+Encoding: 983412 983412 6082
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF018D
-Encoding: 983437 983437 6084
+Encoding: 983437 983437 6083
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF01A7
-Encoding: 983463 983463 6085
+Encoding: 983463 983463 6084
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF01BA
-Encoding: 983482 983482 6086
+Encoding: 983482 983482 6085
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF01BB
-Encoding: 983483 983483 6087
+Encoding: 983483 983483 6086
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF01BC
-Encoding: 983484 983484 6088
+Encoding: 983484 983484 6087
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0200
-Encoding: 983552 983552 6089
+Encoding: 983552 983552 6088
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0214
-Encoding: 983572 983572 6090
+Encoding: 983572 983572 6089
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0219
-Encoding: 983577 983577 6091
+Encoding: 983577 983577 6090
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF021B
-Encoding: 983579 983579 6092
+Encoding: 983579 983579 6091
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF021D
-Encoding: 983581 983581 6093
+Encoding: 983581 983581 6092
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF021F
-Encoding: 983583 983583 6094
+Encoding: 983583 983583 6093
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0223
-Encoding: 983587 983587 6095
+Encoding: 983587 983587 6094
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF022B
-Encoding: 983595 983595 6096
+Encoding: 983595 983595 6095
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF022C
-Encoding: 983596 983596 6097
+Encoding: 983596 983596 6096
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF024B
-Encoding: 983627 983627 6098
+Encoding: 983627 983627 6097
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0284
-Encoding: 983684 983684 6099
+Encoding: 983684 983684 6098
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0295
-Encoding: 983701 983701 6100
+Encoding: 983701 983701 6099
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF02B8
-Encoding: 983736 983736 6101
+Encoding: 983736 983736 6100
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF02CB
-Encoding: 983755 983755 6102
+Encoding: 983755 983755 6101
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF02CC
-Encoding: 983756 983756 6103
+Encoding: 983756 983756 6102
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF02CD
-Encoding: 983757 983757 6104
+Encoding: 983757 983757 6103
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF02CE
-Encoding: 983758 983758 6105
+Encoding: 983758 983758 6104
 Width: 945
 VWidth: 0
 Flags: HW
@@ -50606,7 +50599,7 @@ LayerCount: 2
 EndChar
 
 StartChar: uF02D0
-Encoding: 983760 983760 6106
+Encoding: 983760 983760 6105
 Width: 945
 VWidth: 0
 Flags: HW
@@ -50614,118 +50607,118 @@ LayerCount: 2
 EndChar
 
 StartChar: uF02FC
-Encoding: 983804 983804 6107
+Encoding: 983804 983804 6106
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF030B
-Encoding: 983819 983819 6108
+Encoding: 983819 983819 6107
 Width: 945
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0317
-Encoding: 983831 983831 6109
+Encoding: 983831 983831 6108
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0333
-Encoding: 983859 983859 6110
+Encoding: 983859 983859 6109
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0334
-Encoding: 983860 983860 6111
+Encoding: 983860 983860 6110
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0335
-Encoding: 983861 983861 6112
+Encoding: 983861 983861 6111
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0336
-Encoding: 983862 983862 6113
+Encoding: 983862 983862 6112
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0337
-Encoding: 983863 983863 6114
+Encoding: 983863 983863 6113
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0338
-Encoding: 983864 983864 6115
+Encoding: 983864 983864 6114
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF033D
-Encoding: 983869 983869 6116
+Encoding: 983869 983869 6115
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0387
-Encoding: 983943 983943 6117
+Encoding: 983943 983943 6116
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF03A0
-Encoding: 983968 983968 6118
+Encoding: 983968 983968 6117
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF03D7
-Encoding: 984023 984023 6119
+Encoding: 984023 984023 6118
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF03D8
-Encoding: 984024 984024 6120
+Encoding: 984024 984024 6119
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF03FF
-Encoding: 984063 984063 6121
+Encoding: 984063 984063 6120
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 
 StartChar: uF0AB7
-Encoding: 985783 985783 6122
+Encoding: 985783 985783 6121
 Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
 EndChars
-BitmapFont: 13 6126 10 3 1
+BitmapFont: 13 6124 10 3 1
 BDFStartProperties: 42
 FONT 1 "-inesw-Cozette-Medium-R-Normal--13-120-75-75-M-60-ISO10646-1"
 COMMENT 0 "(c) 2020-2025 Ines @ the.moonwit.ch"
@@ -62863,159 +62856,157 @@ BDFChar: 6044 23383 12 1 11 -1 9
 "9<qe5X6Ck!<<<(s54"["98Q)#QOi)
 BDFChar: 6045 28450 12 1 11 -1 9
 6@^`I!e?'A76h*n+TO1R+TOiZ9OIi#
-BDFChar: 6046 8517 6 1 5 0 7
-n>N:aW2QZa
-BDFChar: 6047 10223 6 2 4 -1 7
+BDFChar: 6046 10223 6 2 4 -1 7
 J3Y5"+<VdlJ,fQL
-BDFChar: 6048 10222 6 2 4 -1 7
+BDFChar: 6047 10222 6 2 4 -1 7
 +@(I-J:N/8+92BA
-BDFChar: 6049 120120 6 1 5 0 7
+BDFChar: 6048 120120 6 1 5 0 7
 E2]_FW2QZY
-BDFChar: 6050 120121 6 1 5 0 7
+BDFChar: 6049 120121 6 1 5 0 7
 n>N:iW2QZa
-BDFChar: 6051 120123 6 1 5 0 7
+BDFChar: 6050 120123 6 1 5 0 7
 n>N:aW2QZa
-BDFChar: 6052 120124 6 1 5 0 7
+BDFChar: 6051 120124 6 1 5 0 7
 pn4:iTV.tQ
-BDFChar: 6053 120128 6 1 5 0 7
+BDFChar: 6052 120128 6 1 5 0 7
 peXd`:f(!`
-BDFChar: 6054 120129 6 1 5 0 7
+BDFChar: 6053 120129 6 1 5 0 7
 peXd`:f(!H
-BDFChar: 6055 120130 6 1 5 0 7
+BDFChar: 6054 120130 6 1 5 0 7
 kbtGaW2QZY
-BDFChar: 6056 120131 6 1 5 0 7
+BDFChar: 6055 120131 6 1 5 0 7
 i1Qa9TV.tQ
-BDFChar: 6057 120132 6 1 5 0 7
+BDFChar: 6056 120132 6 1 5 0 7
 :f'ueW7Zo^
-BDFChar: 6058 120134 6 1 5 0 7
+BDFChar: 6057 120134 6 1 5 0 7
 E2]_6W2QY6
-BDFChar: 6059 120139 6 1 5 0 7
+BDFChar: 6058 120139 6 1 5 0 7
 peXd`:f'u-
-BDFChar: 6060 120140 6 1 5 0 7
+BDFChar: 6059 120140 6 1 5 0 7
 \>Z@)W2QY6
-BDFChar: 6061 120141 6 1 5 0 7
+BDFChar: 6060 120141 6 1 5 0 7
 kbtGY:f'u-
-BDFChar: 6062 120144 6 1 5 0 7
+BDFChar: 6061 120144 6 1 5 0 7
 kbq<S:f'u-
-BDFChar: 6063 8844 6 1 5 0 5
+BDFChar: 6062 8844 6 1 5 0 5
 Lo@h^Li<=o
-BDFChar: 6064 8845 6 1 5 0 5
+BDFChar: 6063 8845 6 1 5 0 5
 Lkr!cLi<=o
-BDFChar: 6065 8846 6 1 5 0 5
+BDFChar: 6064 8846 6 1 5 0 5
 LoC*ILi<=o
-BDFChar: 6066 128256 12 1 11 -2 8
+BDFChar: 6065 128256 12 1 11 -2 8
 !.Y'boABbe#_30\#_3K%kMQ?U!.Y%L
-BDFChar: 6067 128257 12 1 11 -2 8
+BDFChar: 6066 128257 12 1 11 -2 8
 !.Y'b5N"fBJ:N.m+<Y&Ws+"JW+92BA
-BDFChar: 6068 128258 12 1 11 -1 8
+BDFChar: 6067 128258 12 1 11 -1 8
 !.Y'b5N"fBJ:N.mO<Cbm(P!%s
-BDFChar: 6069 983770 6 0 6 0 7
+BDFChar: 6068 983770 6 0 6 0 7
 +F#/`RZ^&u
-BDFChar: 6070 983215 6 0 4 -1 6
+BDFChar: 6069 983215 6 0 4 -1 6
 +L#N50PI[5
-BDFChar: 6071 983216 6 0 6 -1 6
+BDFChar: 6070 983216 6 0 6 -1 6
 ,dM/?12=*?
-BDFChar: 6072 983217 6 0 4 -1 8
+BDFChar: 6071 983217 6 0 4 -1 8
 +L#N50PI[5!2okt
-BDFChar: 6073 983218 6 0 5 -1 6
+BDFChar: 6072 983218 6 0 5 -1 6
 +L#N50PIg9
-BDFChar: 6074 983229 6 0 6 0 6
+BDFChar: 6073 983229 6 0 6 0 6
 ro3A*mc+3G
-BDFChar: 6075 983230 6 0 6 0 5
+BDFChar: 6074 983230 6 0 6 0 5
 D"@/fo'QJX
-BDFChar: 6076 983276 6 0 6 -2 7
+BDFChar: 6075 983276 6 0 6 -2 7
 rdob$WrB$tWr;tu
-BDFChar: 6077 983346 6 0 6 0 6
+BDFChar: 6076 983346 6 0 6 0 6
 rqc2_No'a8
-BDFChar: 6078 983347 6 0 6 0 6
+BDFChar: 6077 983347 6 0 6 0 6
 3.1:oNa+OD
-BDFChar: 6079 983385 6 0 6 0 6
+BDFChar: 6078 983385 6 0 6 0 6
 3.0<FepKFW
-BDFChar: 6080 983386 6 0 6 0 6
+BDFChar: 6079 983386 6 0 6 0 6
 3(0d0W^JfH
-BDFChar: 6081 983401 6 0 6 -1 7
+BDFChar: 6080 983401 6 0 6 -1 7
 -q$HkJj`!p-ia5I
-BDFChar: 6082 983402 6 1 5 -1 7
+BDFChar: 6081 983402 6 1 5 -1 7
 fSG?>LkpkCfDkmO
-BDFChar: 6083 983412 6 0 6 -1 7
+BDFChar: 6082 983412 6 0 6 -1 7
 -n%JOJj`!T-ia5I
-BDFChar: 6084 983437 6 0 6 0 6
+BDFChar: 6083 983437 6 0 6 0 6
 rr0Xg^>f+l
-BDFChar: 6085 983463 6 0 6 -1 8
+BDFChar: 6084 983463 6 0 6 -1 8
 &1Bqu`i>2$3"Q&i
-BDFChar: 6086 983482 6 0 5 1 6
+BDFChar: 6085 983482 6 0 5 1 6
 E/=!sS7hm&
-BDFChar: 6087 983483 6 0 5 1 6
+BDFChar: 6086 983483 6 0 5 1 6
 E/=9sS6u<s
-BDFChar: 6088 983484 6 0 6 0 7
+BDFChar: 6087 983484 6 0 6 0 7
 I)c/5Jp`/t
-BDFChar: 6089 983552 6 0 6 0 6
+BDFChar: 6088 983552 6 0 6 0 6
 rl0PAJu\eM
-BDFChar: 6090 983572 6 0 5 0 7
+BDFChar: 6089 983572 6 0 5 0 7
 n<f`!KS5$V
-BDFChar: 6091 983577 6 0 5 0 7
+BDFChar: 6090 983577 6 0 5 0 7
 n<f`!["Pga
-BDFChar: 6092 983579 6 0 5 0 7
+BDFChar: 6091 983579 6 0 5 0 7
 n<f`!e>1Ul
-BDFChar: 6093 983581 6 0 5 0 7
+BDFChar: 6092 983581 6 0 5 0 7
 nEAs2N6JC$
-BDFChar: 6094 983583 6 0 5 0 7
+BDFChar: 6093 983583 6 0 5 0 7
 n<f`aPe;\I
-BDFChar: 6095 983587 6 0 5 0 7
+BDFChar: 6094 983587 6 0 5 0 7
 n<f`!S<UDY
-BDFChar: 6096 983595 6 0 5 0 7
+BDFChar: 6095 983595 6 0 5 0 7
 nEAs2P`1k)
-BDFChar: 6097 983596 6 0 5 0 7
+BDFChar: 6096 983596 6 0 5 0 7
 n<f`!eC:St
-BDFChar: 6098 983627 6 0 5 1 5
+BDFChar: 6097 983627 6 0 5 1 5
 i;ENNqu?]s
-BDFChar: 6099 983684 6 1 5 0 5
+BDFChar: 6098 983684 6 1 5 0 5
 po#;X+E.;\
-BDFChar: 6100 983701 6 1 5 -1 8
+BDFChar: 6099 983701 6 1 5 -1 8
 &1AYDE$-8GTKiJW
-BDFChar: 6101 983736 6 0 6 0 6
+BDFChar: 6100 983736 6 0 6 0 6
 3(/:WJj_Qu
-BDFChar: 6102 983755 6 1 5 1 5
+BDFChar: 6101 983755 6 1 5 1 5
 E/9>&fDkmO
-BDFChar: 6103 983756 6 0 6 0 6
+BDFChar: 6102 983756 6 0 6 0 6
 rl2O\P*5eE
-BDFChar: 6104 983757 6 1 5 -1 5
+BDFChar: 6103 983757 6 1 5 -1 5
 E/9>&fDqiM
-BDFChar: 6105 983758 6 1 5 -1 5
+BDFChar: 6104 983758 6 1 5 -1 5
 E/9>&fEa/2
-BDFChar: 6106 983760 6 0 6 -1 6
+BDFChar: 6105 983760 6 0 6 -1 6
 !^'.UCi"bA
-BDFChar: 6107 983804 6 0 6 0 6
+BDFChar: 6106 983804 6 0 6 0 6
 3,JT^mVFi_
-BDFChar: 6108 983819 6 0 5 1 6
+BDFChar: 6107 983819 6 0 5 1 6
 @'K-F*"2fI
-BDFChar: 6109 983831 6 0 6 -1 7
+BDFChar: 6108 983831 6 0 6 -1 7
 3%-`tr^?1SmJm4e
-BDFChar: 6110 983859 6 0 6 0 6
+BDFChar: 6109 983859 6 0 6 0 6
 4u0RD^4>tY
-BDFChar: 6111 983860 6 0 6 0 6
+BDFChar: 6110 983860 6 0 6 0 6
 4uT.D^4>tY
-BDFChar: 6112 983861 6 1 5 -1 6
+BDFChar: 6111 983861 6 1 5 -1 6
 E;95'E,Yer
-BDFChar: 6113 983862 6 1 5 -1 6
+BDFChar: 6112 983862 6 1 5 -1 6
 E/9=+:iHDR
-BDFChar: 6114 983863 6 0 6 1 5
+BDFChar: 6113 983863 6 0 6 1 5
 CkB6MC]FG8
-BDFChar: 6115 983864 6 0 6 0 6
+BDFChar: 6114 983864 6 0 6 0 6
 J8CskMJN=o
-BDFChar: 6116 983869 6 0 6 0 7
+BDFChar: 6115 983869 6 0 6 0 7
 3)k9!I)`16
-BDFChar: 6117 983943 6 2 5 0 6
+BDFChar: 6116 983943 6 2 5 0 6
 ?r0*R5et/8
-BDFChar: 6118 983968 6 0 6 1 5
+BDFChar: 6117 983968 6 0 6 1 5
 [Z\(n[K$:-
-BDFChar: 6119 984023 6 0 6 0 7
+BDFChar: 6118 984023 6 0 6 0 7
 ppAbhU7u*\
-BDFChar: 6120 984024 6 0 6 0 5
+BDFChar: 6119 984024 6 0 6 0 5
 I+J;.r*TL)
-BDFChar: 6121 984063 6 0 6 0 5
+BDFChar: 6120 984063 6 0 6 0 5
 r('@L8jiXZ
-BDFChar: 6122 985783 6 0 6 0 6
+BDFChar: 6121 985783 6 0 6 0 6
 4sI_<^4>tY
 BDFRefChar: 1999 1944 0 0 N
 BDFRefChar: 2000 1943 0 0 N

--- a/Cozette/Cozette.sfd
+++ b/Cozette/Cozette.sfd
@@ -22,7 +22,7 @@ OS2Version: 1
 OS2_WeightWidthSlopeOnly: 0
 OS2_UseTypoMetrics: 0
 CreationTime: -2082812035
-ModificationTime: 1753860416
+ModificationTime: 315532800
 PfmFamily: 49
 TTFWeight: 500
 TTFWidth: 5
@@ -114,17 +114,18 @@ MATH:RadicalKernAfterDegree: -1137
 MATH:RadicalDegreeBottomRaisePercent: 60
 MATH:MinConnectorOverlap: 40
 Encoding: UnicodeFull
+Compacted: 1
 UnicodeInterp: none
 NameList: AGL with PUA
 DisplaySize: 13
 AntiAlias: 1
 FitToEm: 0
 WidthSeparation: 307
-WinInfo: 12284 37 14
+WinInfo: 3108 37 14
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 524288 262144 174762 0 -1048576 174762 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 1114112 6046
+BeginChars: 1114112 6123
 
 StartChar: uni0000
 Encoding: 0 0 0
@@ -50182,8 +50183,549 @@ Width: 1890
 Flags: HW
 LayerCount: 2
 EndChar
+
+StartChar: uni2145
+Encoding: 8517 8517 6046
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni27EF
+Encoding: 10223 10223 6047
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni27EE
+Encoding: 10222 10222 6048
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D538
+Encoding: 120120 120120 6049
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D539
+Encoding: 120121 120121 6050
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D53B
+Encoding: 120123 120123 6051
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D53C
+Encoding: 120124 120124 6052
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D540
+Encoding: 120128 120128 6053
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D541
+Encoding: 120129 120129 6054
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D542
+Encoding: 120130 120130 6055
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D543
+Encoding: 120131 120131 6056
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D544
+Encoding: 120132 120132 6057
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D546
+Encoding: 120134 120134 6058
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D54B
+Encoding: 120139 120139 6059
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D54C
+Encoding: 120140 120140 6060
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D54D
+Encoding: 120141 120141 6061
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1D550
+Encoding: 120144 120144 6062
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni228C
+Encoding: 8844 8844 6063
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni228D
+Encoding: 8845 8845 6064
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uni228E
+Encoding: 8846 8846 6065
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1F500
+Encoding: 128256 128256 6066
+Width: 1890
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1F501
+Encoding: 128257 128257 6067
+Width: 1890
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: u1F502
+Encoding: 128258 128258 6068
+Width: 1890
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02DA
+Encoding: 983770 983770 6069
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00AF
+Encoding: 983215 983215 6070
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00B0
+Encoding: 983216 983216 6071
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00B1
+Encoding: 983217 983217 6072
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00B2
+Encoding: 983218 983218 6073
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00BD
+Encoding: 983229 983229 6074
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00BE
+Encoding: 983230 983230 6075
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF00EC
+Encoding: 983276 983276 6076
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0132
+Encoding: 983346 983346 6077
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0133
+Encoding: 983347 983347 6078
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0159
+Encoding: 983385 983385 6079
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF015A
+Encoding: 983386 983386 6080
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0169
+Encoding: 983401 983401 6081
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF016A
+Encoding: 983402 983402 6082
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0174
+Encoding: 983412 983412 6083
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF018D
+Encoding: 983437 983437 6084
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF01A7
+Encoding: 983463 983463 6085
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF01BA
+Encoding: 983482 983482 6086
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF01BB
+Encoding: 983483 983483 6087
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF01BC
+Encoding: 983484 983484 6088
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0200
+Encoding: 983552 983552 6089
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0214
+Encoding: 983572 983572 6090
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0219
+Encoding: 983577 983577 6091
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF021B
+Encoding: 983579 983579 6092
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF021D
+Encoding: 983581 983581 6093
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF021F
+Encoding: 983583 983583 6094
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0223
+Encoding: 983587 983587 6095
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF022B
+Encoding: 983595 983595 6096
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF022C
+Encoding: 983596 983596 6097
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF024B
+Encoding: 983627 983627 6098
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0284
+Encoding: 983684 983684 6099
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0295
+Encoding: 983701 983701 6100
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02B8
+Encoding: 983736 983736 6101
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02CB
+Encoding: 983755 983755 6102
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02CC
+Encoding: 983756 983756 6103
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02CD
+Encoding: 983757 983757 6104
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02CE
+Encoding: 983758 983758 6105
+Width: 945
+VWidth: 0
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02D0
+Encoding: 983760 983760 6106
+Width: 945
+VWidth: 0
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF02FC
+Encoding: 983804 983804 6107
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF030B
+Encoding: 983819 983819 6108
+Width: 945
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0317
+Encoding: 983831 983831 6109
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0333
+Encoding: 983859 983859 6110
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0334
+Encoding: 983860 983860 6111
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0335
+Encoding: 983861 983861 6112
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0336
+Encoding: 983862 983862 6113
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0337
+Encoding: 983863 983863 6114
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0338
+Encoding: 983864 983864 6115
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF033D
+Encoding: 983869 983869 6116
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0387
+Encoding: 983943 983943 6117
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF03A0
+Encoding: 983968 983968 6118
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF03D7
+Encoding: 984023 984023 6119
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF03D8
+Encoding: 984024 984024 6120
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF03FF
+Encoding: 984063 984063 6121
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
+
+StartChar: uF0AB7
+Encoding: 985783 985783 6122
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
 EndChars
-BitmapFont: 13 6047 10 3 1
+BitmapFont: 13 6126 10 3 1
 BDFStartProperties: 42
 FONT 1 "-inesw-Cozette-Medium-R-Normal--13-120-75-75-M-60-ISO10646-1"
 COMMENT 0 "(c) 2020-2025 Ines @ the.moonwit.ch"
@@ -61522,7 +62064,7 @@ BDFChar: 5644 8368 6 1 6 -1 8
 BDFChar: 5645 8369 6 0 5 0 7
 E;W9)E'QZR
 BDFChar: 5646 8450 6 1 5 0 7
-E6,i1^qe$1
+E2]G&TV/6&
 BDFChar: 5647 8452 6 1 5 0 7
 +E4!HTPu#5
 BDFChar: 5648 8455 6 1 5 0 7
@@ -61536,7 +62078,7 @@ BDFChar: 5651 8459 6 0 6 0 7
 BDFChar: 5652 8460 6 0 6 0 7
 Au)4b,U=XI
 BDFChar: 5653 8461 6 1 5 0 7
-f\"jOf\"j/
+kbtGiW2QZY
 BDFChar: 5654 8464 6 1 5 0 7
 G`Y`5+E48E
 BDFChar: 5655 8465 6 1 5 0 7
@@ -61548,15 +62090,15 @@ BDFChar: 5657 8467 6 1 4 0 7
 BDFChar: 5658 8468 6 0 5 0 7
 ;#!jh<)ch!
 BDFChar: 5659 8469 6 1 5 0 7
-aN3T/\@@on
+LrcOIW0iBs
 BDFChar: 5660 8473 6 1 5 0 7
-nCZCGnA)iT
+n>N:aYb7ZI
 BDFChar: 5661 8474 6 1 5 -1 7
-E7igqf\"hq2uipY
+E2]_6W2QY62uipY
 BDFChar: 5662 8477 6 1 5 0 7
-nCZC_nCZCG
+n>N:iW2QZY
 BDFChar: 5663 8484 6 1 5 0 7
-p_Y\=?speF
+po#T;:nXc^
 BDFChar: 5664 8480 6 0 6 5 7
 IU:G&
 BDFChar: 5665 8578 6 -1 7 0 7
@@ -62321,6 +62863,160 @@ BDFChar: 6044 23383 12 1 11 -1 9
 "9<qe5X6Ck!<<<(s54"["98Q)#QOi)
 BDFChar: 6045 28450 12 1 11 -1 9
 6@^`I!e?'A76h*n+TO1R+TOiZ9OIi#
+BDFChar: 6046 8517 6 1 5 0 7
+n>N:aW2QZa
+BDFChar: 6047 10223 6 2 4 -1 7
+J3Y5"+<VdlJ,fQL
+BDFChar: 6048 10222 6 2 4 -1 7
++@(I-J:N/8+92BA
+BDFChar: 6049 120120 6 1 5 0 7
+E2]_FW2QZY
+BDFChar: 6050 120121 6 1 5 0 7
+n>N:iW2QZa
+BDFChar: 6051 120123 6 1 5 0 7
+n>N:aW2QZa
+BDFChar: 6052 120124 6 1 5 0 7
+pn4:iTV.tQ
+BDFChar: 6053 120128 6 1 5 0 7
+peXd`:f(!`
+BDFChar: 6054 120129 6 1 5 0 7
+peXd`:f(!H
+BDFChar: 6055 120130 6 1 5 0 7
+kbtGaW2QZY
+BDFChar: 6056 120131 6 1 5 0 7
+i1Qa9TV.tQ
+BDFChar: 6057 120132 6 1 5 0 7
+:f'ueW7Zo^
+BDFChar: 6058 120134 6 1 5 0 7
+E2]_6W2QY6
+BDFChar: 6059 120139 6 1 5 0 7
+peXd`:f'u-
+BDFChar: 6060 120140 6 1 5 0 7
+\>Z@)W2QY6
+BDFChar: 6061 120141 6 1 5 0 7
+kbtGY:f'u-
+BDFChar: 6062 120144 6 1 5 0 7
+kbq<S:f'u-
+BDFChar: 6063 8844 6 1 5 0 5
+Lo@h^Li<=o
+BDFChar: 6064 8845 6 1 5 0 5
+Lkr!cLi<=o
+BDFChar: 6065 8846 6 1 5 0 5
+LoC*ILi<=o
+BDFChar: 6066 128256 12 1 11 -2 8
+!.Y'boABbe#_30\#_3K%kMQ?U!.Y%L
+BDFChar: 6067 128257 12 1 11 -2 8
+!.Y'b5N"fBJ:N.m+<Y&Ws+"JW+92BA
+BDFChar: 6068 128258 12 1 11 -1 8
+!.Y'b5N"fBJ:N.mO<Cbm(P!%s
+BDFChar: 6069 983770 6 0 6 0 7
++F#/`RZ^&u
+BDFChar: 6070 983215 6 0 4 -1 6
++L#N50PI[5
+BDFChar: 6071 983216 6 0 6 -1 6
+,dM/?12=*?
+BDFChar: 6072 983217 6 0 4 -1 8
++L#N50PI[5!2okt
+BDFChar: 6073 983218 6 0 5 -1 6
++L#N50PIg9
+BDFChar: 6074 983229 6 0 6 0 6
+ro3A*mc+3G
+BDFChar: 6075 983230 6 0 6 0 5
+D"@/fo'QJX
+BDFChar: 6076 983276 6 0 6 -2 7
+rdob$WrB$tWr;tu
+BDFChar: 6077 983346 6 0 6 0 6
+rqc2_No'a8
+BDFChar: 6078 983347 6 0 6 0 6
+3.1:oNa+OD
+BDFChar: 6079 983385 6 0 6 0 6
+3.0<FepKFW
+BDFChar: 6080 983386 6 0 6 0 6
+3(0d0W^JfH
+BDFChar: 6081 983401 6 0 6 -1 7
+-q$HkJj`!p-ia5I
+BDFChar: 6082 983402 6 1 5 -1 7
+fSG?>LkpkCfDkmO
+BDFChar: 6083 983412 6 0 6 -1 7
+-n%JOJj`!T-ia5I
+BDFChar: 6084 983437 6 0 6 0 6
+rr0Xg^>f+l
+BDFChar: 6085 983463 6 0 6 -1 8
+&1Bqu`i>2$3"Q&i
+BDFChar: 6086 983482 6 0 5 1 6
+E/=!sS7hm&
+BDFChar: 6087 983483 6 0 5 1 6
+E/=9sS6u<s
+BDFChar: 6088 983484 6 0 6 0 7
+I)c/5Jp`/t
+BDFChar: 6089 983552 6 0 6 0 6
+rl0PAJu\eM
+BDFChar: 6090 983572 6 0 5 0 7
+n<f`!KS5$V
+BDFChar: 6091 983577 6 0 5 0 7
+n<f`!["Pga
+BDFChar: 6092 983579 6 0 5 0 7
+n<f`!e>1Ul
+BDFChar: 6093 983581 6 0 5 0 7
+nEAs2N6JC$
+BDFChar: 6094 983583 6 0 5 0 7
+n<f`aPe;\I
+BDFChar: 6095 983587 6 0 5 0 7
+n<f`!S<UDY
+BDFChar: 6096 983595 6 0 5 0 7
+nEAs2P`1k)
+BDFChar: 6097 983596 6 0 5 0 7
+n<f`!eC:St
+BDFChar: 6098 983627 6 0 5 1 5
+i;ENNqu?]s
+BDFChar: 6099 983684 6 1 5 0 5
+po#;X+E.;\
+BDFChar: 6100 983701 6 1 5 -1 8
+&1AYDE$-8GTKiJW
+BDFChar: 6101 983736 6 0 6 0 6
+3(/:WJj_Qu
+BDFChar: 6102 983755 6 1 5 1 5
+E/9>&fDkmO
+BDFChar: 6103 983756 6 0 6 0 6
+rl2O\P*5eE
+BDFChar: 6104 983757 6 1 5 -1 5
+E/9>&fDqiM
+BDFChar: 6105 983758 6 1 5 -1 5
+E/9>&fEa/2
+BDFChar: 6106 983760 6 0 6 -1 6
+!^'.UCi"bA
+BDFChar: 6107 983804 6 0 6 0 6
+3,JT^mVFi_
+BDFChar: 6108 983819 6 0 5 1 6
+@'K-F*"2fI
+BDFChar: 6109 983831 6 0 6 -1 7
+3%-`tr^?1SmJm4e
+BDFChar: 6110 983859 6 0 6 0 6
+4u0RD^4>tY
+BDFChar: 6111 983860 6 0 6 0 6
+4uT.D^4>tY
+BDFChar: 6112 983861 6 1 5 -1 6
+E;95'E,Yer
+BDFChar: 6113 983862 6 1 5 -1 6
+E/9=+:iHDR
+BDFChar: 6114 983863 6 0 6 1 5
+CkB6MC]FG8
+BDFChar: 6115 983864 6 0 6 0 6
+J8CskMJN=o
+BDFChar: 6116 983869 6 0 6 0 7
+3)k9!I)`16
+BDFChar: 6117 983943 6 2 5 0 6
+?r0*R5et/8
+BDFChar: 6118 983968 6 0 6 1 5
+[Z\(n[K$:-
+BDFChar: 6119 984023 6 0 6 0 7
+ppAbhU7u*\
+BDFChar: 6120 984024 6 0 6 0 5
+I+J;.r*TL)
+BDFChar: 6121 984063 6 0 6 0 5
+r('@L8jiXZ
+BDFChar: 6122 985783 6 0 6 0 6
+4sI_<^4>tY
 BDFRefChar: 1999 1944 0 0 N
 BDFRefChar: 2000 1943 0 0 N
 BDFRefChar: 2001 1941 0 0 N

--- a/Cozette/Cozette.sfd
+++ b/Cozette/Cozette.sfd
@@ -121,11 +121,11 @@ DisplaySize: 13
 AntiAlias: 1
 FitToEm: 0
 WidthSeparation: 307
-WinInfo: 1665 37 14
+WinInfo: 3105 23 16
 BeginPrivate: 0
 EndPrivate
 TeXData: 1 0 0 524288 262144 174762 0 -1048576 174762 783286 444596 497025 792723 393216 433062 380633 303038 157286 324010 404750 52429 2506097 1059062 262144
-BeginChars: 1114112 6122
+BeginChars: 1114112 6123
 
 StartChar: uni0000
 Encoding: 0 0 0
@@ -16667,10 +16667,8 @@ EndChar
 StartChar: ohorn
 Encoding: 417 417 1836
 Width: 1024
-Flags: W
+Flags: HW
 LayerCount: 2
-Fore
-Validated: 1
 EndChar
 
 StartChar: uni01A2
@@ -21513,10 +21511,8 @@ EndChar
 StartChar: uni01BD
 Encoding: 445 445 2374
 Width: 1024
-Flags: W
+Flags: HW
 LayerCount: 2
-Fore
-Validated: 1
 EndChar
 
 StartChar: uni01BF
@@ -50717,6 +50713,13 @@ Width: 1024
 Flags: HW
 LayerCount: 2
 EndChar
+
+StartChar: uni2982
+Encoding: 10626 10626 6122
+Width: 1024
+Flags: HW
+LayerCount: 2
+EndChar
 EndChars
 BitmapFont: 13 6124 10 3 1
 BDFStartProperties: 42
@@ -63008,6 +63011,8 @@ BDFChar: 6120 984063 6 0 6 0 5
 r('@L8jiXZ
 BDFChar: 6121 985783 6 0 6 0 6
 4sI_<^4>tY
+BDFChar: 6122 10626 6 2 4 0 6
+i1T!.i1T!.
 BDFRefChar: 1999 1944 0 0 N
 BDFRefChar: 2000 1943 0 0 N
 BDFRefChar: 2001 1941 0 0 N


### PR DESCRIPTION
This PR adds:

- Math characters commonly used in the language Agda (specifically, those seen in the Iowa Agda Library). This PR introduces all of the missing capital double-struck characters, left and right flattened parentheses, and multiset operations. I also modified the existing double-struck characters because they did not have a gap between strikes, making it hard to discern them from regular bold characters. 
- Media control emojis for shuffle, repeat, and repeat-once. This is useful for terminal-based music players, such as rmpc.
- A number of glyphs in the `nf-md-*` range. All of these glyphs were previously present in Cozette's `nf-mdi-*` range, which is now deprecated by nerd-fonts. Tools such as Emacs' nerd-fonts package do not support `nf-mdi-*` icons, so I felt it was important to move them to the non-deprecated range.

### Added

- ⊌ (U+228C MULTISET)
- ⊍ (U+228D MULTISET MULTIPLICATION)
- ⊎ (U+228E MULTISET UNION)
- ⟮ (U+27EE MATHEMATICAL LEFT FLATTENED PARENTHESIS)
- ⟯ (U+27EF MATHEMATICAL RIGHT FLATTENED PARENTHESIS)
- 𝔸 (U+1D538 MATHEMATICAL DOUBLE-STRUCK CAPITAL A)
- 𝔹 (U+1D539 MATHEMATICAL DOUBLE-STRUCK CAPITAL B)
- 𝔻 (U+1D53B MATHEMATICAL DOUBLE-STRUCK CAPITAL D)
- 𝔼 (U+1D53C MATHEMATICAL DOUBLE-STRUCK CAPITAL E)
- 𝕀 (U+1D540 MATHEMATICAL DOUBLE-STRUCK CAPITAL I)
- 𝕁 (U+1D541 MATHEMATICAL DOUBLE-STRUCK CAPITAL J)
- 𝕂 (U+1D542 MATHEMATICAL DOUBLE-STRUCK CAPITAL K)
- 𝕃 (U+1D543 MATHEMATICAL DOUBLE-STRUCK CAPITAL L)
- 𝕄 (U+1D544 MATHEMATICAL DOUBLE-STRUCK CAPITAL M)
- 𝕆 (U+1D546 MATHEMATICAL DOUBLE-STRUCK CAPITAL O)
- 𝕋 (U+1D54B MATHEMATICAL DOUBLE-STRUCK CAPITAL T)
- 𝕌 (U+1D54C MATHEMATICAL DOUBLE-STRUCK CAPITAL U)
- 𝕍 (U+1D54D MATHEMATICAL DOUBLE-STRUCK CAPITAL V)
- 𝕐 (U+1D550 MATHEMATICAL DOUBLE-STRUCK CAPITAL Y)
- 🔀 (U+1F500 TWISTED RIGHTWARDS ARROWS)
- 🔁 (U+1F501 CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS)
- 🔂 (U+1F502 CLOCKWISE RIGHTWARDS AND LEFTWARDS OPEN CIRCLE ARROWS WITH CIRCLED ONE OVERLAY)
- 󰂯 (U+F00AF)
- 󰂰 (U+F00B0)
- 󰂱 (U+F00B1)
- 󰂲 (U+F00B2)
- 󰂽 (U+F00BD)
- 󰂾 (U+F00BE)
- 󰃬 (U+F00EC)
- 󰄲 (U+F0132)
- 󰄳 (U+F0133)
- 󰅙 (U+F0159)
- 󰅚 (U+F015A)
- 󰅩 (U+F0169)
- 󰅪 (U+F016A)
- 󰅴 (U+F0174)
- 󰆍 (U+F018D)
- 󰆧 (U+F01A7)
- 󰆺 (U+F01BA)
- 󰆻 (U+F01BB)
- 󰆼 (U+F01BC)
- 󰈀 (U+F0200)
- 󰈔 (U+F0214)
- 󰈙 (U+F0219)
- 󰈛 (U+F021B)
- 󰈝 (U+F021D)
- 󰈟 (U+F021F)
- 󰈣 (U+F0223)
- 󰈫 (U+F022B)
- 󰈬 (U+F022C)
- 󰉋 (U+F024B)
- 󰊄 (U+F0284)
- 󰊕 (U+F0295)
- 󰊸 (U+F02B8)
- 󰋋 (U+F02CB)
- 󰋌 (U+F02CC)
- 󰋍 (U+F02CD)
- 󰋎 (U+F02CE)
- 󰋐 (U+F02D0)
- 󰋚 (U+F02DA)
- 󰋼 (U+F02FC)
- 󰌋 (U+F030B)
- 󰌗 (U+F0317)
- 󰌳 (U+F0333)
- 󰌴 (U+F0334)
- 󰌵 (U+F0335)
- 󰌶 (U+F0336)
- 󰌷 (U+F0337)
- 󰌸 (U+F0338)
- 󰌽 (U+F033D)
- 󰎇 (U+F0387)
- 󰎠 (U+F03A0)
- 󰏗 (U+F03D7)
- 󰏘 (U+F03D8)
- 󰏿 (U+F03FF)
- 󰪷 (U+F0AB7)

### Changed

- ℂ (U+2102 DOUBLE-STRUCK CAPITAL C)
- ℍ (U+210D DOUBLE-STRUCK CAPITAL H)
- ℕ (U+2115 DOUBLE-STRUCK CAPITAL N)
- ℙ (U+2119 DOUBLE-STRUCK CAPITAL P)
- ℚ (U+211A DOUBLE-STRUCK CAPITAL Q)
- ℝ (U+211D DOUBLE-STRUCK CAPITAL R)
- ℤ (U+2124 DOUBLE-STRUCK CAPITAL Z)

## Image of new glyphs

<img width="736" height="712" alt="glyphs" src="https://github.com/user-attachments/assets/620caeaf-eb85-44ac-988b-516e1d8ea3f4" />
