### PR TITLE
Update Nix flake and the package

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746183838,
-        "narHash": "sha256-kwaaguGkAqTZ1oK0yXeQ3ayYjs8u/W7eEfrFpFfIDFA=",
+        "lastModified": 1765838191,
+        "narHash": "sha256-m5KWt1nOm76ILk/JSCxBM4MfK3rYY7Wq9/TZIIeGnT8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bf3287dac860542719fe7554e21e686108716879",
+        "rev": "c6f52ebd45e5925c188d1a20119978aa4ffd5ef6",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,18 +1,24 @@
 {
   description = "A bitmap programming font optimized for coziness";
 
-  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
   inputs.flake-utils.url = "github:numtide/flake-utils";
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-      in {
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
         devShells = {
           default = pkgs.mkShellNoCC {
             packages = with pkgs; [
-              # BitsNPicas GUI wrapped with java
-              self.packages.${system}.bitsnpicas-bin
               # FontForge GUI
               fontforge-gtk
               # Python tools
@@ -24,35 +30,6 @@
           };
         };
         packages = rec {
-          # BitsNPicas needs to be fetched here since `nix build` is sandboxed
-          # and does not have internet access
-          bitsnpicas = pkgs.stdenvNoCC.mkDerivation rec {
-            pname = "bitsnpicas";
-            version = "2.1";
-            src = pkgs.fetchFromGitHub {
-              owner = "kreativekorp";
-              repo = "bitsnpicas";
-              rev = "v${version}";
-              hash = "sha256-hw7UuzesqpmnTjgpfikAIYyY70ni7BxjaUtHAPEdkXI=";
-            };
-            buildInputs = [ pkgs.zulu23 pkgs.zip ];
-            buildPhase = ''
-              cd main/java/BitsNPicas
-              make
-            '';
-            installPhase = ''
-              mkdir -p $out
-              cp BitsNPicas.jar $out
-              cp KeyEdit.jar $out
-              cp MapEdit.jar $out
-            '';
-          };
-
-          # Shell script to run the BitsNPicas GUI
-          bitsnpicas-bin = pkgs.writeShellScriptBin "bitsnpicas" ''
-            ${pkgs.zulu23}/bin/java -jar ${bitsnpicas}/BitsNPicas.jar $@
-          '';
-
           # Derivation to build and install cozette
           cozette = pkgs.stdenvNoCC.mkDerivation {
             pname = "cozette";
@@ -61,8 +38,8 @@
             src = ./.;
 
             buildInputs = with pkgs; [
-              (pkgs.python312.withPackages (ppkgs:
-                with ppkgs; [
+              (pkgs.python312.withPackages (
+                ppkgs: with ppkgs; [
                   numpy
                   pillow
                   fonttools
@@ -70,18 +47,18 @@
                   gitpython
                   setuptools
                   pip
-                ]))
+                ]
+              ))
               fontforge
-              zulu23
+              bitsnpicas
             ];
 
-            configurePhase = ''
-              mkdir -p deps
-              cp ${bitsnpicas}/BitsNPicas.jar deps/
+            postPatch = ''
+              substituteInPlace build.py --replace-fail \
+                'bitsnpicas.sh' '${pkgs.lib.getExe pkgs.bitsnpicas}'
             '';
 
             buildPhase = ''
-              patchShebangs bitsnpicas.sh
               python3 build.py fonts
             '';
 
@@ -102,5 +79,6 @@
           };
           default = cozette;
         };
-      });
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
       system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        inherit (pkgs) lib;
       in
       {
         devShells = {
@@ -33,7 +34,19 @@
           # Derivation to build and install cozette
           cozette = pkgs.stdenvNoCC.mkDerivation {
             pname = "cozette";
-            version = "1.28.0";
+            version =
+              let
+                sfdLines = lib.strings.splitString "\n" (builtins.readFile ./Cozette/Cozette.sfd);
+                sfdVersionLine = lib.lists.findFirst (l: lib.strings.hasPrefix "Version: " l) null sfdLines;
+                sfdVersion =
+                  if sfdVersionLine != null then lib.strings.removePrefix "Version: " sfdVersionLine else "0.00";
+                majorRest = lib.strings.splitString "." sfdVersion;
+                major = builtins.elemAt majorRest 0;
+                minorPatch = builtins.elemAt majorRest 1;
+                minor = builtins.substring 0 2 minorPatch;
+                patch = builtins.substring 2 1 minorPatch;
+              in
+              "${major}.${minor}.${patch}";
 
             src = ./.;
 
@@ -55,7 +68,7 @@
 
             postPatch = ''
               substituteInPlace build.py --replace-fail \
-                'bitsnpicas.sh' '${pkgs.lib.getExe pkgs.bitsnpicas}'
+                'bitsnpicas.sh' '${lib.getExe pkgs.bitsnpicas}'
             '';
 
             buildPhase = ''


### PR DESCRIPTION
This PR updates the Nix flake for the following:

* Sync the package version with the source (1.28.0 to 1.30.0)

* Simplify the Bits'N'Picas setup

Ref: #166 cc: @breitnw
