### PR TITLE
Optional interim workflow workaround

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build fonts
         run: |
-          pipenv --python /bin/python install
-          pipenv run python build.py fonts
+          pip install --break-system-packages fonttools Pillow crayons gitpython setuptools
+          python build.py fonts
       - name: Save version
         id: version
         run: |


### PR DESCRIPTION
Hi @the-moonwitch,

This PR implements the tiny workaround described in issue #187. It’s just an easy two-line interim fix for the GitHub workflow so the existing build system can produce release files again.

I tested this change in my fork and it successfully produced the [release files](https://github.com/PhMajerus/Cozette/releases).

I know you’re planning to unify the client and GitHub build workflows later, and this doesn’t interfere with that at all - it simply decouples the current workflow issue from the future build system evolution, so that the upgrade can happen at your own pace, without the extra pressure of a blocking release.

Absolutely no expectations - feel free to merge, ignore, or close it if you’d rather handle things differently. I only wanted to offer a small convenience in case it helps.

__Note for other collaborators:__
Since this is just an optional interim workaround, and modifies the build script, please don’t merge it - I’d prefer to leave that decision to @the-moonwitch.
